### PR TITLE
Fix typo: LangChain-Google to LangChain-Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ is split across separate test & release flows.
 
 ## Repository Structure
 
-If you plan on contributing to LangChain-Google code or documentation, it can be useful
+If you plan on contributing to LangChain-Azure code or documentation, it can be useful
 to understand the high level structure of the repository.
 
 LangChain-Azure is organized as a [monorepo](https://en.wikipedia.org/wiki/Monorepo) that contains multiple packages.


### PR DESCRIPTION
Fixes a copy-paste error in the README where 'LangChain-Google' should be 'LangChain-Azure' since this is the langchain-azure repository.