### PR TITLE
cosmosdb: add retry configurability and fix error handling resilience

### DIFF
--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_chat_history.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_chat_history.py
@@ -161,18 +161,26 @@ class CosmosDBChatMessageHistory(BaseChatMessageHistory):
         """Update the cosmosdb item."""
         if not self._container:
             raise ValueError("Container not initialized")
-        self._container.upsert_item(
-            body={
-                "id": self.session_id,
-                "user_id": self.user_id,
-                "messages": messages_to_dict(self.messages),
-            }
-        )
+        try:
+            self._container.upsert_item(
+                body={
+                    "id": self.session_id,
+                    "user_id": self.user_id,
+                    "messages": messages_to_dict(self.messages),
+                }
+            )
+        except Exception:
+            logger.warning("Failed to upsert messages for session %s", self.session_id)
+            raise
 
     def clear(self) -> None:
         """Clear session memory from this memory and cosmos."""
         self.messages = []
         if self._container:
-            self._container.delete_item(
-                item=self.session_id, partition_key=self.user_id
-            )
+            try:
+                self._container.delete_item(
+                    item=self.session_id, partition_key=self.user_id
+                )
+            except Exception:
+                logger.warning("Failed to delete session %s", self.session_id)
+                raise

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_langgraph_cache.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_langgraph_cache.py
@@ -56,6 +56,7 @@ class CosmosDBCacheSync(BaseCache[ValueT]):
         endpoint: str | None = None,
         key: str | None = None,
         serde: SerializerProtocol | None = None,
+        cosmos_client_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the CosmosDB sync cache.
 
@@ -68,6 +69,8 @@ class CosmosDBCacheSync(BaseCache[ValueT]):
                 env var if not provided. When absent,
                 ``DefaultAzureCredential`` is used.
             serde: Optional custom serializer.
+            cosmos_client_kwargs: Additional keyword arguments passed to
+                the ``CosmosClient`` constructor (e.g. ``retry_options``).
         """
         super().__init__(serde=serde)
 
@@ -77,15 +80,22 @@ class CosmosDBCacheSync(BaseCache[ValueT]):
 
         resolved_key = key or os.getenv("COSMOSDB_KEY")
 
+        extra_kwargs = cosmos_client_kwargs or {}
         try:
             if resolved_key:
                 self.client = CosmosClient(
-                    resolved_endpoint, resolved_key, user_agent=USER_AGENT
+                    resolved_endpoint,
+                    resolved_key,
+                    user_agent=USER_AGENT,
+                    **extra_kwargs,
                 )
             else:
                 credential = DefaultAzureCredential()
                 self.client = CosmosClient(
-                    resolved_endpoint, credential=credential, user_agent=USER_AGENT
+                    resolved_endpoint,
+                    credential=credential,
+                    user_agent=USER_AGENT,
+                    **extra_kwargs,
                 )
             self.database = self.client.create_database_if_not_exists(database_name)
             self.container = self.database.create_container_if_not_exists(

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_langgraph_checkpoint_store.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_langgraph_checkpoint_store.py
@@ -222,6 +222,7 @@ class CosmosDBSaverSync(BaseCheckpointSaver):
         *,
         endpoint: str | None = None,
         key: str | None = None,
+        cosmos_client_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the CosmosDB sync checkpoint saver.
 
@@ -233,6 +234,8 @@ class CosmosDBSaverSync(BaseCheckpointSaver):
             key: CosmosDB access key. Falls back to ``COSMOSDB_KEY``
                 env var if not provided. When absent,
                 ``DefaultAzureCredential`` is used.
+            cosmos_client_kwargs: Additional keyword arguments passed to
+                the ``CosmosClient`` constructor (e.g. ``retry_options``).
         """
         super().__init__()
 
@@ -242,15 +245,22 @@ class CosmosDBSaverSync(BaseCheckpointSaver):
 
         resolved_key = key or os.getenv("COSMOSDB_KEY")
 
+        extra_kwargs = cosmos_client_kwargs or {}
         try:
             if resolved_key:
                 self.client = CosmosClient(
-                    resolved_endpoint, resolved_key, user_agent=USER_AGENT
+                    resolved_endpoint,
+                    resolved_key,
+                    user_agent=USER_AGENT,
+                    **extra_kwargs,
                 )
             else:
                 credential = DefaultAzureCredential()
                 self.client = CosmosClient(
-                    resolved_endpoint, credential=credential, user_agent=USER_AGENT
+                    resolved_endpoint,
+                    credential=credential,
+                    user_agent=USER_AGENT,
+                    **extra_kwargs,
                 )
             self.database = self.client.create_database_if_not_exists(database_name)
             self.container = self.database.create_container_if_not_exists(

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_langgraph_store.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_langgraph_store.py
@@ -439,6 +439,7 @@ class CosmosDBStore(BaseStore, BaseCosmosDBStore[CosmosClient]):
         container_name: str = "store",
         index: CosmosDBIndexConfig | None = None,
         ttl: TTLConfig | None = None,
+        cosmos_client_kwargs: dict[str, Any] | None = None,
     ) -> CosmosDBStore:
         """Create a new CosmosDBStore from a connection string.
 
@@ -448,11 +449,16 @@ class CosmosDBStore(BaseStore, BaseCosmosDBStore[CosmosClient]):
             container_name: Name of the container to use.
             index: Optional index/embedding configuration for vector search.
             ttl: Optional TTL configuration.
+            cosmos_client_kwargs: Additional keyword arguments passed to
+                the ``CosmosClient`` constructor (e.g. ``retry_options``).
 
         Returns:
             A new CosmosDBStore instance.
         """
-        client = CosmosClient.from_connection_string(conn_string, user_agent=USER_AGENT)
+        extra_kwargs = cosmos_client_kwargs or {}
+        client = CosmosClient.from_connection_string(
+            conn_string, user_agent=USER_AGENT, **extra_kwargs
+        )
         return cls(
             conn=client,
             database_name=database_name,
@@ -471,6 +477,7 @@ class CosmosDBStore(BaseStore, BaseCosmosDBStore[CosmosClient]):
         container_name: str = "store",
         index: CosmosDBIndexConfig | None = None,
         ttl: TTLConfig | None = None,
+        cosmos_client_kwargs: dict[str, Any] | None = None,
     ) -> CosmosDBStore:
         """Create a new CosmosDBStore from an endpoint URL.
 
@@ -485,13 +492,18 @@ class CosmosDBStore(BaseStore, BaseCosmosDBStore[CosmosClient]):
             container_name: Name of the container to use.
             index: Optional index/embedding configuration for vector search.
             ttl: Optional TTL configuration.
+            cosmos_client_kwargs: Additional keyword arguments passed to
+                the ``CosmosClient`` constructor (e.g. ``retry_options``).
 
         Returns:
             A new CosmosDBStore instance.
         """
         if credential is None:
             credential = DefaultAzureCredential()
-        client = CosmosClient(endpoint, credential=credential, user_agent=USER_AGENT)
+        extra_kwargs = cosmos_client_kwargs or {}
+        client = CosmosClient(
+            endpoint, credential=credential, user_agent=USER_AGENT, **extra_kwargs
+        )
         return cls(
             conn=client,
             database_name=database_name,
@@ -705,7 +717,7 @@ class CosmosDBStore(BaseStore, BaseCosmosDBStore[CosmosClient]):
                         item=doc_id, partition_key=prefix
                     )
                     existing_created_at = existing.get("created_at")
-                except Exception:  # noqa: BLE001
+                except CosmosResourceNotFoundError:
                     pass  # Document doesn't exist yet — created_at = now.
 
                 doc = self._prepare_put_document(

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_chat_history.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_chat_history.py
@@ -180,13 +180,17 @@ class AsyncCosmosDBChatMessageHistory(BaseChatMessageHistory):
         """Update the cosmosdb item asynchronously."""
         if not self._container:
             raise ValueError("Container not initialized")
-        await self._container.upsert_item(
-            body={
-                "id": self.session_id,
-                "user_id": self.user_id,
-                "messages": messages_to_dict(self.messages),
-            }
-        )
+        try:
+            await self._container.upsert_item(
+                body={
+                    "id": self.session_id,
+                    "user_id": self.user_id,
+                    "messages": messages_to_dict(self.messages),
+                }
+            )
+        except Exception:
+            logger.warning("Failed to upsert messages for session %s", self.session_id)
+            raise
 
     def clear(self) -> None:
         """Not implemented. Use ``aclear`` instead.
@@ -200,6 +204,10 @@ class AsyncCosmosDBChatMessageHistory(BaseChatMessageHistory):
         """Clear session memory from this memory and cosmos."""
         self.messages = []
         if self._container:
-            await self._container.delete_item(
-                item=self.session_id, partition_key=self.user_id
-            )
+            try:
+                await self._container.delete_item(
+                    item=self.session_id, partition_key=self.user_id
+                )
+            except Exception:
+                logger.warning("Failed to delete session %s", self.session_id)
+                raise

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_langgraph_cache.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_langgraph_cache.py
@@ -75,6 +75,7 @@ class CosmosDBCache(BaseCache[ValueT]):
         database_name: str,
         container_name: str,
         serde: SerializerProtocol | None = None,
+        cosmos_client_kwargs: dict[str, Any] | None = None,
     ) -> AsyncIterator[CosmosDBCache[ValueT]]:
         """Create a CosmosDBCache from explicit connection info.
 
@@ -85,14 +86,17 @@ class CosmosDBCache(BaseCache[ValueT]):
             database_name: Name of the CosmosDB database.
             container_name: Name of the CosmosDB container.
             serde: Optional custom serializer.
+            cosmos_client_kwargs: Additional keyword arguments passed to
+                the ``AsyncCosmosClient`` constructor (e.g. ``retry_options``).
 
         Yields:
             A configured async cache instance.
         """
         credential = key if key else AsyncDefaultAzureCredential()
+        extra_kwargs = cosmos_client_kwargs or {}
         try:
             async with AsyncCosmosClient(
-                endpoint, credential, user_agent=USER_AGENT
+                endpoint, credential, user_agent=USER_AGENT, **extra_kwargs
             ) as client:
                 database = await client.create_database_if_not_exists(database_name)
                 container = await database.create_container_if_not_exists(

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_langgraph_checkpoint_store.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_langgraph_checkpoint_store.py
@@ -95,6 +95,7 @@ class CosmosDBSaver(BaseCheckpointSaver):
         database_name: str,
         container_name: str,
         serde: SerializerProtocol | None = None,
+        cosmos_client_kwargs: dict[str, Any] | None = None,
     ) -> AsyncIterator[CosmosDBSaver]:
         """Create a CosmosDBSaver from explicit connection info.
 
@@ -105,14 +106,17 @@ class CosmosDBSaver(BaseCheckpointSaver):
             database_name: Name of the CosmosDB database.
             container_name: Name of the CosmosDB container.
             serde: Optional custom serializer.
+            cosmos_client_kwargs: Additional keyword arguments passed to
+                the ``AsyncCosmosClient`` constructor (e.g. ``retry_options``).
 
         Yields:
             A configured async saver instance.
         """
         credential = key if key else AsyncDefaultAzureCredential()
+        extra_kwargs = cosmos_client_kwargs or {}
         try:
             async with AsyncCosmosClient(
-                endpoint, credential, user_agent=USER_AGENT
+                endpoint, credential, user_agent=USER_AGENT, **extra_kwargs
             ) as client:
                 database = await client.create_database_if_not_exists(database_name)
                 container = await database.create_container_if_not_exists(

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_langgraph_store.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_langgraph_store.py
@@ -130,6 +130,7 @@ class AsyncCosmosDBStore(AsyncBatchedBaseStore, BaseCosmosDBStore[AsyncCosmosCli
         container_name: str = "store",
         index: CosmosDBIndexConfig | None = None,
         ttl: TTLConfig | None = None,
+        cosmos_client_kwargs: dict[str, Any] | None = None,
     ) -> AsyncIterator[AsyncCosmosDBStore]:
         """Create a new AsyncCosmosDBStore from a connection string.
 
@@ -139,12 +140,15 @@ class AsyncCosmosDBStore(AsyncBatchedBaseStore, BaseCosmosDBStore[AsyncCosmosCli
             container_name: Name of the container to use.
             index: Optional index/embedding configuration for vector search.
             ttl: Optional TTL configuration.
+            cosmos_client_kwargs: Additional keyword arguments passed to
+                the ``AsyncCosmosClient`` constructor (e.g. ``retry_options``).
 
         Yields:
             A new AsyncCosmosDBStore instance.
         """
+        extra_kwargs = cosmos_client_kwargs or {}
         client = AsyncCosmosClient.from_connection_string(
-            conn_string, user_agent=USER_AGENT
+            conn_string, user_agent=USER_AGENT, **extra_kwargs
         )
         try:
             store = cls(
@@ -169,6 +173,7 @@ class AsyncCosmosDBStore(AsyncBatchedBaseStore, BaseCosmosDBStore[AsyncCosmosCli
         container_name: str = "store",
         index: CosmosDBIndexConfig | None = None,
         ttl: TTLConfig | None = None,
+        cosmos_client_kwargs: dict[str, Any] | None = None,
     ) -> AsyncIterator[AsyncCosmosDBStore]:
         """Create a new AsyncCosmosDBStore from an endpoint URL.
 
@@ -183,6 +188,8 @@ class AsyncCosmosDBStore(AsyncBatchedBaseStore, BaseCosmosDBStore[AsyncCosmosCli
             container_name: Name of the container to use.
             index: Optional index/embedding configuration for vector search.
             ttl: Optional TTL configuration.
+            cosmos_client_kwargs: Additional keyword arguments passed to
+                the ``AsyncCosmosClient`` constructor (e.g. ``retry_options``).
 
         Yields:
             A new AsyncCosmosDBStore instance.
@@ -193,8 +200,9 @@ class AsyncCosmosDBStore(AsyncBatchedBaseStore, BaseCosmosDBStore[AsyncCosmosCli
             )
 
             credential = AsyncDefaultAzureCredential()
+        extra_kwargs = cosmos_client_kwargs or {}
         client = AsyncCosmosClient(
-            endpoint, credential=credential, user_agent=USER_AGENT
+            endpoint, credential=credential, user_agent=USER_AGENT, **extra_kwargs
         )
         try:
             store = cls(
@@ -407,7 +415,7 @@ class AsyncCosmosDBStore(AsyncBatchedBaseStore, BaseCosmosDBStore[AsyncCosmosCli
                         item=doc_id, partition_key=prefix
                     )
                     existing_created_at = existing.get("created_at")
-                except Exception:  # noqa: BLE001
+                except CosmosResourceNotFoundError:
                     pass  # Document doesn't exist yet — created_at = now.
 
                 doc = self._prepare_put_document(

--- a/libs/azure-cosmosdb/tests/unit_tests/test_resilience.py
+++ b/libs/azure-cosmosdb/tests/unit_tests/test_resilience.py
@@ -1,0 +1,405 @@
+"""Unit tests for cosmos_client_kwargs propagation and error handling resilience."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from azure.cosmos.exceptions import CosmosHttpResponseError, CosmosResourceNotFoundError
+
+# ---------------------------------------------------------------------------
+# Sync: CosmosDBSaverSync — cosmos_client_kwargs propagation
+# ---------------------------------------------------------------------------
+
+USER_AGENT_CHECKPOINT = "langchain-azure-cosmosdb-checkpoint"
+USER_AGENT_CACHE = "langchain-azure-cosmosdb-lgcache"
+
+
+class TestCosmosDBSaverSyncKwargs:
+    """Verify cosmos_client_kwargs flows through to CosmosClient."""
+
+    @patch(
+        "langchain_azure_cosmosdb._langgraph_checkpoint_store.CosmosClient",
+    )
+    def test_kwargs_passed_with_key(self, mock_cosmos_cls: MagicMock) -> None:
+        mock_client = mock_cosmos_cls.return_value
+        mock_db = MagicMock()
+        mock_client.create_database_if_not_exists.return_value = mock_db
+        mock_db.create_container_if_not_exists.return_value = MagicMock()
+
+        sentinel = object()
+        from langchain_azure_cosmosdb._langgraph_checkpoint_store import (
+            CosmosDBSaverSync,
+        )
+
+        CosmosDBSaverSync(
+            "db",
+            "container",
+            endpoint="https://fake.documents.azure.com:443/",
+            key="fake_key",
+            cosmos_client_kwargs={"retry_options": sentinel},
+        )
+
+        mock_cosmos_cls.assert_called_once_with(
+            "https://fake.documents.azure.com:443/",
+            "fake_key",
+            user_agent=USER_AGENT_CHECKPOINT,
+            retry_options=sentinel,
+        )
+
+    @patch(
+        "langchain_azure_cosmosdb._langgraph_checkpoint_store.DefaultAzureCredential",
+    )
+    @patch(
+        "langchain_azure_cosmosdb._langgraph_checkpoint_store.CosmosClient",
+    )
+    def test_kwargs_passed_with_credential(
+        self, mock_cosmos_cls: MagicMock, mock_cred_cls: MagicMock
+    ) -> None:
+        mock_client = mock_cosmos_cls.return_value
+        mock_db = MagicMock()
+        mock_client.create_database_if_not_exists.return_value = mock_db
+        mock_db.create_container_if_not_exists.return_value = MagicMock()
+
+        sentinel = object()
+        from langchain_azure_cosmosdb._langgraph_checkpoint_store import (
+            CosmosDBSaverSync,
+        )
+
+        CosmosDBSaverSync(
+            "db",
+            "container",
+            endpoint="https://fake.documents.azure.com:443/",
+            cosmos_client_kwargs={"retry_options": sentinel},
+        )
+
+        mock_cosmos_cls.assert_called_once_with(
+            "https://fake.documents.azure.com:443/",
+            credential=mock_cred_cls.return_value,
+            user_agent=USER_AGENT_CHECKPOINT,
+            retry_options=sentinel,
+        )
+
+    @patch(
+        "langchain_azure_cosmosdb._langgraph_checkpoint_store.CosmosClient",
+    )
+    def test_no_kwargs_still_works(self, mock_cosmos_cls: MagicMock) -> None:
+        mock_client = mock_cosmos_cls.return_value
+        mock_db = MagicMock()
+        mock_client.create_database_if_not_exists.return_value = mock_db
+        mock_db.create_container_if_not_exists.return_value = MagicMock()
+
+        from langchain_azure_cosmosdb._langgraph_checkpoint_store import (
+            CosmosDBSaverSync,
+        )
+
+        CosmosDBSaverSync(
+            "db",
+            "container",
+            endpoint="https://fake.documents.azure.com:443/",
+            key="fake_key",
+        )
+
+        mock_cosmos_cls.assert_called_once_with(
+            "https://fake.documents.azure.com:443/",
+            "fake_key",
+            user_agent=USER_AGENT_CHECKPOINT,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sync: CosmosDBCacheSync — cosmos_client_kwargs propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCosmosDBCacheSyncKwargs:
+    """Verify cosmos_client_kwargs flows through to CosmosClient."""
+
+    @patch("langchain_azure_cosmosdb._langgraph_cache.CosmosClient")
+    def test_kwargs_passed_with_key(self, mock_cosmos_cls: MagicMock) -> None:
+        mock_client = mock_cosmos_cls.return_value
+        mock_db = MagicMock()
+        mock_client.create_database_if_not_exists.return_value = mock_db
+        mock_db.create_container_if_not_exists.return_value = MagicMock()
+
+        sentinel = object()
+        from langchain_azure_cosmosdb._langgraph_cache import CosmosDBCacheSync
+
+        CosmosDBCacheSync(
+            "db",
+            "container",
+            endpoint="https://fake.documents.azure.com:443/",
+            key="fake_key",
+            cosmos_client_kwargs={"retry_options": sentinel},
+        )
+
+        mock_cosmos_cls.assert_called_once_with(
+            "https://fake.documents.azure.com:443/",
+            "fake_key",
+            user_agent=USER_AGENT_CACHE,
+            retry_options=sentinel,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sync: CosmosDBStore — cosmos_client_kwargs propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCosmosDBStoreKwargs:
+    """Verify cosmos_client_kwargs flows through factory methods."""
+
+    @patch("langchain_azure_cosmosdb._langgraph_store.CosmosClient")
+    def test_from_conn_string_passes_kwargs(self, mock_cosmos_cls: MagicMock) -> None:
+        sentinel = object()
+        from langchain_azure_cosmosdb._langgraph_store import CosmosDBStore
+
+        CosmosDBStore.from_conn_string(
+            "AccountEndpoint=https://fake;AccountKey=key;",
+            cosmos_client_kwargs={"retry_options": sentinel},
+        )
+
+        mock_cosmos_cls.from_connection_string.assert_called_once_with(
+            "AccountEndpoint=https://fake;AccountKey=key;",
+            user_agent="langchain-azure-cosmosdb-lgstore",
+            retry_options=sentinel,
+        )
+
+    @patch("langchain_azure_cosmosdb._langgraph_store.DefaultAzureCredential")
+    @patch("langchain_azure_cosmosdb._langgraph_store.CosmosClient")
+    def test_from_endpoint_passes_kwargs(
+        self, mock_cosmos_cls: MagicMock, mock_cred_cls: MagicMock
+    ) -> None:
+        sentinel = object()
+        from langchain_azure_cosmosdb._langgraph_store import CosmosDBStore
+
+        CosmosDBStore.from_endpoint(
+            "https://fake.documents.azure.com:443/",
+            cosmos_client_kwargs={"retry_options": sentinel},
+        )
+
+        mock_cosmos_cls.assert_called_once_with(
+            "https://fake.documents.azure.com:443/",
+            credential=mock_cred_cls.return_value,
+            user_agent="langchain-azure-cosmosdb-lgstore",
+            retry_options=sentinel,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Exception narrowing: _batch_put_ops point-read
+# ---------------------------------------------------------------------------
+
+
+class TestBatchPutOpsExceptionNarrowing:
+    """Verify that non-404 errors on read_item propagate instead of being swallowed."""
+
+    def test_429_propagates_on_point_read(self) -> None:
+        """A 429 rate-limit error on read_item must NOT be swallowed."""
+        from langchain_azure_cosmosdb._langgraph_store import CosmosDBStore
+
+        mock_client = MagicMock()
+        store = CosmosDBStore(conn=mock_client)
+        store._container = MagicMock()
+
+        # Simulate 429 on point-read
+        error_429 = CosmosHttpResponseError(
+            status_code=429, message="Rate limit exceeded"
+        )
+        store._container.read_item.side_effect = error_429
+
+        from langgraph.store.base import PutOp
+
+        op = PutOp(namespace=("test",), key="k1", value={"data": "value"})
+
+        with pytest.raises(CosmosHttpResponseError) as exc_info:
+            store._batch_put_ops([(0, op)])
+
+        assert exc_info.value.status_code == 429
+
+    def test_404_is_silently_handled(self) -> None:
+        """A CosmosResourceNotFoundError on read_item should be handled gracefully."""
+        from langchain_azure_cosmosdb._langgraph_store import CosmosDBStore
+
+        mock_client = MagicMock()
+        store = CosmosDBStore(conn=mock_client)
+        store._container = MagicMock()
+
+        # Simulate 404 on point-read
+        store._container.read_item.side_effect = CosmosResourceNotFoundError()
+        store._container.upsert_item.return_value = None
+
+        from langgraph.store.base import PutOp
+
+        op = PutOp(namespace=("test",), key="k1", value={"data": "value"})
+
+        # Should not raise
+        store._batch_put_ops([(0, op)])
+        store._container.upsert_item.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Async exception narrowing
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncBatchPutOpsExceptionNarrowing:
+    """Verify that non-404 errors on async read_item propagate."""
+
+    async def test_429_propagates_on_async_point_read(self) -> None:
+        """A 429 rate-limit error on async read_item must NOT be swallowed."""
+        from langchain_azure_cosmosdb.aio._langgraph_store import AsyncCosmosDBStore
+
+        mock_client = MagicMock()
+        store = AsyncCosmosDBStore(conn=mock_client)
+        store._container = MagicMock()
+
+        error_429 = CosmosHttpResponseError(
+            status_code=429, message="Rate limit exceeded"
+        )
+
+        async def raise_429(*args: object, **kwargs: object) -> None:
+            raise error_429
+
+        store._container.read_item = raise_429
+        store._container.upsert_item = MagicMock()
+
+        from langgraph.store.base import PutOp
+
+        op = PutOp(namespace=("test",), key="k1", value={"data": "value"})
+
+        with pytest.raises(CosmosHttpResponseError) as exc_info:
+            await store._abatch_put_ops([(0, op)])
+
+        assert exc_info.value.status_code == 429
+
+    async def test_404_is_silently_handled_async(self) -> None:
+        """CosmosResourceNotFoundError on async read_item is handled gracefully."""
+        from langchain_azure_cosmosdb.aio._langgraph_store import AsyncCosmosDBStore
+
+        mock_client = MagicMock()
+        store = AsyncCosmosDBStore(conn=mock_client)
+        store._container = MagicMock()
+
+        async def raise_not_found(*args: object, **kwargs: object) -> None:
+            raise CosmosResourceNotFoundError()
+
+        async def noop_upsert(*args: object, **kwargs: object) -> None:
+            pass
+
+        store._container.read_item = raise_not_found
+        store._container.upsert_item = noop_upsert
+
+        from langgraph.store.base import PutOp
+
+        op = PutOp(namespace=("test",), key="k1", value={"data": "value"})
+
+        # Should not raise
+        await store._abatch_put_ops([(0, op)])
+
+
+# ---------------------------------------------------------------------------
+# Chat history logging on write failures
+# ---------------------------------------------------------------------------
+
+
+class TestChatHistoryWriteLogging:
+    """Verify that write failures are logged before re-raising."""
+
+    @patch("langchain_azure_cosmosdb._chat_history.logger")
+    def test_upsert_messages_logs_on_failure(self, mock_logger: MagicMock) -> None:
+        from langchain_azure_cosmosdb._chat_history import (
+            CosmosDBChatMessageHistory,
+        )
+
+        history = CosmosDBChatMessageHistory.__new__(CosmosDBChatMessageHistory)
+        history.session_id = "sess-1"
+        history.user_id = "user-1"
+        history.messages = []
+        history._container = MagicMock()
+        history._container.upsert_item.side_effect = CosmosHttpResponseError(
+            status_code=500, message="Internal Server Error"
+        )
+
+        with pytest.raises(CosmosHttpResponseError):
+            history.upsert_messages()
+
+        mock_logger.warning.assert_called_once()
+        assert "sess-1" in mock_logger.warning.call_args[0][1]
+
+    @patch("langchain_azure_cosmosdb._chat_history.logger")
+    def test_clear_logs_on_failure(self, mock_logger: MagicMock) -> None:
+        from langchain_azure_cosmosdb._chat_history import (
+            CosmosDBChatMessageHistory,
+        )
+
+        history = CosmosDBChatMessageHistory.__new__(CosmosDBChatMessageHistory)
+        history.session_id = "sess-1"
+        history.user_id = "user-1"
+        history.messages = []
+        history._container = MagicMock()
+        history._container.delete_item.side_effect = CosmosHttpResponseError(
+            status_code=429, message="Rate limit"
+        )
+
+        with pytest.raises(CosmosHttpResponseError):
+            history.clear()
+
+        mock_logger.warning.assert_called_once()
+        assert "sess-1" in mock_logger.warning.call_args[0][1]
+
+
+class TestAsyncChatHistoryWriteLogging:
+    """Verify that async write failures are logged before re-raising."""
+
+    @patch("langchain_azure_cosmosdb.aio._chat_history.logger")
+    async def test_upsert_messages_logs_on_failure(
+        self, mock_logger: MagicMock
+    ) -> None:
+        from langchain_azure_cosmosdb.aio._chat_history import (
+            AsyncCosmosDBChatMessageHistory,
+        )
+
+        history = AsyncCosmosDBChatMessageHistory.__new__(
+            AsyncCosmosDBChatMessageHistory
+        )
+        history.session_id = "sess-1"
+        history.user_id = "user-1"
+        history.messages = []
+        history._container = MagicMock()
+
+        async def raise_error(*args: object, **kwargs: object) -> None:
+            raise CosmosHttpResponseError(
+                status_code=500, message="Internal Server Error"
+            )
+
+        history._container.upsert_item = raise_error
+
+        with pytest.raises(CosmosHttpResponseError):
+            await history.upsert_messages()
+
+        mock_logger.warning.assert_called_once()
+
+    @patch("langchain_azure_cosmosdb.aio._chat_history.logger")
+    async def test_aclear_logs_on_failure(self, mock_logger: MagicMock) -> None:
+        from langchain_azure_cosmosdb.aio._chat_history import (
+            AsyncCosmosDBChatMessageHistory,
+        )
+
+        history = AsyncCosmosDBChatMessageHistory.__new__(
+            AsyncCosmosDBChatMessageHistory
+        )
+        history.session_id = "sess-1"
+        history.user_id = "user-1"
+        history.messages = []
+        history._container = MagicMock()
+
+        async def raise_error(*args: object, **kwargs: object) -> None:
+            raise CosmosHttpResponseError(status_code=429, message="Rate limit")
+
+        history._container.delete_item = raise_error
+
+        with pytest.raises(CosmosHttpResponseError):
+            await history.aclear()
+
+        mock_logger.warning.assert_called_once()


### PR DESCRIPTION
- Add cosmos_client_kwargs parameter to all classes that construct their own CosmosClient/AsyncCosmosClient, enabling users to pass SDK-level RetryOptions for tuning 429/5xx/transient retry behavior.

  Affected: CosmosDBSaverSync, CosmosDBCacheSync, CosmosDBStore (from_conn_string, from_endpoint), and their async counterparts (CosmosDBSaver, CosmosDBCache, AsyncCosmosDBStore).

- Narrow except Exception to except CosmosResourceNotFoundError in _batch_put_ops point-read (sync + async store). Previously, 429 rate-limit and 5xx errors were silently swallowed as 'document not found', masking real failures under load.

- Add warning-level logging to chat history write operations (upsert_messages, clear/aclear) so failures are observable before the exception propagates.

- Add 14 unit tests covering kwargs propagation, exception narrowing, and write-failure logging.