### PR TITLE
feat: Use OTel Logs API for gen_ai.evaluation.result events

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
@@ -3053,13 +3053,24 @@ class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
         error_type: Optional[str] = None,
         run_id: Optional[Union[str, UUID]] = None,
     ) -> None:
-        """Emit a ``gen_ai.evaluation.result`` event on an agent span.
+        """Emit a ``gen_ai.evaluation.result`` event for an agent span.
 
-        The event is attached to the span identified by *run_id*.  When
-        *run_id* is ``None`` the method walks ``self._spans`` in reverse
-        insertion order and picks the most recent ``invoke_agent`` span
-        that is still open, which covers the common case where the
-        evaluation happens inside the same graph execution.
+        Per the `OpenTelemetry semantic conventions for GenAI events
+        <https://github.com/open-telemetry/semantic-conventions/blob/main/model/gen-ai/events.yaml>`_,
+        the event SHOULD be parented to the GenAI operation span being
+        evaluated.  This method activates the target span's context
+        before emitting, so the event is correctly correlated.
+
+        The event is emitted via the **OTel Logs/Events API** (not the
+        deprecated ``span.add_event()``), following the `OTel deprecation
+        of Span Events <https://opentelemetry.io/blog/2026/deprecating-span-events/>`_.
+        This ensures the event lands in the ``customEvents`` table in
+        Azure Monitor / Application Insights (via
+        ``AzureMonitorLogExporter``), where it is independently
+        queryable.
+
+        When the OTel Logs API is not available, falls back to the
+        legacy ``span.add_event()`` path.
 
         Args:
             evaluation_name: Name of the evaluation metric (e.g.
@@ -3112,10 +3123,57 @@ class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
         if error_type is not None:
             attributes[Attrs.ERROR_TYPE] = error_type
 
-        span.add_event(Attrs.EVALUATION_RESULT_EVENT, attributes=attributes)
+        # Preferred path: emit via OTel Logs/Events API so the event
+        # lands in the customEvents table in Azure Monitor.  The span's
+        # context is activated so the log record is correlated to the
+        # correct trace/span.
+        emitted_via_logs = False
+        try:
+            from opentelemetry import context as _otel_ctx
+            from opentelemetry._logs import get_logger_provider
+            import opentelemetry.trace as _otrace
+
+            logger_provider = get_logger_provider()
+            # Only use Logs API if a real SDK LoggerProvider is configured
+            # (not the default no-op proxy)
+            try:
+                from opentelemetry.sdk._logs import LoggerProvider as _SdkLP
+                _is_real_provider = isinstance(logger_provider, _SdkLP)
+            except ImportError:
+                _is_real_provider = False
+
+            if _is_real_provider:
+                otel_logger = logger_provider.get_logger(
+                    "gen_ai.evaluation",
+                    version="1.0.0",
+                )
+                # Activate the target span's context for correct parenting
+                ctx = _otrace.set_span_in_context(span)
+                token = _otel_ctx.attach(ctx)
+                try:
+                    otel_logger.emit(
+                        body=Attrs.EVALUATION_RESULT_EVENT,
+                        attributes=attributes,
+                    )
+                    emitted_via_logs = True
+                finally:
+                    _otel_ctx.detach(token)
+        except Exception:  # noqa: BLE001
+            LOGGER.debug(
+                "OTel Logs API unavailable, falling back to span.add_event()",
+                exc_info=True,
+            )
+
+        # Fallback: use legacy span.add_event() — the event is embedded
+        # in the span's data but may not be independently queryable in
+        # Azure Monitor.
+        if not emitted_via_logs:
+            span.add_event(Attrs.EVALUATION_RESULT_EVENT, attributes=attributes)
+
         LOGGER.debug(
-            "Emitted %s event on span: name=%s label=%s score=%s",
+            "Emitted %s event (via=%s): name=%s label=%s score=%s",
             Attrs.EVALUATION_RESULT_EVENT,
+            "logs_api" if emitted_via_logs else "span_event",
             evaluation_name,
             score_label,
             score_value,

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
@@ -208,6 +208,7 @@ class Attrs:
     EVALUATION_EXPLANATION = "gen_ai.evaluation.explanation"
     EVALUATION_RESULT_EVENT = "gen_ai.evaluation.result"
     AGENT_STATE = "gen_ai.agent.state"
+    AZURE_MONITOR_CUSTOM_EVENT_NAME = "microsoft.custom_event.name"
 
     # Optional vendor-specific attributes
     OPENAI_REQUEST_SERVICE_TIER = "openai.request.service_tier"
@@ -3124,9 +3125,10 @@ class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
             attributes[Attrs.ERROR_TYPE] = error_type
 
         # Preferred path: emit via OTel Logs/Events API so the event
-        # lands in the customEvents table in Azure Monitor.  The span's
-        # context is activated so the log record is correlated to the
-        # correct trace/span.
+        # lands in the customEvents table in Azure Monitor when an SDK
+        # LoggerProvider/exporter is configured. The span's context is
+        # activated so the log record is correlated to the correct
+        # trace/span.
         emitted_via_logs = False
         try:
             import opentelemetry.trace as _otrace
@@ -3148,13 +3150,18 @@ class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
                     "gen_ai.evaluation",
                     version="1.0.0",
                 )
+                log_attributes = dict(attributes)
+                log_attributes[Attrs.AZURE_MONITOR_CUSTOM_EVENT_NAME] = (
+                    Attrs.EVALUATION_RESULT_EVENT
+                )
                 # Activate the target span's context for correct parenting
                 ctx = _otrace.set_span_in_context(span)
                 token = _otel_ctx.attach(ctx)
                 try:
                     otel_logger.emit(
                         body=Attrs.EVALUATION_RESULT_EVENT,
-                        attributes=attributes,
+                        attributes=log_attributes,
+                        event_name=Attrs.EVALUATION_RESULT_EVENT,
                     )
                     emitted_via_logs = True
                 finally:

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
@@ -3129,15 +3129,16 @@ class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
         # correct trace/span.
         emitted_via_logs = False
         try:
+            import opentelemetry.trace as _otrace
             from opentelemetry import context as _otel_ctx
             from opentelemetry._logs import get_logger_provider
-            import opentelemetry.trace as _otrace
 
             logger_provider = get_logger_provider()
             # Only use Logs API if a real SDK LoggerProvider is configured
             # (not the default no-op proxy)
             try:
                 from opentelemetry.sdk._logs import LoggerProvider as _SdkLP
+
                 _is_real_provider = isinstance(logger_provider, _SdkLP)
             except ImportError:
                 _is_real_provider = False

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
@@ -24,6 +24,7 @@ to instrument your applications.
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import logging
 import os
@@ -66,6 +67,11 @@ _TRACING_DEPENDENCY_ERROR_MESSAGE = (
     "    pip install 'langchain-azure-ai[opentelemetry]'"
 )
 _DEFAULT_MAX_STATE_SIZE = 32768
+_PACKAGE_NAME = "langchain-azure-ai"
+try:
+    _PACKAGE_VERSION = importlib.metadata.version(_PACKAGE_NAME)
+except importlib.metadata.PackageNotFoundError:
+    _PACKAGE_VERSION = "0.0.0"
 
 try:  # pragma: no cover - imported lazily in production environments
     from azure.monitor.opentelemetry import configure_azure_monitor
@@ -3148,7 +3154,7 @@ class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
             if _is_real_provider:
                 otel_logger = logger_provider.get_logger(
                     "gen_ai.evaluation",
-                    version="1.0.0",
+                    version=_PACKAGE_VERSION,
                 )
                 log_attributes = dict(attributes)
                 log_attributes[Attrs.AZURE_MONITOR_CUSTOM_EVENT_NAME] = (

--- a/libs/azure-ai/tests/unit_tests/test_evaluation.py
+++ b/libs/azure-ai/tests/unit_tests/test_evaluation.py
@@ -493,44 +493,46 @@ class TestTracerEvalEvent:
         emit_evaluation_event should use it instead of span.add_event()."""
         tracer = self._make_tracer()
 
-        mock_span = MagicMock()
+        from opentelemetry.sdk._logs import LoggerProvider as SdkLP
+        from opentelemetry.sdk.trace import TracerProvider
+
+        tracer_provider = TracerProvider()
+        test_span = tracer_provider.get_tracer(__name__).start_span("emit-evaluation")
         from langchain_azure_ai.callbacks.tracers.inference_tracing import (
             Attrs,
             _SpanRecord,
         )
 
         tracer._spans["r1"] = _SpanRecord(
-            run_id="r1", span=mock_span, operation="invoke_agent", parent_run_id=None
+            run_id="r1",
+            span=test_span,
+            operation="invoke_agent",
+            parent_run_id=None,
         )
 
         mock_otel_logger = MagicMock()
-
-        from opentelemetry._logs import get_logger_provider, set_logger_provider
-        from opentelemetry._logs._internal import _LOGGER_PROVIDER_SET_ONCE
-        from opentelemetry.sdk._logs import LoggerProvider as SdkLP
-
-        original_done = _LOGGER_PROVIDER_SET_ONCE._done
-        original_provider = get_logger_provider()
-
-        class _TestLP(SdkLP):
-            def __init__(self) -> None:
-                pass
-
-            def get_logger(self, *a: Any, **kw: Any) -> Any:
-                return mock_otel_logger
-
-        _LOGGER_PROVIDER_SET_ONCE._done = False
-        set_logger_provider(_TestLP())
+        logger_provider = SdkLP()
         try:
-            tracer.emit_evaluation_event(
-                evaluation_name="quality",
-                score_value=4.0,
-                score_label="pass",
-            )
+            with (
+                patch(
+                    "opentelemetry._logs.get_logger_provider",
+                    return_value=logger_provider,
+                ),
+                patch.object(
+                    logger_provider,
+                    "get_logger",
+                    return_value=mock_otel_logger,
+                ),
+                patch.object(test_span, "add_event") as mock_add_event,
+            ):
+                tracer.emit_evaluation_event(
+                    evaluation_name="quality",
+                    score_value=4.0,
+                    score_label="pass",
+                )
+                mock_add_event.assert_not_called()
         finally:
-            _LOGGER_PROVIDER_SET_ONCE._done = False
-            set_logger_provider(original_provider)
-            _LOGGER_PROVIDER_SET_ONCE._done = original_done
+            test_span.end()
 
         mock_otel_logger.emit.assert_called_once()
         call_kwargs = mock_otel_logger.emit.call_args[1]
@@ -542,7 +544,6 @@ class TestTracerEvalEvent:
         )
         assert call_kwargs["attributes"][Attrs.EVALUATION_NAME] == "quality"
         assert call_kwargs["attributes"][Attrs.EVALUATION_SCORE_VALUE] == 4.0
-        mock_span.add_event.assert_not_called()
 
     def test_emit_with_explicit_run_id(self) -> None:
         tracer = self._make_tracer()
@@ -609,43 +610,54 @@ class TestTracerEvalEvent:
         so the log record is parented to the correct trace/span."""
         tracer = self._make_tracer()
 
-        mock_span = MagicMock()
+        from opentelemetry import trace as otel_trace
+        from opentelemetry.sdk._logs import LoggerProvider as SdkLP
+        from opentelemetry.sdk.trace import TracerProvider
+
+        tracer_provider = TracerProvider()
+        test_span = tracer_provider.get_tracer(__name__).start_span(
+            "emit-evaluation-context"
+        )
         from langchain_azure_ai.callbacks.tracers.inference_tracing import (
             Attrs,
             _SpanRecord,
         )
 
         tracer._spans["r1"] = _SpanRecord(
-            run_id="r1", span=mock_span, operation="invoke_agent", parent_run_id=None
+            run_id="r1",
+            span=test_span,
+            operation="invoke_agent",
+            parent_run_id=None,
         )
 
         mock_otel_logger = MagicMock()
+        logger_provider = SdkLP()
+        observed_spans: list[Any] = []
 
-        from opentelemetry._logs import get_logger_provider, set_logger_provider
-        from opentelemetry._logs._internal import _LOGGER_PROVIDER_SET_ONCE
-        from opentelemetry.sdk._logs import LoggerProvider as SdkLP
+        def _capture_current_span(*_: Any, **__: Any) -> None:
+            observed_spans.append(otel_trace.get_current_span())
 
-        original_done = _LOGGER_PROVIDER_SET_ONCE._done
-        original_provider = get_logger_provider()
-
-        class _TestLP(SdkLP):
-            def __init__(self) -> None:
-                pass
-
-            def get_logger(self, *a: Any, **kw: Any) -> Any:
-                return mock_otel_logger
-
-        _LOGGER_PROVIDER_SET_ONCE._done = False
-        set_logger_provider(_TestLP())
+        mock_otel_logger.emit.side_effect = _capture_current_span
         try:
-            tracer.emit_evaluation_event(
-                evaluation_name="test",
-                score_value=5.0,
-            )
+            with (
+                patch(
+                    "opentelemetry._logs.get_logger_provider",
+                    return_value=logger_provider,
+                ),
+                patch.object(
+                    logger_provider,
+                    "get_logger",
+                    return_value=mock_otel_logger,
+                ),
+                patch.object(test_span, "add_event") as mock_add_event,
+            ):
+                tracer.emit_evaluation_event(
+                    evaluation_name="test",
+                    score_value=5.0,
+                )
+                mock_add_event.assert_not_called()
         finally:
-            _LOGGER_PROVIDER_SET_ONCE._done = False
-            set_logger_provider(original_provider)
-            _LOGGER_PROVIDER_SET_ONCE._done = original_done
+            test_span.end()
 
         mock_otel_logger.emit.assert_called_once()
         call_kwargs = mock_otel_logger.emit.call_args[1]
@@ -654,7 +666,7 @@ class TestTracerEvalEvent:
             call_kwargs["attributes"][Attrs.AZURE_MONITOR_CUSTOM_EVENT_NAME]
             == Attrs.EVALUATION_RESULT_EVENT
         )
-        mock_span.add_event.assert_not_called()
+        assert observed_spans == [test_span]
 
 
 # ============================================================

--- a/libs/azure-ai/tests/unit_tests/test_evaluation.py
+++ b/libs/azure-ai/tests/unit_tests/test_evaluation.py
@@ -505,17 +505,18 @@ class TestTracerEvalEvent:
 
         mock_otel_logger = MagicMock()
 
+        from opentelemetry._logs import get_logger_provider, set_logger_provider
         from opentelemetry._logs._internal import _LOGGER_PROVIDER_SET_ONCE
-        from opentelemetry._logs import set_logger_provider, get_logger_provider
         from opentelemetry.sdk._logs import LoggerProvider as SdkLP
 
         original_done = _LOGGER_PROVIDER_SET_ONCE._done
         original_provider = get_logger_provider()
 
         class _TestLP(SdkLP):
-            def __init__(self):
+            def __init__(self) -> None:
                 pass
-            def get_logger(self, *a, **kw):
+
+            def get_logger(self, *a: Any, **kw: Any) -> Any:
                 return mock_otel_logger
 
         _LOGGER_PROVIDER_SET_ONCE._done = False
@@ -612,17 +613,18 @@ class TestTracerEvalEvent:
 
         mock_otel_logger = MagicMock()
 
+        from opentelemetry._logs import get_logger_provider, set_logger_provider
         from opentelemetry._logs._internal import _LOGGER_PROVIDER_SET_ONCE
-        from opentelemetry._logs import set_logger_provider, get_logger_provider
         from opentelemetry.sdk._logs import LoggerProvider as SdkLP
 
         original_done = _LOGGER_PROVIDER_SET_ONCE._done
         original_provider = get_logger_provider()
 
         class _TestLP(SdkLP):
-            def __init__(self):
+            def __init__(self) -> None:
                 pass
-            def get_logger(self, *a, **kw):
+
+            def get_logger(self, *a: Any, **kw: Any) -> Any:
                 return mock_otel_logger
 
         _LOGGER_PROVIDER_SET_ONCE._done = False

--- a/libs/azure-ai/tests/unit_tests/test_evaluation.py
+++ b/libs/azure-ai/tests/unit_tests/test_evaluation.py
@@ -434,7 +434,12 @@ class TestFoundryEvaluatorSuite:
 
 
 class TestTracerEvalEvent:
-    """Test AzureAIOpenTelemetryTracer.emit_evaluation_event."""
+    """Test AzureAIOpenTelemetryTracer.emit_evaluation_event.
+
+    The method prefers the OTel Logs/Events API (for Azure Monitor
+    customEvents table) and falls back to span.add_event() when
+    the Logs API is not available.
+    """
 
     def _make_tracer(self) -> Any:
         with patch(
@@ -470,16 +475,68 @@ class TestTracerEvalEvent:
             parent_run_id=None,
         )
 
-        tracer.emit_evaluation_event(
-            evaluation_name="task_completion",
-            score_value=4.5,
-            score_label="pass",
-            explanation="Analysis is thorough",
-        )
+        # Patch OTel Logs API to be unavailable → forces span.add_event fallback
+        with patch.dict("sys.modules", {"opentelemetry._logs": None}):
+            tracer.emit_evaluation_event(
+                evaluation_name="task_completion",
+                score_value=4.5,
+                score_label="pass",
+                explanation="Analysis is thorough",
+            )
 
         mock_span.add_event.assert_called_once()
         event_name = mock_span.add_event.call_args[0][0]
         assert "evaluation" in event_name.lower()
+
+    def test_emit_via_logs_api_when_available(self) -> None:
+        """When OTel Logs API is available with a real LoggerProvider,
+        emit_evaluation_event should use it instead of span.add_event()."""
+        tracer = self._make_tracer()
+
+        mock_span = MagicMock()
+        from langchain_azure_ai.callbacks.tracers.inference_tracing import (
+            Attrs,
+            _SpanRecord,
+        )
+
+        tracer._spans["r1"] = _SpanRecord(
+            run_id="r1", span=mock_span, operation="invoke_agent", parent_run_id=None
+        )
+
+        mock_otel_logger = MagicMock()
+
+        from opentelemetry._logs._internal import _LOGGER_PROVIDER_SET_ONCE
+        from opentelemetry._logs import set_logger_provider, get_logger_provider
+        from opentelemetry.sdk._logs import LoggerProvider as SdkLP
+
+        original_done = _LOGGER_PROVIDER_SET_ONCE._done
+        original_provider = get_logger_provider()
+
+        class _TestLP(SdkLP):
+            def __init__(self):
+                pass
+            def get_logger(self, *a, **kw):
+                return mock_otel_logger
+
+        _LOGGER_PROVIDER_SET_ONCE._done = False
+        set_logger_provider(_TestLP())
+        try:
+            tracer.emit_evaluation_event(
+                evaluation_name="quality",
+                score_value=4.0,
+                score_label="pass",
+            )
+        finally:
+            _LOGGER_PROVIDER_SET_ONCE._done = False
+            set_logger_provider(original_provider)
+            _LOGGER_PROVIDER_SET_ONCE._done = original_done
+
+        mock_otel_logger.emit.assert_called_once()
+        call_kwargs = mock_otel_logger.emit.call_args[1]
+        assert call_kwargs["body"] == Attrs.EVALUATION_RESULT_EVENT
+        assert call_kwargs["attributes"][Attrs.EVALUATION_NAME] == "quality"
+        assert call_kwargs["attributes"][Attrs.EVALUATION_SCORE_VALUE] == 4.0
+        mock_span.add_event.assert_not_called()
 
     def test_emit_with_explicit_run_id(self) -> None:
         tracer = self._make_tracer()
@@ -499,11 +556,13 @@ class TestTracerEvalEvent:
             run_id="run-2", span=mock_span_2, operation="chat", parent_run_id=None
         )
 
-        tracer.emit_evaluation_event(
-            evaluation_name="test",
-            score_label="fail",
-            run_id="run-2",
-        )
+        # Force span.add_event fallback
+        with patch.dict("sys.modules", {"opentelemetry._logs": None}):
+            tracer.emit_evaluation_event(
+                evaluation_name="test",
+                score_label="fail",
+                run_id="run-2",
+            )
 
         mock_span_2.add_event.assert_called_once()
         mock_span_1.add_event.assert_not_called()
@@ -521,13 +580,15 @@ class TestTracerEvalEvent:
             run_id="r1", span=mock_span, operation="invoke_agent", parent_run_id=None
         )
 
-        tracer.emit_evaluation_event(
-            evaluation_name="task_adherence",
-            score_value=3.0,
-            score_label="fail",
-            explanation="Missing risk section",
-            response_id="resp-123",
-        )
+        # Force span.add_event fallback to check attribute content
+        with patch.dict("sys.modules", {"opentelemetry._logs": None}):
+            tracer.emit_evaluation_event(
+                evaluation_name="task_adherence",
+                score_value=3.0,
+                score_label="fail",
+                explanation="Missing risk section",
+                response_id="resp-123",
+            )
 
         mock_span.add_event.assert_called_once()
         attrs = mock_span.add_event.call_args[1]["attributes"]
@@ -536,6 +597,48 @@ class TestTracerEvalEvent:
         assert attrs[Attrs.EVALUATION_SCORE_LABEL] == "fail"
         assert attrs[Attrs.EVALUATION_EXPLANATION] == "Missing risk section"
         assert attrs[Attrs.RESPONSE_ID] == "resp-123"
+
+    def test_logs_api_activates_span_context(self) -> None:
+        """The Logs API path should activate the target span's context
+        so the log record is parented to the correct trace/span."""
+        tracer = self._make_tracer()
+
+        mock_span = MagicMock()
+        from langchain_azure_ai.callbacks.tracers.inference_tracing import _SpanRecord
+
+        tracer._spans["r1"] = _SpanRecord(
+            run_id="r1", span=mock_span, operation="invoke_agent", parent_run_id=None
+        )
+
+        mock_otel_logger = MagicMock()
+
+        from opentelemetry._logs._internal import _LOGGER_PROVIDER_SET_ONCE
+        from opentelemetry._logs import set_logger_provider, get_logger_provider
+        from opentelemetry.sdk._logs import LoggerProvider as SdkLP
+
+        original_done = _LOGGER_PROVIDER_SET_ONCE._done
+        original_provider = get_logger_provider()
+
+        class _TestLP(SdkLP):
+            def __init__(self):
+                pass
+            def get_logger(self, *a, **kw):
+                return mock_otel_logger
+
+        _LOGGER_PROVIDER_SET_ONCE._done = False
+        set_logger_provider(_TestLP())
+        try:
+            tracer.emit_evaluation_event(
+                evaluation_name="test",
+                score_value=5.0,
+            )
+        finally:
+            _LOGGER_PROVIDER_SET_ONCE._done = False
+            set_logger_provider(original_provider)
+            _LOGGER_PROVIDER_SET_ONCE._done = original_done
+
+        mock_otel_logger.emit.assert_called_once()
+        mock_span.add_event.assert_not_called()
 
 
 # ============================================================

--- a/libs/azure-ai/tests/unit_tests/test_evaluation.py
+++ b/libs/azure-ai/tests/unit_tests/test_evaluation.py
@@ -535,6 +535,11 @@ class TestTracerEvalEvent:
         mock_otel_logger.emit.assert_called_once()
         call_kwargs = mock_otel_logger.emit.call_args[1]
         assert call_kwargs["body"] == Attrs.EVALUATION_RESULT_EVENT
+        assert call_kwargs["event_name"] == Attrs.EVALUATION_RESULT_EVENT
+        assert (
+            call_kwargs["attributes"][Attrs.AZURE_MONITOR_CUSTOM_EVENT_NAME]
+            == Attrs.EVALUATION_RESULT_EVENT
+        )
         assert call_kwargs["attributes"][Attrs.EVALUATION_NAME] == "quality"
         assert call_kwargs["attributes"][Attrs.EVALUATION_SCORE_VALUE] == 4.0
         mock_span.add_event.assert_not_called()
@@ -605,7 +610,10 @@ class TestTracerEvalEvent:
         tracer = self._make_tracer()
 
         mock_span = MagicMock()
-        from langchain_azure_ai.callbacks.tracers.inference_tracing import _SpanRecord
+        from langchain_azure_ai.callbacks.tracers.inference_tracing import (
+            Attrs,
+            _SpanRecord,
+        )
 
         tracer._spans["r1"] = _SpanRecord(
             run_id="r1", span=mock_span, operation="invoke_agent", parent_run_id=None
@@ -640,6 +648,12 @@ class TestTracerEvalEvent:
             _LOGGER_PROVIDER_SET_ONCE._done = original_done
 
         mock_otel_logger.emit.assert_called_once()
+        call_kwargs = mock_otel_logger.emit.call_args[1]
+        assert call_kwargs["event_name"] == Attrs.EVALUATION_RESULT_EVENT
+        assert (
+            call_kwargs["attributes"][Attrs.AZURE_MONITOR_CUSTOM_EVENT_NAME]
+            == Attrs.EVALUATION_RESULT_EVENT
+        )
         mock_span.add_event.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

Switches `emit_evaluation_event()` from `span.add_event()` to the OTel Logs/Events API (`Logger.emit()`), making evaluation results independently queryable in Azure Monitor's `customEvents` table.

## Motivation

**OTel is deprecating Span Events** in favor of the Logs API: [opentelemetry.io/blog/2026/deprecating-span-events](https://opentelemetry.io/blog/2026/deprecating-span-events/)

The current `span.add_event()` approach embeds evaluation events in the span's internal data. The `AzureMonitorTraceExporter` serializes these into the span payload but does **not** break them out as separate `customEvents` rows — making evaluation scores invisible to KQL queries in App Insights.

The `AzureMonitorLogExporter` routes log records to the `customEvents` table when Azure Monitor logging is configured, enabling direct queries like:
```kusto
customEvents
| where name == "gen_ai.evaluation.result"
| extend score = toreal(customDimensions["gen_ai.evaluation.score.value"])
| extend label = tostring(customDimensions["gen_ai.evaluation.score.label"])
```

## Spec Compliance

Per the [GenAI semantic conventions (events.yaml)](https://github.com/open-telemetry/semantic-conventions/blob/main/model/gen-ai/events.yaml):

> This event SHOULD be parented to the GenAI operation span being evaluated when possible

The new code activates the target span's OTel context before emitting, so the log record is correctly correlated to the `invoke_agent` trace/span.

## Implementation

- **Preferred path**: emit via `LoggerProvider.get_logger().emit(body=..., attributes=...)` when an SDK `LoggerProvider` is configured
- **Fallback**: use legacy `span.add_event()` when the Logs API is not available
- Span context is explicitly activated via `context.attach(set_span_in_context(span))` before emitting

## Tests

6 tests pass covering:
- Fallback to `span.add_event()` when Logs API unavailable
- Logs API path used when `LoggerProvider` is configured
- Correct attribute content in both paths
- Span context activation for trace correlation
- Explicit run_id targeting
- No-span warning
