### PR TITLE
Remove duplicate assignment of raw_tool_calls to additional_kwargs

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
@@ -213,7 +213,6 @@ def _convert_delta_to_message_chunk(
 
     tool_call_chunks: List[ToolCallChunk] = []
     if raw_tool_calls := _dict.get("tool_calls"):
-        additional_kwargs["tool_calls"] = raw_tool_calls
         try:
             tool_call_chunks = [
                 tool_call_chunk(


### PR DESCRIPTION
Remove duplicate assignment of raw_tool_calls to additional_kwargs this fixes serialization error in LangGraph for streaming. Previous PR fixed it for non-streaming