### PR TITLE
chore: add minimum permissions to all workflow files

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.1.4"
 

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.1.4"
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -14,6 +14,8 @@ on:
         type: string
         default: 'libs/azure-dynamic-sessions'
 
+permissions: {}
+
 env:
   PYTHON_VERSION: "3.11"
   POETRY_VERSION: "2.1.4"
@@ -22,6 +24,8 @@ jobs:
   build:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     outputs:
       pkg-name: ${{ steps.check-version.outputs.pkg-name }}
@@ -72,7 +76,9 @@ jobs:
       - build
     uses:
       ./.github/workflows/_test_release.yml
-    permissions: write-all
+    permissions:
+      contents: read
+      id-token: write
     with:
       working-directory: ${{ inputs.working-directory }}
     secrets: inherit
@@ -82,6 +88,8 @@ jobs:
       - build
       - test-pypi-publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       PGHOST: ${{ secrets.PGHOST }}
       PGPASSWORD: ${{ secrets.PGPASSWORD }}
@@ -189,6 +197,7 @@ jobs:
       - pre-release-checks
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # This permission is used for trusted publishing:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
       #

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.1.4"
 

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -8,6 +8,8 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions: {}
+
 env:
   POETRY_VERSION: "2.1.4"
   PYTHON_VERSION: "3.10"
@@ -16,6 +18,8 @@ jobs:
   build:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     outputs:
       pkg-name: ${{ steps.check-version.outputs.pkg-name }}
@@ -66,6 +70,7 @@ jobs:
       - build
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # This permission is used for trusted publishing:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
       #

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 env:
   POETRY_VERSION: "2.1.4"
 


### PR DESCRIPTION
## Summary

Applies the principle of least privilege to all GitHub Actions workflows by explicitly declaring the minimum `permissions` needed for each workflow/job.

- `_codespell.yml` — already had `contents: read`, no change
- `_compile_integration_test.yml` — add `contents: read`
- `_lint.yml` — add `contents: read`
- `_test.yml` — add `contents: read`
- `_test_release.yml` — top-level `permissions: {}` (deny all); `build` job gets `contents: read`; `publish` job gets `contents: read` + `id-token: write`
- `_release.yml` — top-level `permissions: {}` (deny all); each job scoped explicitly; `test-pypi-publish` drops `write-all` in favour of `contents: read` + `id-token: write`
- `check_diffs.yml` — add `contents: read` + `pull-requests: read` (required by `Ana06/get-changed-files`)

The most impactful change is replacing `permissions: write-all` on the `test-pypi-publish` job in `_release.yml`, which previously granted every permission to a job that only needs `id-token: write` for trusted publishing.

🤖 Submitted by langster-patch