### PR TITLE
Bump version from 1.0.0 to 1.0.1

### DIFF
--- a/libs/sqlserver/pyproject.toml
+++ b/libs/sqlserver/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-sqlserver"
-version = "1.0.0"
+version = "1.0.1"
 description = "An integration package to support SQL Server in LangChain."
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
This pull request makes a minor update to the `langchain-sqlserver` package by incrementing its version number from 1.0.0 to 1.0.1 introducing security updates from dependencies.