### PR TITLE
Flexible agent deletion in AgentServiceFactory

### DIFF
--- a/libs/azure-ai/pyproject.toml
+++ b/libs/azure-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-azure-ai"
-version = "0.1.6"
+version = "0.1.7"
 description = "An integration package to support Azure AI Foundry capabilities for model inference in LangChain."
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
This pull request updates the `langchain-azure-ai` package to version 0.1.7 and enhances the agent deletion logic in the `agent_service.py` module. The main improvement is that the `delete_agent` method now supports deleting both `CompiledStateGraph` and `DeclarativeChatAgentNode` agent types, adding type checks and appropriate deletion handling.

Agent deletion enhancements:

* The `delete_agent` method in `agent_service.py` now accepts both `CompiledStateGraph` and `DeclarativeChatAgentNode` instances, allowing for more flexible agent deletion.
* Added logic to handle deletion for `DeclarativeChatAgentNode` by calling its `delete_agent_from_node` method, and included type validation to raise a `ValueError` for unsupported types.

Version update:

* Bumped the package version from `0.1.6` to `0.1.7` in `pyproject.toml` to reflect the new changes.