### PR TITLE
Replace MD5 with SHA256 for cache index entry keys and names

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/vectorstores/cache.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/cache.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__file__)
 
 def _hash(_input: str) -> str:
     """Use a deterministic hashing approach."""
-    return hashlib.md5(_input.encode()).hexdigest()
+    return hashlib.sha256(_input.encode()).hexdigest()
 
 
 def _dump_generations_to_json(generations: RETURN_VAL_TYPE) -> str:


### PR DESCRIPTION
MD5 and SHA1 should never be used for cache keys because there is a chance of collisions. 

The implication here is that the in-process cache dictionary will use different cache keys, but that doesn't matter since it's stored in memory and you need to restart to run this update.

Cosmos will end up with a second index for the cache entry, so possibly you'd have a duplicate cache index key if you previously had a cache, but that would be invalidated after the TTL.