### PR TITLE
Minor fixes

### DIFF
--- a/.github/scripts/get_min_versions.py
+++ b/.github/scripts/get_min_versions.py
@@ -1,8 +1,8 @@
+import re
 import sys
 
 import tomllib
 from packaging.version import parse as parse_version
-import re
 
 MIN_VERSION_LIBS = ["langchain-core"]
 
@@ -34,8 +34,8 @@ def get_min_version_from_toml(toml_path: str):
     with open(toml_path, "rb") as file:
         toml_data = tomllib.load(file)
 
-    # Get the dependencies from tool.poetry.dependencies
-    dependencies = toml_data["tool"]["poetry"]["dependencies"]
+    # Get the dependencies from project.dependencies
+    dependencies = toml_data["project"]["dependencies"]
 
     # Initialize a dictionary to store the minimum versions
     min_versions = {}

--- a/libs/azure-postgresql/pyproject.toml
+++ b/libs/azure-postgresql/pyproject.toml
@@ -9,6 +9,9 @@ requires-python = "~=3.10"
 
 authors = [
   { name = "Arda Aytekin", email = "8845951+aytekinar@users.noreply.github.com" },
+]
+maintainers = [
+  { name = "Arda Aytekin", email = "8845951+aytekinar@users.noreply.github.com" },
   { name = "Orhan Kislal", email = "kislalorhan@microsoft.com" },
 ]
 keywords = ["azure", "postgresql", "langchain", "vectorstore", "database"]


### PR DESCRIPTION
Minor fixes to

- [x] update `get_min_versions` to use `project.dependencies` instead of `tool.poetry.dependencies`, and,
- [x] update `pyproject.toml` file to add maintainers section for `langchain-azure-postgresql`.