### PR TITLE
Fix: AzureAIMemoryChatMessageHistory should not take session_id and base_history_factory. It directly decorates a BaseChatMessageHistory instance now.

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/chat_history/azure_ai_memory.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_history/azure_ai_memory.py
@@ -142,16 +142,12 @@ class AzureAIMemoryChatMessageHistory(BaseChatMessageHistory):
     from azure.identity import DefaultAzureCredential
     from langchain_core.chat_history import InMemoryChatMessageHistory
 
-    def base_factory(session_id: str) -> InMemoryChatMessageHistory:
-        return InMemoryChatMessageHistory()
-
     history = AzureAIMemoryChatMessageHistory(
         project_endpoint="https://myproject.api.azureml.ms",
         credential=DefaultAzureCredential(),
         store_name="my_store",
         scope="user:123",
-        session_id="session_001",
-        base_history_factory=base_factory,
+        base_history=InMemoryChatMessageHistory(),
     )
     ```
 
@@ -161,8 +157,7 @@ class AzureAIMemoryChatMessageHistory(BaseChatMessageHistory):
     history = AzureAIMemoryChatMessageHistory(
         store_name="my_store",
         scope="user:123",
-        session_id="session_001",
-        base_history_factory=base_factory,
+        base_history=InMemoryChatMessageHistory(),
     )
     ```
     """
@@ -171,8 +166,7 @@ class AzureAIMemoryChatMessageHistory(BaseChatMessageHistory):
         self,
         store_name: str,
         scope: str,
-        session_id: str,
-        base_history_factory: Callable[[str], BaseChatMessageHistory],
+        base_history: BaseChatMessageHistory,
         *,
         project_endpoint: Optional[str] = None,
         credential: Optional[TokenCredential] = None,
@@ -185,9 +179,7 @@ class AzureAIMemoryChatMessageHistory(BaseChatMessageHistory):
             store_name: Memory store name in Azure AI Foundry.
             scope: Memory scope (for example, `user:{user_id}` or
                 `tenant:{org_id}`) used for long-term recall across sessions.
-            session_id: Ephemeral session ID for this chat thread.
-            base_history_factory: Function that creates the underlying
-                short-term history instance for the given session ID.
+            base_history: Underlying short-term history instance to wrap.
             project_endpoint: Azure AI project endpoint. If not provided,
                 reads from `AZURE_AI_PROJECT_ENDPOINT`.
             credential: Azure credential for authentication. If not provided,
@@ -231,8 +223,7 @@ class AzureAIMemoryChatMessageHistory(BaseChatMessageHistory):
 
         self._store = store_name
         self._scope = scope
-        self._session_id = session_id
-        self._base = base_history_factory(session_id)
+        self._base = base_history
         self._update_delay = update_delay
         self._role_mapper = role_mapper
         self._previous_update_id: Optional[str] = None  # advanced incremental updates
@@ -256,11 +247,6 @@ class AzureAIMemoryChatMessageHistory(BaseChatMessageHistory):
     def scope(self) -> str:
         """Memory scope (e.g., user ID or tenant ID)."""
         return self._scope
-
-    @property
-    def session_id(self) -> str:
-        """Ephemeral session ID for this chat thread."""
-        return self._session_id
 
     def add_message(self, message: BaseMessage) -> None:
         """Persist in short-term transcript AND asynchronously update Foundry Memory.
@@ -306,7 +292,7 @@ class AzureAIMemoryChatMessageHistory(BaseChatMessageHistory):
         self._base.clear()
 
     def get_retriever(self, *, k: int = 5) -> AzureAIMemoryRetriever:
-        """Create a retriever bound to this store/scope/session.
+        """Create a retriever bound to this store/scope/history.
 
         History-bound retrievers always use incremental search with multi-turn
         conversation context for better contextual memory retrieval.

--- a/libs/azure-ai/langchain_azure_ai/retrievers/azure_ai_memory_retriever.py
+++ b/libs/azure-ai/langchain_azure_ai/retrievers/azure_ai_memory_retriever.py
@@ -129,8 +129,7 @@ class AzureAIMemoryRetriever(BaseRetriever):
         project_endpoint="https://myproject.api.azureml.ms",
         store_name="my_store",
         scope="user:123",
-        session_id="session_001",
-        base_history_factory=lambda _: InMemoryChatMessageHistory(),
+        base_history=InMemoryChatMessageHistory(),
     )
     retriever = history.get_retriever(k=5)
     docs = retriever.invoke("Tell me more")
@@ -172,7 +171,6 @@ class AzureAIMemoryRetriever(BaseRetriever):
 
         store_name = values.get("store_name")
         scope_val = values.get("scope")
-        session_val = values.get("session_id")
 
         if history_ref is not None:
             # History properties take precedence when retriever is bound to history
@@ -181,7 +179,6 @@ class AzureAIMemoryRetriever(BaseRetriever):
 
             store_name = history_ref.store_name or store_name
             scope_val = history_ref.scope or scope_val
-            session_val = history_ref.session_id or session_val
 
             # Warn if explicitly provided values differ from history
             if provided_store and provided_store != store_name:
@@ -219,7 +216,6 @@ class AzureAIMemoryRetriever(BaseRetriever):
 
         values["store_name"] = store_name
         values["scope"] = scope_val
-        values["session_id"] = session_val
 
         return values
 

--- a/libs/azure-ai/tests/unit_tests/test_memory_history.py
+++ b/libs/azure-ai/tests/unit_tests/test_memory_history.py
@@ -36,8 +36,7 @@ class TestRoleMapping:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         msg = HumanMessage(content="Hello")
@@ -58,8 +57,7 @@ class TestRoleMapping:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         msg = AIMessage(content="Hi there!")
@@ -80,8 +78,7 @@ class TestRoleMapping:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_id",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         msg = SystemMessage(content="System instruction")
@@ -102,8 +99,7 @@ class TestRoleMapping:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         msg = ToolMessage(content="Tool result", tool_call_id="tool_123")
@@ -125,8 +121,7 @@ class TestRoleMapping:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         msg = AIMessageChunk(content="Streaming response")
@@ -152,8 +147,7 @@ class TestChatMessageHistory:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         msg = HumanMessage(content="Test message")
@@ -176,8 +170,7 @@ class TestChatMessageHistory:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         msg = HumanMessage(content="Test message")
@@ -202,8 +195,7 @@ class TestChatMessageHistory:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         msg = HumanMessage(content="Test message")
@@ -227,8 +219,7 @@ class TestChatMessageHistory:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         history.add_message(HumanMessage(content="Test"))
@@ -251,13 +242,11 @@ class TestChatMessageHistory:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test123",
-                session_id="session_abc",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         assert history.store_name == "test_store"
         assert history.scope == "user:test123"
-        assert history.session_id == "session_abc"
 
     def test_custom_role_mapper(self) -> None:
         """Test that custom role mapper is used when provided."""
@@ -272,8 +261,7 @@ class TestChatMessageHistory:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
                 role_mapper=custom_mapper,
             )
 
@@ -293,8 +281,7 @@ class TestChatMessageHistory:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
         messages = [

--- a/libs/azure-ai/tests/unit_tests/test_memory_retriever.py
+++ b/libs/azure-ai/tests/unit_tests/test_memory_retriever.py
@@ -30,15 +30,14 @@ class TestRetrieverConstruction:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
             retriever = AzureAIMemoryRetriever(history_ref=history, k=10)
 
         assert retriever.store_name == "test_store"
         assert retriever.scope == "user:test"
-        assert retriever.session_id == "session_1"
+        assert retriever.session_id is None
         assert retriever.k == 10
 
     def test_retriever_without_history_ref(self) -> None:
@@ -143,8 +142,7 @@ class TestRetrieverSearch:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
             retriever = AzureAIMemoryRetriever(history_ref=history, k=5)
@@ -208,8 +206,7 @@ class TestRetrieverSearch:
                 project_endpoint="https://test.api.azureml.ms",
                 store_name="test_store",
                 scope="user:test",
-                session_id="session_1",
-                base_history_factory=lambda _: InMemoryChatMessageHistory(),
+                base_history=InMemoryChatMessageHistory(),
             )
 
             # Add conversation history

--- a/samples/foundry-memory/README.md
+++ b/samples/foundry-memory/README.md
@@ -53,15 +53,11 @@ client = AIProjectClient(
     credential=DefaultAzureCredential(),
 )
 
-def base_history_factory(session_id: str):
-    return InMemoryChatMessageHistory()
-
 history = AzureAIMemoryChatMessageHistory(
     client=client,
     store_name="my_store",
     scope="user:123",
-    session_id="session_001",
-    base_history_factory=base_history_factory,
+    base_history=InMemoryChatMessageHistory(),
     update_delay=0,
 )
 

--- a/samples/foundry-memory/basic_usage.py
+++ b/samples/foundry-memory/basic_usage.py
@@ -79,12 +79,6 @@ except ResourceNotFoundError:
     print(f"✓ Memory store '{store_name}' created successfully")
 
 
-# 2) History factory
-def base_history_factory(_: str) -> InMemoryChatMessageHistory:
-    """Create a new in-memory chat message history."""
-    return InMemoryChatMessageHistory()
-
-
 # Session cache: CRITICAL for incremental search to work
 # RunnableWithMessageHistory calls get_session_history on every invoke,
 # so we must cache instances to preserve _previous_search_id state across turns.
@@ -109,8 +103,7 @@ def get_session_history(user_id: str, session_id: str) -> AzureAIMemoryChatMessa
             credential=credential,
             store_name=store_name,
             scope=user_id,
-            session_id=session_id,
-            base_history_factory=base_history_factory,
+            base_history=InMemoryChatMessageHistory(),
             update_delay=0,  # TEST MODE: process updates immediately (default ~300s)
         )
     return _session_histories[cache_key]


### PR DESCRIPTION
Fixes #366
Fixes #367