### PR TITLE
Updating minor version for langchain-sqlserver

### DIFF
--- a/libs/sqlserver/pyproject.toml
+++ b/libs/sqlserver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-sqlserver"
-version = "0.1.2"
+version = "0.1.3"
 description = "An integration package to support SQL Server in LangChain."
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
This PR is made as a follow up to the PR: https://github.com/langchain-ai/langchain-azure/pull/227, since we upgraded the `numpy` version we will be releasing a new minor version of the package.