### PR TITLE
Bug fix for, error when inserting more than 500 documents at once

### DIFF
--- a/libs/sqlserver/langchain_sqlserver/vectorstores.py
+++ b/libs/sqlserver/langchain_sqlserver/vectorstores.py
@@ -1202,7 +1202,6 @@ class SQLServer_VectorStore(VectorStore):
             if ids is None:
                 # Get IDs from metadata if available.
                 ids = [metadata.get("id", uuid.uuid4()) for metadata in metadatas]
-                print("nnn ", ids)
 
             with Session(self._bind) as session:
                 documents = []


### PR DESCRIPTION
### What is this change about?

There is a bug in the current implementation of **add_texts**, where if we insert more than 500 texts or documents at once into the DB, it throws an exception as below.
```
2024-12-02 11:02:35,662 - ERROR - Add text failed:
 ('07002', '[07002] [Microsoft][ODBC Driver 18 for SQL Server]COUNT field incorrect or syntax error (0) (SQLExecDirectW)')
```
### How is it fixed?

Use batching to insert the documents into the database based on the batch_sie value.
1. The batch_size is an optional parameter for inserting documents / data.
2. The default batch_size will be 100.

### How are the changes tested?

Integration tests were added to insert 636 documents at once and also 1000 texts at once using **add_texts** API. All  the tests were successful.
![Screenshot 2025-02-06 002906](https://github.com/user-attachments/assets/62340625-8a3f-486b-8864-d3f679501c56)
