### PR TITLE
Fix span attributes lost when Azure Monitor distro sampler drops constructor attrs

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
@@ -2392,12 +2392,22 @@ class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
             parent_context = set_span_in_context(parent_record.span)
             parent_source = "stack_override"
 
+        # Pass attributes to start_span for sampler input, then re-apply
+        # them via set_attribute.  Some TracerProvider samplers (e.g. the
+        # Azure Monitor distro's RateLimitedSampler) do not copy
+        # user-provided attributes onto the span — only
+        # ``SamplingResult.attributes`` are kept (OTel SDK behaviour).
+        # Explicitly setting each attribute after creation guarantees they
+        # survive regardless of the sampler implementation.
+        resolved_attrs = attributes or {}
         span = self._tracer.start_span(
             name=name,
             context=parent_context,
             kind=kind,
-            attributes=attributes or {},
+            attributes=resolved_attrs,
         )
+        for attr_key, attr_val in resolved_attrs.items():
+            span.set_attribute(attr_key, attr_val)
         span_record = _SpanRecord(
             run_id=run_key,
             span=span,

--- a/libs/azure-ai/tests/unit_tests/test_inference_tracing.py
+++ b/libs/azure-ai/tests/unit_tests/test_inference_tracing.py
@@ -2437,3 +2437,68 @@ def test_contextvar_reset_cross_thread_does_not_raise() -> None:
 
     # Span should be cleaned up without error.
     assert str(agent_run) not in tracer._spans
+
+
+def test_start_span_attributes_survive_sampler_that_drops_constructor_attrs() -> None:
+    """Verify gen_ai attributes are applied via set_attribute after start_span.
+
+    The OTel Python SDK only copies ``SamplingResult.attributes`` onto new
+    spans — user-provided ``attributes`` passed to ``start_span()`` are fed to
+    the sampler but never applied to the span itself (see
+    ``opentelemetry/sdk/trace/__init__.py`` ``Tracer.start_span``).  Some
+    samplers (e.g. the Azure Monitor distro's ``RateLimitedSampler``) do not
+    forward those user attributes in their ``SamplingResult``, causing all
+    ``gen_ai.*`` attributes to be silently lost.
+
+    The tracer must explicitly re-apply attributes via ``set_attribute()``
+    after ``start_span()`` returns, so attributes survive regardless of the
+    sampler implementation.
+    """
+
+    class DroppingMockSpan(MockSpan):
+        """Simulates a span whose sampler dropped constructor attributes."""
+
+        def __init__(
+            self,
+            name: str,
+            attributes: Optional[Dict[str, Any]] = None,
+        ) -> None:
+            # Simulate sampler dropping constructor attrs
+            super().__init__(name, attributes=None)
+
+    class DroppingMockTracer(MockTracer):
+        """Simulates an OTel TracerProvider with a sampler that drops attrs."""
+
+        def start_span(
+            self,
+            name: str,
+            kind: Any = None,
+            context: Any = None,
+            attributes: Optional[Dict[str, Any]] = None,
+        ) -> DroppingMockSpan:
+            span = DroppingMockSpan(name, attributes)
+            self.spans.append(span)
+            return span
+
+    tracer = tracing.AzureAIOpenTelemetryTracer()
+    dropping_tracer = DroppingMockTracer()
+    tracer._tracer = dropping_tracer  # type: ignore[assignment]
+
+    run_id = uuid4()
+    tracer.on_chain_start(
+        {},
+        {"messages": [{"role": "user", "content": "hi"}]},
+        run_id=run_id,
+        metadata={
+            "otel_agent_span": True,
+            "agent_name": "TestAgent",
+            "thread_id": "t1",
+        },
+    )
+
+    record = tracer._spans[str(run_id)]
+    span = cast(MockSpan, record.span)
+
+    # Attributes must be present even though the mock sampler dropped them
+    assert span.attributes.get("gen_ai.operation.name") == "invoke_agent"
+    assert span.attributes.get("gen_ai.agent.name") == "TestAgent"


### PR DESCRIPTION
## Problem

When users initialize `AzureAIOpenTelemetryTracer` with `configure_azure_monitor()` (the recommended Azure Monitor distro path), **all `gen_ai.*` span attributes are silently lost** from Application Insights. The `customDimensions` field contains only `_MS.ResourceAttributeId`, and the dependency Type column shows "N/A".

## Root Cause

The OTel Python SDK's `Tracer.start_span()` passes user-provided `attributes` to the sampler as input, but only copies `SamplingResult.attributes` onto the created span ([`opentelemetry-sdk trace/__init__.py` line 1168](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L1168)):

```python
span = _Span(
    ...
    attributes=sampling_result.attributes.copy(),  # Only sampler attrs, NOT user attrs!
)
```

Samplers like the Azure Monitor distro's `RateLimitedSampler` (default when using `configure_azure_monitor()`) do not return user attributes in their `SamplingResult`. Attributes set via `span.set_attribute()` after creation work fine because they write directly to `span._attributes`.

## Evidence

| Setup | `customDimensions` has `gen_ai.*` | Type column |
|-------|-----------------------------------|-------------|
| `configure_azure_monitor()` (distro) | ❌ Empty | N/A |
| Manual `TracerProvider` + `AzureMonitorTraceExporter` | ✅ All present | azure_openai |
| `configure_azure_monitor()` + `OTEL_TRACES_SAMPLER=always_on` | ✅ All present | azure_openai |

## Fix

After `start_span()`, explicitly re-apply all attributes via `set_attribute()`. The attributes are still passed to `start_span()` for sampler input, but the `set_attribute()` calls guarantee they survive regardless of sampler implementation.

## Affected Attributes

- `gen_ai.operation.name` (invoke_agent, chat, execute_tool)
- `gen_ai.provider.name` (shows "N/A" in Azure Monitor Type column)
- `gen_ai.agent.name` / `gen_ai.agent.id`
- `gen_ai.usage.input_tokens` / `output_tokens`
- `gen_ai.request.model` / `gen_ai.response.model`
- All other attributes passed to `_start_span()`

## Test

Added `test_start_span_attributes_survive_sampler_that_drops_constructor_attrs` with a `DroppingMockTracer` that simulates a sampler discarding constructor attributes. All 96 existing tests continue to pass.