### PR TITLE
adding async close method

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
@@ -753,7 +753,7 @@ class AzureAIChatCompletionsModel(BaseChatModel):
         """Get the namespace of the langchain object."""
         return ["langchain", "chat_models", "azure_inference"]
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         """Close the async client to prevent unclosed session warnings.
 
         This method should be called to properly clean up HTTP connections

--- a/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
@@ -753,11 +753,11 @@ class AzureAIChatCompletionsModel(BaseChatModel):
         """Get the namespace of the langchain object."""
         return ["langchain", "chat_models", "azure_inference"]
 
-    async def aclose(self) -> None:
+    async def close(self) -> None:
         """Close the async client to prevent unclosed session warnings.
 
         This method should be called to properly clean up HTTP connections
         when using async operations.
         """
         if hasattr(self, "_async_client") and self._async_client:
-            await self._async_client.aclose()
+            await self._async_client.close()

--- a/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
@@ -759,5 +759,5 @@ class AzureAIChatCompletionsModel(BaseChatModel):
         This method should be called to properly clean up HTTP connections
         when using async operations.
         """
-        if hasattr(self, '_async_client') and self._async_client:
+        if hasattr(self, "_async_client") and self._async_client:
             await self._async_client.aclose()

--- a/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
@@ -752,3 +752,12 @@ class AzureAIChatCompletionsModel(BaseChatModel):
     def get_lc_namespace(cls) -> List[str]:
         """Get the namespace of the langchain object."""
         return ["langchain", "chat_models", "azure_inference"]
+
+    async def aclose(self) -> None:
+        """Close the async client to prevent unclosed session warnings.
+
+        This method should be called to properly clean up HTTP connections
+        when using async operations.
+        """
+        if hasattr(self, '_async_client') and self._async_client:
+            await self._async_client.aclose()


### PR DESCRIPTION
This PR adds a `aclose` method and closes [issue 69](https://github.com/langchain-ai/langchain-azure/issues/69). Sticking to LC convention of using `aclose`. 
