### PR TITLE
Use ApplicationInsightsSampler instead of RateLimitedSampler in configure_azure_monitor

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
@@ -2510,5 +2510,14 @@ class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
         with cls._configure_lock:
             if cls._azure_monitor_configured:
                 return
-            configure_azure_monitor(connection_string=connection_string)
+            # Set OTEL_TRACES_SAMPLER before configure_azure_monitor() so
+            # the distro does not install its default RateLimitedSampler,
+            # which silently drops user-provided span attributes when
+            # sampling_percentage == 100%.  ``always_on`` delegates to the
+            # standard ALWAYS_ON sampler that preserves attributes.
+            os.environ.setdefault("OTEL_TRACES_SAMPLER", "always_on")
+            configure_azure_monitor(
+                connection_string=connection_string,
+                sampling_ratio=1.0,
+            )
             cls._azure_monitor_configured = True

--- a/libs/azure-ai/tests/unit_tests/test_inference_tracing.py
+++ b/libs/azure-ai/tests/unit_tests/test_inference_tracing.py
@@ -1782,7 +1782,7 @@ def test_use_propagated_context_no_headers_is_noop(
 def test_configure_azure_monitor_is_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
-    def fake_configure(*, connection_string: str) -> None:
+    def fake_configure(*, connection_string: str, **kwargs: Any) -> None:
         calls.append(connection_string)
 
     original = tracing.AzureAIOpenTelemetryTracer._azure_monitor_configured


### PR DESCRIPTION
## Problem

`configure_azure_monitor()` defaults to `RateLimitedSampler`, which has a [bug](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_rate_limited_sampling.py#L95-L96): when `sampling_percentage == 100.0` (common at low traffic / first spans), it returns `new_attributes = {}` instead of `dict(attributes)`, dropping all user-provided span attributes.

`ApplicationInsightsSampler` does NOT have this bug — it correctly passes through user attributes in `SamplingResult`.

While #341 added a defensive `set_attribute()` re-apply, this change selects the correct sampler to avoid the bug entirely.

## Changes

- **`_configure_azure_monitor`**: pass `sampling_ratio=1.0` to `configure_azure_monitor()`, which selects `ApplicationInsightsSampler` instead of `RateLimitedSampler`
- **`_configure_azure_monitor`**: set `OTEL_TRACES_SAMPLER=always_on` as default env var (via `setdefault`) to prevent the distro from overriding with `RateLimitedSampler`
- **Test fix**: update `fake_configure` mock to accept `**kwargs` so it handles the new `sampling_ratio` parameter

## Evidence

Tested all 3 samplers against `_start_span`:

| Sampler | Preserves `gen_ai.*` attrs from `start_span(attributes=...)` |
|---------|-----|
| `ALWAYS_ON` | ✅ |
| `ApplicationInsightsSampler(1.0)` | ✅ |
| `RateLimitedSampler(100)` at 100% | ❌ Drops all |

## Tests

All 96 unit tests pass. Lint clean on Python 3.10 and 3.12.