### PR TITLE
fix: patch 1 high-severity security alert (langchain-core CVE-2026-34070)

### DIFF
--- a/libs/azure-postgresql/poetry.lock
+++ b/libs/azure-postgresql/poetry.lock
@@ -2369,14 +2369,14 @@ tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
 
 [[package]]
 name = "langchain-core"
-version = "1.2.15"
+version = "1.2.23"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main", "dev"]
 files = [
-    {file = "langchain_core-1.2.15-py3-none-any.whl", hash = "sha256:8d920d8a31d8c223966a3993d8c79fd6093b9665f2222fc878812f3a52072ab7"},
-    {file = "langchain_core-1.2.15.tar.gz", hash = "sha256:7d5f5d2daa8ddbe4054a96101dc5d509926f831b9914808c24640987d499758c"},
+    {file = "langchain_core-1.2.23-py3-none-any.whl", hash = "sha256:70866dfc5275b7840ce272ff70f0ff216c8666ab25dc1b41964a4ef58c02a3ff"},
+    {file = "langchain_core-1.2.23.tar.gz", hash = "sha256:fdec64f90cfea25317e88d9803c44684af1f4e30dec4e58320dd7393bb0f0785"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Security Alert Patch

Resolves 1 Dependabot security alert in the **high** severity tier.

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| `langchain-core` | 1.2.15 | 1.2.23 | A — direct lockfile regen | published | CVE-2026-34070 |

Strategy = direct lockfile regen (A) — `pyproject.toml` constraint `>=1.2.5,<2.0.0` already permitted the fix; no manifest edit needed.
Scope = published (ships to end users as a direct dependency).

Note: `uv.lock` was already at 1.2.22 (fixed by #426). Only `poetry.lock` needed updating.

### CVE Details

| CVE | GHSA | Package | Summary |
|-----|------|---------|---------|
| CVE-2026-34070 | [GHSA-qh6h-p6c9-ff54](https://github.com/advisories/GHSA-qh6h-p6c9-ff54) | `langchain-core` | Path Traversal vulnerabilities in legacy `load_prompt` functions |

### Linear Tickets

No matching Linear tickets found.

### Verification

- [x] All lockfiles regenerated (`poetry.lock` bumped to 1.2.23)
- [x] Pre-existing lint issues confirmed pre-existing on `main` (not introduced by this change)
- [x] Package imports cleanly

🤖 Submitted by langster-patch