### PR TITLE
Update CI to test on 3.10 for the lower Python bound

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
+          - "3.10"
           - "3.12"
     name: "poetry run pytest -m compile tests/integration_tests #${{ matrix.python-version }}"
     steps:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -29,7 +29,7 @@ jobs:
         # Starting new jobs is also relatively slow,
         # so linting on fewer versions makes CI faster.
         python-version:
-          - "3.9"
+          - "3.10"
           - "3.12"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
+          - "3.10"
           - "3.12"
     name: "make test #${{ matrix.python-version }}"
     steps:


### PR DESCRIPTION
As part of LangChain 1.0, Python 3.9 is being dropped. This commit updates the CI so that azure langchain packages that update to drop 3.9 as well will be testing under the correct Python version lower bound (instead of GitHub possibly falling back to a different Python version that is available in the environment).

I confirmed, I'm not seeing Python3.9 in the `.github` directory:
```
PS C:\Users\kyleknapp\GitHub\langchain-azure\.github> rg 3.9
<No output>
```