### PR TITLE
Removing duplicate tool_calls from additional_kwargs so it doesn't break LanGraph code with msgpack serializable

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
@@ -155,7 +155,6 @@ def from_inference_message(message: ChatResponseMessage) -> BaseMessage:
                     invalid_tool_calls.append(
                         make_invalid_tool_call(tool_call.as_dict(), str(e))
                     )
-            additional_kwargs.update(tool_calls=tool_calls)
         if audio := message.get("audio"):
             additional_kwargs.update(audio=audio)
         return AIMessage(

--- a/libs/azure-ai/tests/unit_tests/test_chat_models.py
+++ b/libs/azure-ai/tests/unit_tests/test_chat_models.py
@@ -280,8 +280,8 @@ def test_chat_completion_with_tools(
     )
 
     assert isinstance(response, AIMessage)
-    assert len(response.additional_kwargs["tool_calls"]) == 1
-    assert response.additional_kwargs["tool_calls"][0]["name"] == "echo"
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0]["name"] == "echo"
 
 
 def test_with_structured_output_json_mode(


### PR DESCRIPTION
This PR fixes this issue: https://github.com/langchain-ai/langchain-azure/issues/179. The AI Message isn't serializable because of these duplicate tool calls, so removing the extra one. 