### PR TITLE
Santiagxf/patch tests

### DIFF
--- a/libs/azure-ai/tests/unit_tests/test_agents_prebuilt_v1.py
+++ b/libs/azure-ai/tests/unit_tests/test_agents_prebuilt_v1.py
@@ -5,11 +5,17 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from azure.ai.agents.models import (
-    CodeInterpreterToolDefinition,
-    FilePurpose,
-    FunctionToolDefinition,
-)
+
+try:
+    from azure.ai.agents.models import (
+        CodeInterpreterToolDefinition,
+        FilePurpose,
+        FunctionToolDefinition,
+    )
+except ImportError:
+    pytest.skip("Agents V1 not available", allow_module_level=True)
+
+
 from langchain_core.messages import HumanMessage
 
 from langchain_azure_ai.agents._v1.prebuilt.declarative import (


### PR DESCRIPTION
This pull request updates the test suite for Azure AI agents by renaming a test file and improving its compatibility with environments where Agents V1 may not be available. The main change is the addition of a conditional import that gracefully skips the tests if the required module cannot be imported.

Test improvements for compatibility:

* Renamed `test_agents_prebuilt.py` to `test_agents_prebuilt_v1.py` and added a `try`/`except ImportError` block to skip the test file at the module level if the `azure.ai.agents.models` module is not available, ensuring tests do not fail in environments lacking Agents V1 support.