### PR TITLE
Bug fix: Escapes AzureCosmosDBNoSqlVectorStore hybrid & full text queries that contain single quotes

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_no_sql.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_no_sql.py
@@ -683,17 +683,24 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
                     "full_text_rank_filter cannot be None for FULL_TEXT_RANK queries."
                 )
             if len(full_text_rank_filter) == 1:
+                text = full_text_rank_filter[0]["search_text"].replace("'", "\\'").split()
+                
                 query += f""" ORDER BY RANK FullTextScore(c.{full_text_rank_filter[0]["search_field"]}, 
-                [{", ".join(f"'{term}'" for term in full_text_rank_filter[0]["search_text"].split())}])"""  # noqa:E501
+                [{", ".join(f"'{term}'" for term in text)}])"""  # noqa:E501
             else:
-                rank_components = [
-                    f"FullTextScore(c.{search_item['search_field']}, ["
-                    + ", ".join(
-                        f"'{term}'" for term in search_item["search_text"].split()
+                rank_components = []
+
+                for search_item in full_text_rank_filter:
+                    text = search_item["search_text"].replace("'", "\\'").split()
+
+                    rank_components.append(
+                        f"FullTextScore(c.{search_item['search_field']}, ["
+                        + ", ".join(
+                            f"'{term}'" for term in text
+                        )
+                        + "])"
                     )
-                    + "])"
-                    for search_item in full_text_rank_filter
-                ]
+
                 query = f" ORDER BY RANK RRF({', '.join(rank_components)})"
         elif search_type == "vector":
             query += " ORDER BY VectorDistance(c[@embeddingKey], @embeddings)"
@@ -702,12 +709,15 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
                 raise ValueError(
                     "full_text_rank_filter cannot be None for HYBRID queries."
                 )
-            rank_components = [
-                f"FullTextScore(c.{search_item['search_field']}, ["
-                + ", ".join(f"'{term}'" for term in search_item["search_text"].split())
-                + "])"
-                for search_item in full_text_rank_filter
-            ]
+            rank_components = []
+
+            for search_item in full_text_rank_filter:
+                text = search_item["search_text"].replace("'", "\\'").split()
+                rank_components.append(
+                    f"FullTextScore(c.{search_item['search_field']}, ["
+                    + ", ".join(f"'{term}'" for term in text)
+                    + "])"
+                )
             query += f""" ORDER BY RANK RRF({', '.join(rank_components)}, 
             VectorDistance(c.{self._vector_search_fields["embedding_field"]}, {embeddings}))"""  # noqa:E501
         else:

--- a/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_no_sql.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_no_sql.py
@@ -683,8 +683,10 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
                     "full_text_rank_filter cannot be None for FULL_TEXT_RANK queries."
                 )
             if len(full_text_rank_filter) == 1:
-                text = full_text_rank_filter[0]["search_text"].replace("'", "\\'").split()
-                
+                text = (
+                    full_text_rank_filter[0]["search_text"].replace("'", "\\'").split()
+                )
+
                 query += f""" ORDER BY RANK FullTextScore(c.{full_text_rank_filter[0]["search_field"]}, 
                 [{", ".join(f"'{term}'" for term in text)}])"""  # noqa:E501
             else:
@@ -695,9 +697,7 @@ class AzureCosmosDBNoSqlVectorSearch(VectorStore):
 
                     rank_components.append(
                         f"FullTextScore(c.{search_item['search_field']}, ["
-                        + ", ".join(
-                            f"'{term}'" for term in text
-                        )
+                        + ", ".join(f"'{term}'" for term in text)
                         + "])"
                     )
 

--- a/libs/azure-ai/tests/integration_tests/vectorstores/test_azure_cosmos_db_no_sql.py
+++ b/libs/azure-ai/tests/integration_tests/vectorstores/test_azure_cosmos_db_no_sql.py
@@ -360,16 +360,14 @@ class TestAzureCosmosDBNoSqlVectorSearch:
         assert output
         assert len(output) == 5
         assert "Standard Poodles" in output[0].page_content
-        
+
         # Full text search successfully queries for data with a single quote
-        full_text_rank_filter = [
-            {"search_field": "text", "search_text": "'Herders'"}
-        ]
+        full_text_rank_filter = [{"search_field": "text", "search_text": "'Herders'"}]
         output = store.similarity_search(
             "Which dog breed is considered a herder?",
             k=5,
             query_type="full_text_search",
-            full_text_rank_filter=full_text_rank_filter
+            full_text_rank_filter=full_text_rank_filter,
         )
 
         assert output
@@ -411,16 +409,14 @@ class TestAzureCosmosDBNoSqlVectorSearch:
         assert output
         assert len(output) == 5
         assert "Border Collies" in output[0].page_content
-        
+
         # Hybrid search successfully queries for data with a single quote
-        full_text_rank_filter = [
-            {"search_field": "text", "search_text": "'energetic'"}
-        ]
+        full_text_rank_filter = [{"search_field": "text", "search_text": "'energetic'"}]
         output = store.similarity_search(
             "Which breed is energetic?",
             k=5,
             query_type="hybrid",
-            full_text_rank_filter=full_text_rank_filter
+            full_text_rank_filter=full_text_rank_filter,
         )
 
         assert output

--- a/libs/azure-ai/tests/integration_tests/vectorstores/test_azure_cosmos_db_no_sql.py
+++ b/libs/azure-ai/tests/integration_tests/vectorstores/test_azure_cosmos_db_no_sql.py
@@ -360,6 +360,15 @@ class TestAzureCosmosDBNoSqlVectorSearch:
         assert output
         assert len(output) == 5
         assert "Standard Poodles" in output[0].page_content
+        
+        # Full text search successfully queries for data with a single quote
+        output = store.similarity_search(
+            "'Retrievers'", k=5, query_type="full_text_search"
+        )
+
+        assert output
+        assert len(output) == 5
+        assert "Retrievers" in output[0].page_content
 
         # Full text search BM25 ranking with filtering
         pre_filter = PreFilter(
@@ -391,6 +400,15 @@ class TestAzureCosmosDBNoSqlVectorSearch:
             k=5,
             query_type="hybrid",
             full_text_rank_filter=full_text_rank_filter,
+        )
+
+        assert output
+        assert len(output) == 5
+        assert "Border Collies" in output[0].page_content
+        
+        # Hybrid search successfully queries for data with a single quote
+        output = store.similarity_search(
+            "'outdoor activities'", k=5, query_type="hybrid"
         )
 
         assert output

--- a/libs/azure-ai/tests/integration_tests/vectorstores/test_azure_cosmos_db_no_sql.py
+++ b/libs/azure-ai/tests/integration_tests/vectorstores/test_azure_cosmos_db_no_sql.py
@@ -362,8 +362,14 @@ class TestAzureCosmosDBNoSqlVectorSearch:
         assert "Standard Poodles" in output[0].page_content
         
         # Full text search successfully queries for data with a single quote
+        full_text_rank_filter = [
+            {"search_field": "text", "search_text": "'Herders'"}
+        ]
         output = store.similarity_search(
-            "'Retrievers'", k=5, query_type="full_text_search"
+            "Which dog breed is considered a herder?",
+            k=5,
+            query_type="full_text_search",
+            full_text_rank_filter=full_text_rank_filter
         )
 
         assert output
@@ -407,8 +413,14 @@ class TestAzureCosmosDBNoSqlVectorSearch:
         assert "Border Collies" in output[0].page_content
         
         # Hybrid search successfully queries for data with a single quote
+        full_text_rank_filter = [
+            {"search_field": "text", "search_text": "'energetic'"}
+        ]
         output = store.similarity_search(
-            "'outdoor activities'", k=5, query_type="hybrid"
+            "Which breed is energetic?",
+            k=5,
+            query_type="hybrid",
+            full_text_rank_filter=full_text_rank_filter
         )
 
         assert output

--- a/libs/azure-ai/tests/unit_tests/test_chat_models.py
+++ b/libs/azure-ai/tests/unit_tests/test_chat_models.py
@@ -19,7 +19,9 @@ from azure.ai.inference.models import (
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolCall
 
 from langchain_azure_ai.chat_models import AzureAIChatCompletionsModel
-from langchain_azure_ai.chat_models.inference import _format_tool_call_for_azure_inference
+from langchain_azure_ai.chat_models.inference import (
+    _format_tool_call_for_azure_inference,
+)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- **Description:** Escapes vector store searches which contain a single quote, as these will currently result in an error and not search for relevant documents.

Ported from: https://github.com/langchain-ai/langchain/pull/29339

