### PR TITLE
Legacy classes added for backward compatibility

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/chat_models/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/__init__.py
@@ -1,7 +1,16 @@
 """Chat completions model for Azure AI."""
 
+from typing import TYPE_CHECKING
+
 from langchain_openai.chat_models import AzureChatOpenAI
 
 from langchain_azure_ai.chat_models.openai import AzureAIOpenAIApiChatModel
 
-__all__ = ["AzureChatOpenAI", "AzureAIOpenAIApiChatModel"]
+if TYPE_CHECKING:
+    from langchain_azure_ai.chat_models.inference import AzureAIChatCompletionsModel
+
+__all__ = [
+    "AzureChatOpenAI",
+    "AzureAIOpenAIApiChatModel",
+    "AzureAIChatCompletionsModel",
+]

--- a/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/inference.py
@@ -320,6 +320,8 @@ def _format_tool_call_for_azure_inference(tool_call: ToolCall) -> dict:
 class AzureAIChatCompletionsModel(BaseChatModel, ModelInferenceService):
     """Azure AI Chat Completions Model.
 
+    This class has been deprecated in favor of `AzureAIOpenAIApiChatModel`.
+
     The Azure AI model inference API (https://aka.ms/azureai/modelinference)
     provides a common layer to talk with most models deployed to Azure AI. This class
     providers inference for chat completions models supporting it. See documentation

--- a/libs/azure-ai/langchain_azure_ai/embeddings/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/embeddings/__init__.py
@@ -1,7 +1,16 @@
 """Embedding model for Azure AI."""
 
+from typing import TYPE_CHECKING
+
 from langchain_openai.embeddings import AzureOpenAIEmbeddings
 
 from langchain_azure_ai.embeddings.openai import AzureAIOpenAIApiEmbeddingsModel
 
-__all__ = ["AzureOpenAIEmbeddings", "AzureAIOpenAIApiEmbeddingsModel"]
+if TYPE_CHECKING:
+    from langchain_azure_ai.embeddings.inference import AzureAIEmbeddingsModel
+
+__all__ = [
+    "AzureOpenAIEmbeddings",
+    "AzureAIOpenAIApiEmbeddingsModel",
+    "AzureAIEmbeddingsModel",
+]

--- a/libs/azure-ai/langchain_azure_ai/embeddings/inference.py
+++ b/libs/azure-ai/langchain_azure_ai/embeddings/inference.py
@@ -39,6 +39,8 @@ logger = logging.getLogger(__name__)
 class AzureAIEmbeddingsModel(ModelInferenceService, Embeddings):
     """Azure AI model inference for embeddings.
 
+    This class has been deprecated in favor of `AzureAIOpenAIApiEmbeddingsModel`.
+
     **Examples:**
 
     ```python


### PR DESCRIPTION
This pull request updates the Azure AI integration by improving module exports and clarifying the deprecation status of certain classes. The main changes are the addition of new classes to the `__all__` lists for easier imports and the introduction of deprecation notices for legacy classes.

**Module export improvements:**

* Added `AzureAIChatCompletionsModel` to the `__all__` list in `chat_models/__init__.py` for better discoverability and type checking support.
* Added `AzureAIEmbeddingsModel` to the `__all__` list in `embeddings/__init__.py` for better discoverability and type checking support.

**Deprecation notices:**

* Marked `AzureAIChatCompletionsModel` as deprecated in favor of `AzureAIOpenAIApiChatModel`, and updated its docstring accordingly.
* Marked `AzureAIEmbeddingsModel` as deprecated in favor of `AzureAIOpenAIApiEmbeddingsModel`, and updated its docstring accordingly.