### PR TITLE
langchain-sqlserver version update

### DIFF
--- a/libs/sqlserver/pyproject.toml
+++ b/libs/sqlserver/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-sqlserver"
-version = "0.1.0"
+version = "0.1.1"
 description = "An integration package to support SQL Server in LangChain."
 authors = []
 license = "MIT"


### PR DESCRIPTION
Updates `langchain-sqlserver` version from `0.1.0` to `0.1.1` for a new release.