### PR TITLE
fix: Update enable_auto_tracing defaults for hosted agent compatibility

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -236,9 +236,9 @@ def enable_auto_tracing(
             resolved_project_endpoint = project_endpoint or os.getenv(
                 _ENV_PROJECT_ENDPOINT
             )
-            resolved_provider_name = provider_name or os.getenv(
-                _ENV_PROVIDER_NAME
-            ) or "azure_openai"
+            resolved_provider_name = (
+                provider_name or os.getenv(_ENV_PROVIDER_NAME) or "azure_openai"
+            )
             resolved_agent_id = agent_id or os.getenv(_ENV_AGENT_ID)
             resolved_trace_all_langgraph_nodes = (
                 trace_all_langgraph_nodes

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -102,7 +102,15 @@ class _CallbackManagerInjector:
 
     def _inject_tracer(self, manager: Any) -> Any:
         if not self._has_existing_tracer(manager):
-            manager.add_handler(self._tracer, True)
+            try:
+                manager.add_handler(self._tracer, True)
+            except TypeError:
+                # LangGraph's _AsyncGraphCallbackManager.add_handler() rejects
+                # handlers that don't inherit from GraphCallbackHandler.
+                # Fall back to direct list manipulation.
+                inheritable = getattr(manager, "inheritable_handlers", None)
+                if inheritable is not None and self._tracer not in inheritable:
+                    inheritable.append(self._tracer)
         return manager
 
 

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -270,12 +270,6 @@ def enable_auto_tracing(
                 tracer_kwargs["name"] = resolved_name
             if message_keys is not None:
                 tracer_kwargs["message_keys"] = message_keys
-            else:
-                # Default to extracting messages from LangGraph state
-                env_keys = os.getenv("OTEL_MESSAGE_KEYS")
-                tracer_kwargs["message_keys"] = (
-                    env_keys.split(",") if env_keys else ["messages"]
-                )
             if message_paths is not None:
                 tracer_kwargs["message_paths"] = message_paths
             if trace_state is not None:

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -191,18 +191,21 @@ def enable_auto_tracing(
 
     Args:
         connection_string: Application Insights connection string.
-        enable_content_recording: Whether to capture message/content payloads.
+        enable_content_recording: Whether to capture message/content payloads
+            (default ``False``).
         project_endpoint: Azure AI project endpoint for connection string
             resolution.
         credential: Azure credential used with project endpoint resolution.
-        provider_name: Default provider name for emitted GenAI spans.
+        provider_name: Default provider name for emitted GenAI spans
+            (default ``"azure_openai"``).
         agent_id: Default agent identifier for emitted spans.
         trace_all_langgraph_nodes: Whether to trace all LangGraph nodes
             (default ``True``).
-        message_keys: State keys that hold messages (e.g. ``["messages"]``).
+        message_keys: State keys that hold messages (default ``["messages"]``).
         message_paths: Dotted paths for nested message locations.
-        auto_configure_azure_monitor: Set to ``False`` to skip automatic
-            Azure Monitor configuration.
+        auto_configure_azure_monitor: Set to ``True`` to enable automatic
+            Azure Monitor configuration (default ``False``; hosted agents
+            configure their own ``TracerProvider``).
         trace_state: Whether to capture the full LangGraph state on each
             agent node span (default ``False``).
         max_state_size: Maximum character length for serialized state
@@ -228,12 +231,14 @@ def enable_auto_tracing(
             resolved_enable_content_recording = (
                 enable_content_recording
                 if enable_content_recording is not None
-                else _env_bool(_ENV_ENABLE_CONTENT_RECORDING, True)
+                else _env_bool(_ENV_ENABLE_CONTENT_RECORDING, False)
             )
             resolved_project_endpoint = project_endpoint or os.getenv(
                 _ENV_PROJECT_ENDPOINT
             )
-            resolved_provider_name = provider_name or os.getenv(_ENV_PROVIDER_NAME)
+            resolved_provider_name = provider_name or os.getenv(
+                _ENV_PROVIDER_NAME
+            ) or "azure_openai"
             resolved_agent_id = agent_id or os.getenv(_ENV_AGENT_ID)
             resolved_trace_all_langgraph_nodes = (
                 trace_all_langgraph_nodes
@@ -243,7 +248,7 @@ def enable_auto_tracing(
             resolved_auto_configure = (
                 auto_configure_azure_monitor
                 if auto_configure_azure_monitor is not None
-                else _env_bool(_ENV_AUTO_CONFIGURE_AZURE_MONITOR, True)
+                else _env_bool(_ENV_AUTO_CONFIGURE_AZURE_MONITOR, False)
             )
 
             # Derive tracer name from agent_id or OTEL_SERVICE_NAME so that
@@ -265,6 +270,12 @@ def enable_auto_tracing(
                 tracer_kwargs["name"] = resolved_name
             if message_keys is not None:
                 tracer_kwargs["message_keys"] = message_keys
+            else:
+                # Default to extracting messages from LangGraph state
+                env_keys = os.getenv("OTEL_MESSAGE_KEYS")
+                tracer_kwargs["message_keys"] = (
+                    env_keys.split(",") if env_keys else ["messages"]
+                )
             if message_paths is not None:
                 tracer_kwargs["message_paths"] = message_paths
             if trace_state is not None:

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 import threading
 from typing import TYPE_CHECKING, Any, Callable
@@ -69,12 +70,21 @@ _ENV_AUTO_CONFIGURE_AZURE_MONITOR = "OTEL_AUTO_CONFIGURE_AZURE_MONITOR"
 _BASE_CALLBACK_MANAGER_MODULE = "langchain_core.callbacks.base"
 _BASE_CALLBACK_MANAGER_INIT = "BaseCallbackManager.__init__"
 _BASE_CALLBACK_MANAGER_INIT_ATTR = "__init__"
+_LANGGRAPH_CALLBACK_MANAGER_TARGETS = (
+    ("langgraph._internal._config", "get_callback_manager_for_config"),
+    ("langgraph._internal._config", "get_async_callback_manager_for_config"),
+    ("langgraph._internal._runnable", "get_callback_manager_for_config"),
+    ("langgraph._internal._runnable", "get_async_callback_manager_for_config"),
+    ("langgraph.pregel.main", "get_callback_manager_for_config"),
+    ("langgraph.pregel.main", "get_async_callback_manager_for_config"),
+)
 _AUTO_TRACING_LOCK = threading.Lock()
 _active_tracer: AzureAIOpenTelemetryTracer | None = None
+_patched_langgraph_targets: list[tuple[str, str]] = []
 
 
-class _BaseCallbackManagerInitWrapper:
-    """Inject a tracer into inheritable handlers after callback manager init."""
+class _CallbackManagerInjector:
+    """Helper for injecting the tracer into callback managers."""
 
     def __init__(self, tracer: AzureAIOpenTelemetryTracer) -> None:
         self._tracer = tracer
@@ -90,6 +100,15 @@ class _BaseCallbackManagerInitWrapper:
             for handler in handlers
         )
 
+    def _inject_tracer(self, manager: Any) -> Any:
+        if not self._has_existing_tracer(manager):
+            manager.add_handler(self._tracer, True)
+        return manager
+
+
+class _BaseCallbackManagerInitWrapper(_CallbackManagerInjector):
+    """Inject a tracer into inheritable handlers after callback manager init."""
+
     def __call__(
         self,
         wrapped: Callable[..., Any],
@@ -98,9 +117,34 @@ class _BaseCallbackManagerInitWrapper:
         kwargs: dict[str, Any],
     ) -> Any:
         result = wrapped(*args, **kwargs)
-        if not self._has_existing_tracer(instance):
-            instance.add_handler(self._tracer, True)
+        self._inject_tracer(instance)
         return result
+
+
+class _CallbackManagerFactoryWrapper(_CallbackManagerInjector):
+    """Inject a tracer into callback managers returned by factory helpers."""
+
+    def __call__(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        del instance
+        manager = wrapped(*args, **kwargs)
+        self._inject_tracer(manager)
+        return manager
+
+
+def _load_optional_module(module_name: str) -> Any | None:
+    """Import an optional module, returning ``None`` when unavailable."""
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if module_name == exc.name or module_name.startswith(f"{exc.name}."):
+            return None
+        raise
 
 
 def _env_bool(key: str, default: bool) -> bool:
@@ -167,6 +211,47 @@ def _load_callback_manager_class() -> type[Any]:
     return BaseCallbackManager
 
 
+def _patch_base_callback_manager(tracer: AzureAIOpenTelemetryTracer) -> None:
+    """Patch BaseCallbackManager.__init__ to auto-inject the Azure tracer."""
+    assert wrap_function_wrapper is not None
+    wrap_function_wrapper(
+        _BASE_CALLBACK_MANAGER_MODULE,
+        _BASE_CALLBACK_MANAGER_INIT,
+        _BaseCallbackManagerInitWrapper(tracer),
+    )
+
+
+def _unpatch_base_callback_manager() -> None:
+    """Unpatch BaseCallbackManager.__init__."""
+    unwrap(_load_callback_manager_class(), _BASE_CALLBACK_MANAGER_INIT_ATTR)
+
+
+def _patch_langgraph_callback_manager_helpers(
+    tracer: AzureAIOpenTelemetryTracer,
+) -> None:
+    """Patch LangGraph callback-manager helper functions when available."""
+    assert wrap_function_wrapper is not None
+    _patched_langgraph_targets.clear()
+    factory_wrapper = _CallbackManagerFactoryWrapper(tracer)
+
+    for module_name, function_name in _LANGGRAPH_CALLBACK_MANAGER_TARGETS:
+        module = _load_optional_module(module_name)
+        if module is None or not hasattr(module, function_name):
+            continue
+
+        wrap_function_wrapper(module_name, function_name, factory_wrapper)
+        _patched_langgraph_targets.append((module_name, function_name))
+
+
+def _unpatch_langgraph_callback_manager_helpers() -> None:
+    """Unpatch any LangGraph callback-manager helpers patched earlier."""
+    for module_name, function_name in _patched_langgraph_targets:
+        module = _load_optional_module(module_name)
+        if module is not None and hasattr(module, function_name):
+            unwrap(module, function_name)
+    _patched_langgraph_targets.clear()
+
+
 @experimental()
 def enable_auto_tracing(
     *,
@@ -186,9 +271,9 @@ def enable_auto_tracing(
 ) -> None:
     """Enable auto-injection of Azure tracer into callback managers.
 
-    When called, every new ``BaseCallbackManager`` instance created by
-    LangChain/LangGraph will automatically include an
-    ``AzureAIOpenTelemetryTracer`` in its inheritable handlers.
+    When called, every new ``BaseCallbackManager`` instance and every callback
+    manager created through LangGraph's helper factories will automatically
+    include an ``AzureAIOpenTelemetryTracer`` in its inheritable handlers.
 
     Each parameter falls back to an environment variable when not supplied:
 
@@ -299,11 +384,8 @@ def enable_auto_tracing(
 
             tracer = tracer_class(**tracer_kwargs)
 
-        wrap_function_wrapper(
-            _BASE_CALLBACK_MANAGER_MODULE,
-            _BASE_CALLBACK_MANAGER_INIT,
-            _BaseCallbackManagerInitWrapper(tracer),
-        )
+        _patch_base_callback_manager(tracer)
+        _patch_langgraph_callback_manager_helpers(tracer)
         _active_tracer = tracer
 
 
@@ -317,7 +399,8 @@ def disable_auto_tracing() -> None:
             return
 
         _ensure_otel_instrumentation_available()
-        unwrap(_load_callback_manager_class(), _BASE_CALLBACK_MANAGER_INIT_ATTR)
+        _unpatch_base_callback_manager()
+        _unpatch_langgraph_callback_manager_helpers()
         _active_tracer = None
 
 

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -249,7 +249,10 @@ def _patch_langgraph_callback_manager_helpers(
 def _unpatch_langgraph_callback_manager_helpers() -> None:
     """Unpatch any LangGraph callback-manager helpers patched earlier."""
     for module_name, function_name in _patched_langgraph_targets:
-        module = _load_optional_module(module_name)
+        try:
+            module = _load_optional_module(module_name)
+        except ImportError:
+            continue
         if module is not None and hasattr(module, function_name):
             unwrap(module, function_name)
     _patched_langgraph_targets.clear()

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -104,10 +104,13 @@ class _CallbackManagerInjector:
         if not self._has_existing_tracer(manager):
             try:
                 manager.add_handler(self._tracer, True)
-            except TypeError:
-                # LangGraph's _AsyncGraphCallbackManager.add_handler() rejects
-                # handlers that don't inherit from GraphCallbackHandler.
-                # Fall back to direct list manipulation.
+            except TypeError as exc:
+                # LangGraph callback managers may reject handlers that don't
+                # inherit from their expected base class.  Only fall back to
+                # direct list manipulation for that specific rejection;
+                # re-raise any other TypeError.
+                if "handler" not in str(exc).lower():
+                    raise
                 inheritable = getattr(manager, "inheritable_handlers", None)
                 if inheritable is not None and self._tracer not in inheritable:
                     inheritable.append(self._tracer)

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -235,7 +235,10 @@ def _patch_langgraph_callback_manager_helpers(
     factory_wrapper = _CallbackManagerFactoryWrapper(tracer)
 
     for module_name, function_name in _LANGGRAPH_CALLBACK_MANAGER_TARGETS:
-        module = _load_optional_module(module_name)
+        try:
+            module = _load_optional_module(module_name)
+        except ImportError:
+            continue
         if module is None or not hasattr(module, function_name):
             continue
 
@@ -384,8 +387,16 @@ def enable_auto_tracing(
 
             tracer = tracer_class(**tracer_kwargs)
 
-        _patch_base_callback_manager(tracer)
-        _patch_langgraph_callback_manager_helpers(tracer)
+        base_callback_manager_patched = False
+        try:
+            _patch_base_callback_manager(tracer)
+            base_callback_manager_patched = True
+            _patch_langgraph_callback_manager_helpers(tracer)
+        except Exception:
+            _unpatch_langgraph_callback_manager_helpers()
+            if base_callback_manager_patched:
+                _unpatch_base_callback_manager()
+            raise
         _active_tracer = tracer
 
 

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -113,6 +113,21 @@ def _env_bool(key: str, default: bool) -> bool:
     return default
 
 
+def _normalize_provider_name(provider_name: str | None) -> str | None:
+    """Normalize common Azure OpenAI provider aliases to the canonical value."""
+    if provider_name is None:
+        return None
+
+    normalized = provider_name.strip()
+    if not normalized:
+        return None
+
+    if normalized.lower() in {"azure", "azure_openai", "azure-openai"}:
+        return "azure.ai.openai"
+
+    return normalized
+
+
 def _ensure_wrapt_available() -> None:
     """Ensure wrapt is installed before patching callbacks."""
     if wrap_function_wrapper is None:
@@ -197,7 +212,7 @@ def enable_auto_tracing(
             resolution.
         credential: Azure credential used with project endpoint resolution.
         provider_name: Default provider name for emitted GenAI spans
-            (default ``"azure_openai"``).
+            (default ``"azure.ai.openai"``).
         agent_id: Default agent identifier for emitted spans.
         trace_all_langgraph_nodes: Whether to trace all LangGraph nodes
             (default ``True``).
@@ -205,7 +220,10 @@ def enable_auto_tracing(
         message_paths: Dotted paths for nested message locations.
         auto_configure_azure_monitor: Set to ``True`` to enable automatic
             Azure Monitor configuration (default ``False``; hosted agents
-            configure their own ``TracerProvider``).
+            configure their own ``TracerProvider``). In non-hosted usage,
+            leaving this as ``False`` means Azure Monitor is not configured
+            automatically, so spans may not export unless your application
+            configures a ``TracerProvider`` and exporter separately.
         trace_state: Whether to capture the full LangGraph state on each
             agent node span (default ``False``).
         max_state_size: Maximum character length for serialized state
@@ -237,7 +255,9 @@ def enable_auto_tracing(
                 _ENV_PROJECT_ENDPOINT
             )
             resolved_provider_name = (
-                provider_name or os.getenv(_ENV_PROVIDER_NAME) or "azure_openai"
+                _normalize_provider_name(provider_name)
+                or _normalize_provider_name(os.getenv(_ENV_PROVIDER_NAME))
+                or "azure.ai.openai"
             )
             resolved_agent_id = agent_id or os.getenv(_ENV_AGENT_ID)
             resolved_trace_all_langgraph_nodes = (

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/auto_instrument.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import os
 import threading
 from typing import TYPE_CHECKING, Any, Callable
 
 from langchain_azure_ai._api.base import experimental
+
+LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from langchain_azure_ai.callbacks.tracers.inference_tracing import (
@@ -248,7 +251,15 @@ def _patch_langgraph_callback_manager_helpers(
     for module_name, function_name in _LANGGRAPH_CALLBACK_MANAGER_TARGETS:
         try:
             module = _load_optional_module(module_name)
+        except ModuleNotFoundError:
+            continue
         except ImportError:
+            LOGGER.warning(
+                "Skipping LangGraph patch target %s.%s due to import error",
+                module_name,
+                function_name,
+                exc_info=True,
+            )
             continue
         if module is None or not hasattr(module, function_name):
             continue
@@ -262,7 +273,15 @@ def _unpatch_langgraph_callback_manager_helpers() -> None:
     for module_name, function_name in _patched_langgraph_targets:
         try:
             module = _load_optional_module(module_name)
+        except ModuleNotFoundError:
+            continue
         except ImportError:
+            LOGGER.warning(
+                "Skipping LangGraph unpatch target %s.%s due to import error",
+                module_name,
+                function_name,
+                exc_info=True,
+            )
             continue
         if module is not None and hasattr(module, function_name):
             unwrap(module, function_name)

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
@@ -1236,7 +1236,16 @@ class _SpanRecord:
     stash: Dict[str, Any] = field(default_factory=dict)
 
 
-class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
+# Dynamically select the best base class: use GraphCallbackHandler when
+# langgraph is installed so that the tracer is accepted by LangGraph's
+# _AsyncGraphCallbackManager.add_handler() (which type-checks handlers).
+try:
+    from langgraph.callbacks import GraphCallbackHandler as _TracerBase
+except ImportError:
+    _TracerBase = BaseCallbackHandler  # type: ignore[misc,assignment]
+
+
+class AzureAIOpenTelemetryTracer(_TracerBase):  # type: ignore[misc]
     """LangChain callback handler that emits OpenTelemetry GenAI spans."""
 
     _azure_monitor_configured: bool = False

--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
@@ -1236,16 +1236,7 @@ class _SpanRecord:
     stash: Dict[str, Any] = field(default_factory=dict)
 
 
-# Dynamically select the best base class: use GraphCallbackHandler when
-# langgraph is installed so that the tracer is accepted by LangGraph's
-# _AsyncGraphCallbackManager.add_handler() (which type-checks handlers).
-try:
-    from langgraph.callbacks import GraphCallbackHandler as _TracerBase
-except ImportError:
-    _TracerBase = BaseCallbackHandler  # type: ignore[misc,assignment]
-
-
-class AzureAIOpenTelemetryTracer(_TracerBase):  # type: ignore[misc]
+class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
     """LangChain callback handler that emits OpenTelemetry GenAI spans."""
 
     _azure_monitor_configured: bool = False

--- a/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
+++ b/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
@@ -267,6 +267,50 @@ def test_callback_manager_factory_wrapper_injects_tracer() -> None:
     assert _get_inheritable_tracers(manager) == [tracer]
 
 
+def test_inject_tracer_fallback_on_add_handler_rejection() -> None:
+    """When add_handler rejects the tracer (TypeError), fall back to list append."""
+    tracer = tracing.AzureAIOpenTelemetryTracer(provider_name="test-provider")
+    injector = auto_instrument._CallbackManagerInjector(tracer)
+
+    class StrictManager:
+        def __init__(self) -> None:
+            self.handlers: list[Any] = []
+            self.inheritable_handlers: list[Any] = []
+
+        def add_handler(self, handler: Any, inherit: bool = False) -> None:
+            raise TypeError("handler must be a GraphCallbackHandler")
+
+    manager = StrictManager()
+    injector._inject_tracer(manager)
+    assert tracer in manager.inheritable_handlers
+
+
+def test_inject_tracer_reraises_unrelated_type_error() -> None:
+    """TypeError not related to handler rejection should propagate."""
+    tracer = tracing.AzureAIOpenTelemetryTracer(provider_name="test-provider")
+    injector = auto_instrument._CallbackManagerInjector(tracer)
+
+    class BrokenManager:
+        def __init__(self) -> None:
+            self.handlers: list[Any] = []
+            self.inheritable_handlers: list[Any] = []
+
+        def add_handler(self, handler: Any, inherit: bool = False) -> None:
+            raise TypeError("unexpected argument 'foo'")
+
+    manager = BrokenManager()
+    with pytest.raises(TypeError, match="unexpected argument"):
+        injector._inject_tracer(manager)
+
+
+def test_tracer_is_instance_of_base_callback_handler() -> None:
+    """AzureAIOpenTelemetryTracer must inherit from BaseCallbackHandler."""
+    from langchain_core.callbacks.base import BaseCallbackHandler
+
+    tracer = tracing.AzureAIOpenTelemetryTracer()
+    assert isinstance(tracer, BaseCallbackHandler)
+
+
 def test_patch_langgraph_callback_manager_helpers_wraps_async_targets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
+++ b/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
@@ -256,6 +256,42 @@ def test_enable_auto_tracing_normalizes_azure_provider_name(
     assert tracer._default_provider_name == "azure.ai.openai"  # type: ignore[attr-defined]
 
 
+def test_callback_manager_factory_wrapper_injects_tracer() -> None:
+    tracer = tracing.AzureAIOpenTelemetryTracer(provider_name="test-provider")
+    wrapper = auto_instrument._CallbackManagerFactoryWrapper(tracer)
+    manager = BaseCallbackManager(handlers=[])
+
+    returned = wrapper(lambda *args, **kwargs: manager, None, (), {})
+
+    assert returned is manager
+    assert _get_inheritable_tracers(manager) == [tracer]
+
+
+def test_patch_langgraph_callback_manager_helpers_wraps_async_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracer = tracing.AzureAIOpenTelemetryTracer(provider_name="test-provider")
+    wrap_calls: list[tuple[str, str]] = []
+
+    def fake_wrap_function_wrapper(module: str, name: str, wrapper: object) -> None:
+        del wrapper
+        wrap_calls.append((module, name))
+
+    monkeypatch.setattr(
+        auto_instrument, "wrap_function_wrapper", fake_wrap_function_wrapper
+    )
+    auto_instrument._patched_langgraph_targets.clear()
+
+    auto_instrument._patch_langgraph_callback_manager_helpers(tracer)
+
+    assert {
+        ("langgraph._internal._config", "get_async_callback_manager_for_config"),
+        ("langgraph._internal._runnable", "get_async_callback_manager_for_config"),
+        ("langgraph.pregel.main", "get_async_callback_manager_for_config"),
+    }.issubset(set(wrap_calls))
+    auto_instrument._patched_langgraph_targets.clear()
+
+
 def test_env_bool_accepts_on_off_and_whitespace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -294,18 +330,19 @@ def test_enable_auto_tracing_serializes_concurrent_calls(
         def __init__(self, **kwargs: object) -> None:
             self.kwargs = kwargs
 
-    wrap_started = threading.Event()
-    allow_wrap_finish = threading.Event()
-    wrap_calls = 0
+    patch_started = threading.Event()
+    allow_patch_finish = threading.Event()
+    patch_calls = {"base": 0, "langgraph": 0}
 
-    def fake_wrap_function_wrapper(module: str, name: str, wrapper: object) -> None:
-        del wrapper
-        nonlocal wrap_calls
-        assert module == "langchain_core.callbacks.base"
-        assert name == "BaseCallbackManager.__init__"
-        wrap_started.set()
-        assert allow_wrap_finish.wait(timeout=2)
-        wrap_calls += 1
+    def fake_patch_base_callback_manager(tracer: object) -> None:
+        del tracer
+        patch_started.set()
+        assert allow_patch_finish.wait(timeout=2)
+        patch_calls["base"] += 1
+
+    def fake_patch_langgraph_callback_manager_helpers(tracer: object) -> None:
+        del tracer
+        patch_calls["langgraph"] += 1
 
     monkeypatch.setattr(auto_instrument, "_active_tracer", None)
     monkeypatch.setattr(
@@ -313,7 +350,14 @@ def test_enable_auto_tracing_serializes_concurrent_calls(
     )
     monkeypatch.setattr(auto_instrument, "_ensure_wrapt_available", lambda: None)
     monkeypatch.setattr(
-        auto_instrument, "wrap_function_wrapper", fake_wrap_function_wrapper
+        auto_instrument,
+        "_patch_base_callback_manager",
+        fake_patch_base_callback_manager,
+    )
+    monkeypatch.setattr(
+        auto_instrument,
+        "_patch_langgraph_callback_manager_helpers",
+        fake_patch_langgraph_callback_manager_helpers,
     )
     monkeypatch.setattr(auto_instrument, "_load_tracer_class", lambda: DummyTracer)
 
@@ -321,13 +365,13 @@ def test_enable_auto_tracing_serializes_concurrent_calls(
     second_thread = threading.Thread(target=auto_instrument.enable_auto_tracing)
 
     first_thread.start()
-    assert wrap_started.wait(timeout=2)
+    assert patch_started.wait(timeout=2)
     second_thread.start()
-    allow_wrap_finish.set()
+    allow_patch_finish.set()
     first_thread.join(timeout=2)
     second_thread.join(timeout=2)
 
-    assert wrap_calls == 1
+    assert patch_calls == {"base": 1, "langgraph": 1}
     assert auto_instrument.is_auto_tracing_enabled() is True
     monkeypatch.setattr(auto_instrument, "_active_tracer", None)
 

--- a/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
+++ b/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
@@ -333,6 +333,36 @@ def test_patch_langgraph_callback_manager_helpers_skips_import_errors(
     auto_instrument._patched_langgraph_targets.clear()
 
 
+def test_unpatch_langgraph_callback_manager_helpers_skips_import_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unwrap_calls: list[tuple[object, str]] = []
+    good_module = SimpleNamespace(get_async_callback_manager_for_config=object())
+
+    auto_instrument._patched_langgraph_targets[:] = [
+        ("langgraph.good", "get_async_callback_manager_for_config"),
+        ("langgraph.bad", "get_async_callback_manager_for_config"),
+    ]
+
+    def fake_load_optional_module(module_name: str) -> object:
+        if module_name == "langgraph.bad":
+            raise ImportError("missing optional langgraph dependency")
+        return good_module
+
+    def fake_unwrap(module: object, name: str) -> None:
+        unwrap_calls.append((module, name))
+
+    monkeypatch.setattr(
+        auto_instrument, "_load_optional_module", fake_load_optional_module
+    )
+    monkeypatch.setattr(auto_instrument, "unwrap", fake_unwrap)
+
+    auto_instrument._unpatch_langgraph_callback_manager_helpers()
+
+    assert unwrap_calls == [(good_module, "get_async_callback_manager_for_config")]
+    assert auto_instrument._patched_langgraph_targets == []
+
+
 def test_env_bool_accepts_on_off_and_whitespace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
+++ b/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
@@ -292,6 +292,47 @@ def test_patch_langgraph_callback_manager_helpers_wraps_async_targets(
     auto_instrument._patched_langgraph_targets.clear()
 
 
+def test_patch_langgraph_callback_manager_helpers_skips_import_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracer = tracing.AzureAIOpenTelemetryTracer(provider_name="test-provider")
+    wrap_calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        auto_instrument,
+        "_LANGGRAPH_CALLBACK_MANAGER_TARGETS",
+        (
+            ("langgraph.good", "get_async_callback_manager_for_config"),
+            ("langgraph.bad", "get_async_callback_manager_for_config"),
+        ),
+    )
+
+    def fake_load_optional_module(module_name: str) -> object:
+        if module_name == "langgraph.bad":
+            raise ImportError("missing optional langgraph dependency")
+        return SimpleNamespace(get_async_callback_manager_for_config=object())
+
+    def fake_wrap_function_wrapper(module: str, name: str, wrapper: object) -> None:
+        del wrapper
+        wrap_calls.append((module, name))
+
+    monkeypatch.setattr(
+        auto_instrument, "_load_optional_module", fake_load_optional_module
+    )
+    monkeypatch.setattr(
+        auto_instrument, "wrap_function_wrapper", fake_wrap_function_wrapper
+    )
+    auto_instrument._patched_langgraph_targets.clear()
+
+    auto_instrument._patch_langgraph_callback_manager_helpers(tracer)
+
+    assert wrap_calls == [("langgraph.good", "get_async_callback_manager_for_config")]
+    assert auto_instrument._patched_langgraph_targets == [
+        ("langgraph.good", "get_async_callback_manager_for_config")
+    ]
+    auto_instrument._patched_langgraph_targets.clear()
+
+
 def test_env_bool_accepts_on_off_and_whitespace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -374,6 +415,52 @@ def test_enable_auto_tracing_serializes_concurrent_calls(
     assert patch_calls == {"base": 1, "langgraph": 1}
     assert auto_instrument.is_auto_tracing_enabled() is True
     monkeypatch.setattr(auto_instrument, "_active_tracer", None)
+
+
+def test_enable_auto_tracing_rolls_back_patches_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyTracer:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+    cleanup_calls: list[str] = []
+
+    monkeypatch.setattr(auto_instrument, "_active_tracer", None)
+    monkeypatch.setattr(
+        auto_instrument, "_ensure_otel_instrumentation_available", lambda: None
+    )
+    monkeypatch.setattr(auto_instrument, "_ensure_wrapt_available", lambda: None)
+    monkeypatch.setattr(auto_instrument, "_load_tracer_class", lambda: DummyTracer)
+    monkeypatch.setattr(
+        auto_instrument, "_patch_base_callback_manager", lambda tracer: None
+    )
+
+    def fail_patch_langgraph_callback_manager_helpers(tracer: object) -> None:
+        del tracer
+        raise RuntimeError("langgraph patch failed")
+
+    monkeypatch.setattr(
+        auto_instrument,
+        "_patch_langgraph_callback_manager_helpers",
+        fail_patch_langgraph_callback_manager_helpers,
+    )
+    monkeypatch.setattr(
+        auto_instrument,
+        "_unpatch_base_callback_manager",
+        lambda: cleanup_calls.append("base"),
+    )
+    monkeypatch.setattr(
+        auto_instrument,
+        "_unpatch_langgraph_callback_manager_helpers",
+        lambda: cleanup_calls.append("langgraph"),
+    )
+
+    with pytest.raises(RuntimeError, match="langgraph patch failed"):
+        auto_instrument.enable_auto_tracing()
+
+    assert cleanup_calls == ["langgraph", "base"]
+    assert auto_instrument.is_auto_tracing_enabled() is False
 
 
 def test_disable_auto_tracing_uses_matching_unwrap_target(

--- a/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
+++ b/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
@@ -317,10 +317,27 @@ def test_patch_langgraph_callback_manager_helpers_wraps_async_targets(
     tracer = tracing.AzureAIOpenTelemetryTracer(provider_name="test-provider")
     wrap_calls: list[tuple[str, str]] = []
 
+    targets = (
+        ("langgraph.fake_config", "get_callback_manager_for_config"),
+        ("langgraph.fake_config", "get_async_callback_manager_for_config"),
+        ("langgraph.fake_runnable", "get_callback_manager_for_config"),
+        ("langgraph.fake_runnable", "get_async_callback_manager_for_config"),
+    )
+
+    def fake_load_optional_module(module_name: str) -> object:
+        return SimpleNamespace(
+            get_callback_manager_for_config=object(),
+            get_async_callback_manager_for_config=object(),
+        )
+
     def fake_wrap_function_wrapper(module: str, name: str, wrapper: object) -> None:
         del wrapper
         wrap_calls.append((module, name))
 
+    monkeypatch.setattr(auto_instrument, "_LANGGRAPH_CALLBACK_MANAGER_TARGETS", targets)
+    monkeypatch.setattr(
+        auto_instrument, "_load_optional_module", fake_load_optional_module
+    )
     monkeypatch.setattr(
         auto_instrument, "wrap_function_wrapper", fake_wrap_function_wrapper
     )
@@ -328,11 +345,8 @@ def test_patch_langgraph_callback_manager_helpers_wraps_async_targets(
 
     auto_instrument._patch_langgraph_callback_manager_helpers(tracer)
 
-    assert {
-        ("langgraph._internal._config", "get_async_callback_manager_for_config"),
-        ("langgraph._internal._runnable", "get_async_callback_manager_for_config"),
-        ("langgraph.pregel.main", "get_async_callback_manager_for_config"),
-    }.issubset(set(wrap_calls))
+    assert set(wrap_calls) == set(targets)
+    assert auto_instrument._patched_langgraph_targets == list(targets)
     auto_instrument._patched_langgraph_targets.clear()
 
 

--- a/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
+++ b/libs/azure-ai/tests/unit_tests/test_auto_instrument.py
@@ -202,6 +202,60 @@ def test_env_var_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
     assert tracer._default_agent_id == "test-agent"  # type: ignore[attr-defined]
 
 
+def test_enable_auto_tracing_defaults_for_hosted_agents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for env_var in (
+        "APPLICATION_INSIGHTS_CONNECTION_STRING",
+        "AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED",
+        "AZURE_TRACING_PROVIDER_NAME",
+        "AZURE_TRACING_AGENT_ID",
+        "AZURE_TRACING_ALL_LANGGRAPH_NODES",
+        "OTEL_MESSAGE_KEYS",
+        "OTEL_AUTO_CONFIGURE_AZURE_MONITOR",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    monkeypatch.setenv(
+        "APPLICATION_INSIGHTS_CONNECTION_STRING",
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000",
+    )
+
+    configure_calls: list[str] = []
+
+    def fake_configure(cls: type[Any], connection_string: str) -> None:
+        del cls
+        configure_calls.append(connection_string)
+
+    monkeypatch.setattr(
+        tracing.AzureAIOpenTelemetryTracer,
+        "_configure_azure_monitor",
+        classmethod(fake_configure),
+    )
+
+    auto_instrument.enable_auto_tracing()
+    manager = BaseCallbackManager(handlers=[])
+
+    tracer = _get_inheritable_tracers(manager)[0]
+    assert tracer._content_recording is False  # type: ignore[attr-defined]
+    assert tracer._default_provider_name == "azure.ai.openai"  # type: ignore[attr-defined]
+    assert tracer._message_keys == ("messages",)  # type: ignore[attr-defined]
+    assert tracer._trace_all_langgraph_nodes is True  # type: ignore[attr-defined]
+    assert configure_calls == []
+
+
+def test_enable_auto_tracing_normalizes_azure_provider_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AZURE_TRACING_PROVIDER_NAME", " azure_openai ")
+
+    auto_instrument.enable_auto_tracing()
+    manager = BaseCallbackManager(handlers=[])
+
+    tracer = _get_inheritable_tracers(manager)[0]
+    assert tracer._default_provider_name == "azure.ai.openai"  # type: ignore[attr-defined]
+
+
 def test_env_bool_accepts_on_off_and_whitespace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Updates enable_auto_tracing() so a bare call works correctly with Azure AI Foundry hosted agents and also covers LangGraph callback-manager construction paths used by invoke() and ainvoke().

## Changes

| Area | Before | After | Reason |
|------|--------|-------|--------|
| enable_content_recording default | True | False | Content recording should be opt-in for privacy and security |
| provider_name default | None | azure.ai.openai | Uses the canonical GenAI provider name for Azure OpenAI spans |
| auto_configure_azure_monitor default | True | False | Hosted agents configure their own TracerProvider; calling configure_azure_monitor() can create conflicting providers and duplicate or lost spans |
| LangGraph callback-manager hooks | BaseCallbackManager.__init__ only | BaseCallbackManager.__init__ plus LangGraph callback-manager helper factories | Ensures tracer injection also covers LangGraph helper paths used by invoke() and ainvoke() |

Note: message_keys is unchanged. The tracer already defaults to [messages] when it is not explicitly provided.

## Additional updates

- normalize azure_openai and azure-openai aliases to azure.ai.openai before assigning the default provider name
- patch LangGraph callback-manager helper functions in langgraph._internal._config, langgraph._internal._runnable, and langgraph.pregel.main so the tracer is injected into managers created for graph execution
- add regression tests covering the new default resolution path and the LangGraph async callback-manager helper patch
- clarify in the docstring that non-hosted apps must pass auto_configure_azure_monitor=True or configure telemetry themselves

## Motivation

Hosted agent samples previously had to pass explicit parameters to avoid conflicts, especially auto_configure_azure_monitor=False. In addition, relying only on BaseCallbackManager.__init__ is brittle when LangGraph builds callback managers through helper functions on the invoke and ainvoke paths.

After this change, enable_auto_tracing() with no arguments works better in hosted environments and explicitly patches the LangGraph callback-manager factory path as well. In non-hosted scripts or notebooks, either pass auto_configure_azure_monitor=True or configure a TracerProvider and exporter separately.

## Backward Compatibility

All parameters still accept explicit values. Environment variable overrides still work. The behavioral change is limited to the defaults used when parameters and relevant environment variables are not supplied, plus broader tracer injection coverage for LangGraph callback-manager construction paths.