### PR TITLE
Fix: Set tool_choice to "required" when value is "any" for Azure API compatibility

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
@@ -667,8 +667,6 @@ class AzureAIChatCompletionsModel(BaseChatModel):
             kwargs: Any additional parameters are passed directly to
                 ``self.bind(**kwargs)``.
         """
-        # Azure API does not support "any"—default to "required". 
-        # Fix: with_structured_output used "any", preventing function calling.
         if kwargs.get("tool_choice") == "any":
             kwargs["tool_choice"] = "required"
 


### PR DESCRIPTION
When using an LLM in Azure AI Foundry to get structured output, I found that function calls weren’t triggered and the output couldn’t be parsed. This was because bind_tool set tool_choice to "any", which Azure doesn’t support. Changing it to "required" fixes the issue and allows function calls to work as expected. below is the code I used for testing
```python
from langchain_azure_ai.chat_models import AzureAIChatCompletionsModel
from pydantic import BaseModel, Field

class PersonInfo(BaseModel):
    name: str = Field(description="Person's name")
    age: int = Field(description="Person's age")
    occupation: str = Field(description="Person's job")


llm = AzureAIChatCompletionsModel(
    endpoint="your-endpoint",
    credential="your-key",
    model_name="grok-3"
)


structured_llm = llm.with_structured_output(
    PersonInfo,
)


# Test the bound model
response = structured_llm.invoke(
    "Tell me about John who is 25 years old software engineer"
)
```
before fix
```
# include_raw = True
{'raw': AIMessage(content="Here's a brief profile of John, a 25-year-old software engineer, based on typical characteristics and assumptions (since specific details about this particular John aren't provided):\n\nJohn is a young professional in the tech industry, likely having completed a degree in computer science, software engineering, or a related field within the past few years. At 25, he might have a couple of years of work experience under his belt, possibly starting with internships during college and moving into a full-time role after graduation. He could be working for a tech company, startup, or even as a freelancer, depending on his career path and preferences.\n\nAs a software engineer, John probably spends much of his day writing, testing, and debugging code, collaborating with teammates on projects, and solving complex problems. He might specialize in a specific area like web development, mobile app development, backend systems, or even emerging fields like artificial intelligence or cybersecurity. Common programming languages he might use include Python, JavaScript, Java, or C++, depending on his focus.\n\nAt this stage in his career, John is likely eager to grow his skills, take on challenging projects, and possibly work toward a senior role or leadership position in the future. He may also be active in tech communities, attending meetups, contributing to open-source projects, or staying updated on the latest industry trends through platforms like GitHub or Stack Overflow.\n\nOn a personal level, John, at 25, might be balancing his career with hobbies and social life. He could enjoy gaming, fitness, travel, or other interests common among young adults. He might live in a tech hub like San Francisco, Seattle, Bangalore, or London, where job opportunities in his field are abundant, or he could be working remotely, a trend increasingly common in the software industry.\n\nFinancially, John is likely earning a competitive salary for his age and profession, though this varies widely by location and company. He might be focused on saving, paying off student loans (if any), or investing in his future. Personality-wise, he could be analytical, detail-oriented, and curious—traits often associated with engineers—but he might also have a creative side, as software development often requires innovative thinking.\n\nOf course, this is a generalized portrait. If you have specific details or a particular context about John (like his background, personality, or goals), I’d be happy to tailor this description further! What would you like to know more about? His career, hobbies, or something else?", additional_kwargs={}, response_metadata={'model': 'grok-3', 'token_usage': {'input_tokens': 18, 'output_tokens': 498, 'total_tokens': 516}, 'finish_reason': 'stop'}, id='run--XXXXXXXX', usage_metadata={'input_tokens': 18, 'output_tokens': 498, 'total_tokens': 516}),
 'parsed': None,
 'parsing_error': None}
```
after fix
```
PersonInfo(name='John', age=25, occupation='software engineer')
```