### PR TITLE
Fix: Update vCore vector search index to GA status

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_mongo_vcore.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/azure_cosmos_db_mongo_vcore.py
@@ -219,9 +219,8 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
             kind: Type of vector index to create.
                 Possible options are:
                     - vector-ivf
-                    - vector-hnsw: available as a preview feature only,
-                                   to enable visit https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/preview-features
-                    - vector-diskann: available as a preview feature only
+                    - vector-hnsw
+                    - vector-diskann
             num_lists: This integer is the number of clusters that the
                 inverted file (IVF) index uses to group the vector data.
                 We recommend that numLists is set to documentCount/1000
@@ -477,8 +476,7 @@ class AzureCosmosDBMongoVCoreVectorSearch(VectorStore):
                 Possible options are:
                     - vector-ivf
                     - vector-hnsw
-                    - vector-diskann: available as a preview feature only
-                                      to enable visit https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/preview-features
+                    - vector-diskann
             pre_filter: Pre-filtering function
             ef_search: The size of the dynamic candidate list for search
                        (40 by default). A higher value provides better

--- a/libs/azure-ai/langchain_azure_ai/vectorstores/cache.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/cache.py
@@ -186,8 +186,7 @@ class AzureCosmosDBMongoVCoreSemanticCache(BaseCache):
                 Possible options are:
                     - vector-ivf
                     - vector-hnsw
-                    - vector-diskann: available as a preview feature only,
-                                   to enable visit https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/preview-features
+                    - vector-diskann
             m: The max number of connections per layer (16 by default, minimum
                value is 2, maximum value is 100). Higher m is suitable for datasets
                with high dimensionality and/or high accuracy requirements.


### PR DESCRIPTION
- Remove preview status from vector-diskann and vextor-hnsw index documentation as the two index types are now generally available. 