### PR TITLE
Add Vector Index Compression support for Azure Cosmos DB Mongo

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_mongo_vcore.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_mongo_vcore.py
@@ -50,6 +50,15 @@ class CosmosDBVectorSearchType(str, Enum):
     """DISKANN vector index"""
 
 
+class CosmosDBVectorSearchCompression(str, Enum):
+    """Cosmos DB Vector Search Compression as enumerator."""
+
+    PQ = "pq"
+    """Product Quantization compression"""
+    HALF = "half"
+    """Half precision compression"""
+
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_INSERT_BATCH_SIZE = 128
@@ -188,6 +197,9 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         ef_construction: int = 64,
         max_degree: int = 32,
         l_build: int = 50,
+        compression: Optional[CosmosDBVectorSearchCompression] = None,
+        pq_compressed_dims: Optional[int] = None,
+        pq_sample_size: Optional[int] = None,
     ) -> dict[str, Any]:
         """Creates an index using the index name specified at instance construction.
 
@@ -252,6 +264,13 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
             l_build: l value for index building.
                 Default value is 50, range from 10 to 500.
                 Only vector-diskann search supports this for now.
+            compression: compression type for vector indexes.
+                Product quantization compression is only supported for DISKANN and
+                half precision compression is only supported for IVF and HNSW for now.
+            pq_compressed_dims: Number of dimensions after compression for product quantization.
+                Must be less than original dimensions. Automatically calculated if omitted. Range: 1-8000.
+            pq_sample_size: Number of samples for PQ centroid training.
+                Higher value means better quality but longer build time. Default: 1000. Range: 1000-100000.
 
         Returns:
             An object describing the created index
@@ -262,15 +281,31 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         create_index_commands = {}
         if kind == CosmosDBVectorSearchType.VECTOR_IVF:
             create_index_commands = self._get_vector_index_ivf(
-                kind, num_lists, similarity, dimensions
+                kind,
+                num_lists,
+                similarity,
+                dimensions,
+                compression,
             )
         elif kind == CosmosDBVectorSearchType.VECTOR_HNSW:
             create_index_commands = self._get_vector_index_hnsw(
-                kind, m, ef_construction, similarity, dimensions
+                kind,
+                m,
+                ef_construction,
+                similarity,
+                dimensions,
+                compression,
             )
         elif kind == CosmosDBVectorSearchType.VECTOR_DISKANN:
             create_index_commands = self._get_vector_index_diskann(
-                kind, max_degree, l_build, similarity, dimensions
+                kind,
+                max_degree,
+                l_build,
+                similarity,
+                dimensions,
+                compression,
+                pq_compressed_dims,
+                pq_sample_size,
             )
 
         # retrieve the database object
@@ -284,62 +319,96 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         return create_index_responses
 
     def _get_vector_index_ivf(
-        self, kind: str, num_lists: int, similarity: str, dimensions: int
+        self,
+        kind: str,
+        num_lists: int,
+        similarity: str,
+        dimensions: int,
+        compression: Optional[CosmosDBVectorSearchCompression] = None,
     ) -> Dict[str, Any]:
+        cosmos_search_options = {
+            "kind": kind,
+            "numLists": num_lists,
+            "similarity": similarity,
+            "dimensions": dimensions,
+        }
+        if compression:
+            cosmos_search_options["compression"] = compression
+
         command = {
             "createIndexes": self._collection.name,
             "indexes": [
                 {
                     "name": self._index_name,
                     "key": {self._embedding_key: "cosmosSearch"},
-                    "cosmosSearchOptions": {
-                        "kind": kind,
-                        "numLists": num_lists,
-                        "similarity": similarity,
-                        "dimensions": dimensions,
-                    },
+                    "cosmosSearchOptions": cosmos_search_options,
                 }
             ],
         }
         return command
 
     def _get_vector_index_hnsw(
-        self, kind: str, m: int, ef_construction: int, similarity: str, dimensions: int
+        self,
+        kind: str,
+        m: int,
+        ef_construction: int,
+        similarity: str,
+        dimensions: int,
+        compression: Optional[CosmosDBVectorSearchCompression] = None,
     ) -> Dict[str, Any]:
+        cosmos_search_options = {
+            "kind": kind,
+            "m": m,
+            "efConstruction": ef_construction,
+            "similarity": similarity,
+            "dimensions": dimensions,
+        }
+        if compression:
+            cosmos_search_options["compression"] = compression
         command = {
             "createIndexes": self._collection.name,
             "indexes": [
                 {
                     "name": self._index_name,
                     "key": {self._embedding_key: "cosmosSearch"},
-                    "cosmosSearchOptions": {
-                        "kind": kind,
-                        "m": m,
-                        "efConstruction": ef_construction,
-                        "similarity": similarity,
-                        "dimensions": dimensions,
-                    },
+                    "cosmosSearchOptions": cosmos_search_options,
                 }
             ],
         }
         return command
 
     def _get_vector_index_diskann(
-        self, kind: str, max_degree: int, l_build: int, similarity: str, dimensions: int
+        self,
+        kind: str,
+        max_degree: int,
+        l_build: int,
+        similarity: str,
+        dimensions: int,
+        compression: Optional[CosmosDBVectorSearchCompression] = None,
+        pq_compressed_dims: Optional[int] = None,
+        pq_sample_size: Optional[int] = None,
     ) -> Dict[str, Any]:
+        cosmos_search_options = {
+            "kind": kind,
+            "maxDegree": max_degree,
+            "lBuild": l_build,
+            "similarity": similarity,
+            "dimensions": dimensions,
+        }
+        if compression:
+            cosmos_search_options["compression"] = compression
+            if pq_compressed_dims:
+                cosmos_search_options["pqCompressedDims"] = pq_compressed_dims
+            if pq_sample_size:
+                cosmos_search_options["pqSampleSize"] = pq_sample_size
+
         command = {
             "createIndexes": self._collection.name,
             "indexes": [
                 {
                     "name": self._index_name,
                     "key": {self._embedding_key: "cosmosSearch"},
-                    "cosmosSearchOptions": {
-                        "kind": kind,
-                        "maxDegree": max_degree,
-                        "lBuild": l_build,
-                        "similarity": similarity,
-                        "dimensions": dimensions,
-                    },
+                    "cosmosSearchOptions": cosmos_search_options,
                 }
             ],
         }
@@ -467,6 +536,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         score_threshold: float = 0.0,
         l_search: int = 40,
         with_embedding: bool = False,
+        oversampling: Optional[float] = 1.0,
     ) -> List[Tuple[Document, float]]:
         """Returns a list of documents with their scores.
 
@@ -490,6 +560,10 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
                 Default value is 40, range from 10 to 10000.
                 Only vector-diskann search supports this.
             with_embedding: (bool, optional): If true, return a vector with the result
+            oversampling: (Optional[float], optional): The oversampling factor for 
+                compressed index. The oversampling factor (a float with a minimum of 1) 
+                specifies how many more candidate vectors to retrieve from the 
+                compressed index than k (the number of desired results).
 
         Returns:
             A list of documents closest to the query vector
@@ -528,12 +602,17 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         return docs
 
     def _get_pipeline_vector_ivf(
-        self, embeddings: List[float], k: int = 4, pre_filter: Optional[Dict] = None
+        self,
+        embeddings: List[float],
+        k: int = 4,
+        pre_filter: Optional[Dict] = None,
+        oversampling: Optional[float] = 1.0,
     ) -> List[dict[str, Any]]:
         params = {
             "vector": embeddings,
             "path": self._embedding_key,
             "k": k,
+            "oversampling": oversampling,
         }
         if pre_filter:
             params["filter"] = pre_filter
@@ -560,12 +639,14 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         k: int = 4,
         ef_search: int = 40,
         pre_filter: Optional[Dict] = None,
+        oversampling: Optional[float] = 1.0,
     ) -> List[dict[str, Any]]:
         params = {
             "vector": embeddings,
             "path": self._embedding_key,
             "k": k,
             "efSearch": ef_search,
+            "oversampling": oversampling,
         }
         if pre_filter:
             params["filter"] = pre_filter
@@ -591,12 +672,14 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         k: int = 4,
         l_search: int = 40,
         pre_filter: Optional[Dict] = None,
+        oversampling: Optional[float] = 1.0,
     ) -> List[dict[str, Any]]:
         params = {
             "vector": embeddings,
             "path": self._embedding_key,
             "k": k,
             "lSearch": l_search,
+            "oversampling": oversampling,
         }
         if pre_filter:
             params["filter"] = pre_filter
@@ -626,6 +709,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         score_threshold: float = 0.0,
         l_search: int = 40,
         with_embedding: bool = False,
+        oversampling: Optional[float] = 1.0,
     ) -> List[Tuple[Document, float]]:
         """Returns a list of similar documents with their scores."""
         embeddings = self._embedding.embed_query(query)
@@ -638,6 +722,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
             score_threshold=score_threshold,
             l_search=l_search,
             with_embedding=with_embedding,
+            oversampling=oversampling,
         )
         return docs
 
@@ -651,6 +736,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         score_threshold: float = 0.0,
         l_search: int = 40,
         with_embedding: bool = False,
+        oversampling: Optional[float] = 1.0,
         **kwargs: Any,
     ) -> List[Document]:
         """Returns a list of similar documents."""
@@ -663,6 +749,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
             score_threshold=score_threshold,
             l_search=l_search,
             with_embedding=with_embedding,
+            oversampling=oversampling,
         )
         return [doc for doc, _ in docs_and_scores]
 
@@ -678,6 +765,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         score_threshold: float = 0.0,
         l_search: int = 40,
         with_embedding: bool = False,
+        oversampling: Optional[float] = 1.0,
         **kwargs: Any,
     ) -> List[Document]:
         """Retrieves the docs with similarity scores."""
@@ -691,6 +779,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
             score_threshold=score_threshold,
             l_search=l_search,
             with_embedding=with_embedding,
+            oversampling=oversampling,
         )
 
         # Re-ranks the docs using MMR
@@ -715,6 +804,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
         score_threshold: float = 0.0,
         l_search: int = 40,
         with_embedding: bool = False,
+        oversampling: Optional[float] = 1.0,
         **kwargs: Any,
     ) -> List[Document]:
         """Retrieves the similar docs."""
@@ -731,6 +821,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
             score_threshold=score_threshold,
             l_search=l_search,
             with_embedding=with_embedding,
+            oversampling=oversampling,
         )
         return docs
 

--- a/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_mongo_vcore.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_mongo_vcore.py
@@ -560,9 +560,9 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
                 Default value is 40, range from 10 to 10000.
                 Only vector-diskann search supports this.
             with_embedding: (bool, optional): If true, return a vector with the result
-            oversampling: (Optional[float], optional): The oversampling factor for 
-                compressed index. The oversampling factor (a float with a minimum of 1) 
-                specifies how many more candidate vectors to retrieve from the 
+            oversampling: (Optional[float], optional): The oversampling factor for
+                compressed index. The oversampling factor (a float with a minimum of 1)
+                specifies how many more candidate vectors to retrieve from the
                 compressed index than k (the number of desired results).
 
         Returns:

--- a/libs/azure-ai/langchain_azure_ai/vectorstores/cache.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/cache.py
@@ -218,14 +218,14 @@ class AzureCosmosDBMongoVCoreSemanticCache(BaseCache):
             application_name: Application name for the client for tracking and logging
             compression: compression type for vector indexes.
             pq_compressed_dims: Number of dimensions after compression for product
-                quantization. Must be less than original dimensions. Automatically 
+                quantization. Must be less than original dimensions. Automatically
                 calculated if omitted. Range: 1-8000.
             pq_sample_size: Number of samples for PQ centroid training.
-                Higher value means better quality but longer build time. 
+                Higher value means better quality but longer build time.
                 Default: 1000. Range: 1000-100000.
-            oversampling: The oversampling factor for compressed index. 
-                The oversampling factor (a float with a minimum of 1) 
-                specifies how many more candidate vectors to retrieve from the 
+            oversampling: The oversampling factor for compressed index.
+                The oversampling factor (a float with a minimum of 1)
+                specifies how many more candidate vectors to retrieve from the
                 compressed index than k (the number of desired results).
         """
         self._validate_enum_value(similarity, CosmosDBSimilarityType)
@@ -321,7 +321,7 @@ class AzureCosmosDBMongoVCoreSemanticCache(BaseCache):
             kind=self.kind,
             ef_search=self.ef_search,
             l_search=self.l_search,
-            score_threshold=self.score_threshold,
+            score_threshold=self.score_threshold or 0.0,
             oversampling=self.oversampling,
         )
         if results:

--- a/libs/azure-ai/langchain_azure_ai/vectorstores/cache.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/cache.py
@@ -25,6 +25,7 @@ from langchain_core.outputs import Generation
 from langchain_azure_ai.vectorstores.azure_cosmos_db_mongo_vcore import (
     AzureCosmosDBMongoVCoreVectorSearch,
     CosmosDBSimilarityType,
+    CosmosDBVectorSearchCompression,
     CosmosDBVectorSearchType,
 )
 from langchain_azure_ai.vectorstores.azure_cosmos_db_no_sql import (
@@ -156,8 +157,12 @@ class AzureCosmosDBMongoVCoreSemanticCache(BaseCache):
         l_build: int = 50,
         l_search: int = 40,
         ef_search: int = 40,
-        score_threshold: Optional[float] = None,
         application_name: str = "langchainpy",
+        score_threshold: Optional[float] = None,
+        compression: Optional[CosmosDBVectorSearchCompression] = None,
+        pq_compressed_dims: Optional[int] = None,
+        pq_sample_size: Optional[int] = None,
+        oversampling: Optional[float] = None,
     ):
         """AzureCosmosDBMongoVCoreSemanticCache constructor.
 
@@ -211,9 +216,22 @@ class AzureCosmosDBMongoVCoreSemanticCache(BaseCache):
                 Only vector-diskann search supports this.
             score_threshold: Maximum score used to filter the vector search documents.
             application_name: Application name for the client for tracking and logging
+            compression: compression type for vector indexes.
+            pq_compressed_dims: Number of dimensions after compression for product
+                quantization. Must be less than original dimensions. Automatically 
+                calculated if omitted. Range: 1-8000.
+            pq_sample_size: Number of samples for PQ centroid training.
+                Higher value means better quality but longer build time. 
+                Default: 1000. Range: 1000-100000.
+            oversampling: The oversampling factor for compressed index. 
+                The oversampling factor (a float with a minimum of 1) 
+                specifies how many more candidate vectors to retrieve from the 
+                compressed index than k (the number of desired results).
         """
         self._validate_enum_value(similarity, CosmosDBSimilarityType)
         self._validate_enum_value(kind, CosmosDBVectorSearchType)
+        if compression:
+            self._validate_enum_value(compression, CosmosDBVectorSearchCompression)
 
         if not cosmosdb_connection_string:
             raise ValueError(" CosmosDB connection string can be empty.")
@@ -236,6 +254,10 @@ class AzureCosmosDBMongoVCoreSemanticCache(BaseCache):
         self.score_threshold = score_threshold
         self._cache_dict: Dict[str, AzureCosmosDBMongoVCoreVectorSearch] = {}
         self.application_name = application_name
+        self.compression = compression
+        self.pq_compressed_dims = pq_compressed_dims
+        self.pq_sample_size = pq_sample_size
+        self.oversampling = oversampling
 
     def _index_name(self, llm_string: str) -> str:
         hashed_index = _hash(llm_string)
@@ -281,6 +303,9 @@ class AzureCosmosDBMongoVCoreSemanticCache(BaseCache):
                 self.ef_construction,
                 self.max_degree,
                 self.l_build,
+                compression=self.compression,
+                pq_compressed_dims=self.pq_compressed_dims,
+                pq_sample_size=self.pq_sample_size,
             )
 
         return vectorstore
@@ -296,7 +321,8 @@ class AzureCosmosDBMongoVCoreSemanticCache(BaseCache):
             kind=self.kind,
             ef_search=self.ef_search,
             l_search=self.l_search,
-            score_threshold=self.score_threshold,  # type: ignore[arg-type]
+            score_threshold=self.score_threshold,
+            oversampling=self.oversampling,
         )
         if results:
             for document in results:


### PR DESCRIPTION
Add Vector Index Compression support for Azure Cosmos DB Mongo
- Product Quantization: https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/product-quantization
- Half-Precision: https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/half-precision
