### PR TITLE
perf(azure-cosmosdb): push sorting, filtering, and limiting to CosmosDB server-side queries

### DIFF
--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_langgraph_checkpoint_store.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/_langgraph_checkpoint_store.py
@@ -495,19 +495,26 @@ class CosmosDBSaverSync(BaseCheckpointSaver):
         partition_key = _make_checkpoint_key(thread_id, checkpoint_ns, "")
 
         query = "SELECT * FROM c WHERE c.partition_key=@partition_key"
-        parameters = [{"name": "@partition_key", "value": partition_key}]
+        parameters: list[dict[str, Any]] = [
+            {"name": "@partition_key", "value": partition_key},
+        ]
+
+        if before_id:
+            before_key = _make_checkpoint_key(thread_id, checkpoint_ns, before_id)
+            query += " AND c.id < @before_key"
+            parameters.append({"name": "@before_key", "value": before_key})
+
+        query += " ORDER BY c.id DESC"
+
+        if limit is not None and not filter:
+            query = query.replace("SELECT *", f"SELECT TOP {int(limit)} *", 1)
+
         items = list(
             self.container.query_items(
                 query=query,
                 parameters=parameters,
                 enable_cross_partition_query=True,
             )
-        )
-
-        # Sort by checkpoint_id descending (reverse chronological)
-        items.sort(
-            key=lambda d: _parse_checkpoint_key(d["id"])["checkpoint_id"],
-            reverse=True,
         )
 
         count = 0
@@ -517,9 +524,6 @@ class CosmosDBSaverSync(BaseCheckpointSaver):
 
             key = data["id"]
             checkpoint_id = _parse_checkpoint_key(key)["checkpoint_id"]
-
-            if before_id and checkpoint_id >= before_id:
-                continue
 
             checkpoint_tuple = _parse_checkpoint_data(self.cosmos_serde, key, data)
             if checkpoint_tuple is None:
@@ -552,7 +556,9 @@ class CosmosDBSaverSync(BaseCheckpointSaver):
             thread_id, checkpoint_ns, checkpoint_id, "", None
         )
 
-        query = "SELECT * FROM c WHERE c.partition_key=@partition_key"
+        query = (
+            "SELECT * FROM c WHERE c.partition_key=@partition_key " "ORDER BY c.id ASC"
+        )
         parameters = [{"name": "@partition_key", "value": partition_key}]
         writes = list(
             self.container.query_items(
@@ -567,10 +573,7 @@ class CosmosDBSaverSync(BaseCheckpointSaver):
             self.cosmos_serde,
             {
                 (parsed_key["task_id"], parsed_key["idx"]): write
-                for write, parsed_key in sorted(
-                    zip(writes, parsed_keys, strict=True),
-                    key=lambda x: int(x[1]["idx"]),
-                )
+                for write, parsed_key in zip(writes, parsed_keys, strict=True)
             },
         )
 
@@ -587,9 +590,13 @@ class CosmosDBSaverSync(BaseCheckpointSaver):
 
         partition_key = _make_checkpoint_key(thread_id, checkpoint_ns, "")
 
-        query = "SELECT c.id FROM c WHERE c.partition_key=@partition_key"
+        query = (
+            "SELECT TOP 1 c.id FROM c "
+            "WHERE c.partition_key=@partition_key "
+            "ORDER BY c.id DESC"
+        )
         parameters = [{"name": "@partition_key", "value": partition_key}]
-        all_keys = list(
+        items = list(
             container.query_items(
                 query=query,
                 parameters=parameters,
@@ -597,14 +604,10 @@ class CosmosDBSaverSync(BaseCheckpointSaver):
             )
         )
 
-        if not all_keys:
+        if not items:
             return None
 
-        latest_key = max(
-            all_keys,
-            key=lambda k: _parse_checkpoint_key(k["id"])["checkpoint_id"],
-        )
-        return latest_key["id"]
+        return items[0]["id"]
 
 
 __all__ = ["CosmosDBSaverSync", "_validate_key_part"]

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_langgraph_checkpoint_store.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_langgraph_checkpoint_store.py
@@ -208,14 +208,21 @@ class CosmosDBSaver(BaseCheckpointSaver):
         partition_key = _make_checkpoint_key(thread_id, checkpoint_ns, "")
 
         query = "SELECT * FROM c WHERE c.partition_key=@partition_key"
-        parameters = [{"name": "@partition_key", "value": partition_key}]
-        items = await self._query_items(query, parameters)
+        parameters: list[dict[str, Any]] = [
+            {"name": "@partition_key", "value": partition_key},
+        ]
 
-        # Sort by checkpoint_id descending (reverse chronological)
-        items.sort(
-            key=lambda d: _parse_checkpoint_key(d["id"])["checkpoint_id"],
-            reverse=True,
-        )
+        if before_id:
+            before_key = _make_checkpoint_key(thread_id, checkpoint_ns, before_id)
+            query += " AND c.id < @before_key"
+            parameters.append({"name": "@before_key", "value": before_key})
+
+        query += " ORDER BY c.id DESC"
+
+        if limit is not None and not filter:
+            query = query.replace("SELECT *", f"SELECT TOP {int(limit)} *", 1)
+
+        items = await self._query_items(query, parameters)
 
         count = 0
         for data in items:
@@ -224,9 +231,6 @@ class CosmosDBSaver(BaseCheckpointSaver):
 
             key = data["id"]
             cp_id = _parse_checkpoint_key(key)["checkpoint_id"]
-
-            if before_id and cp_id >= before_id:
-                continue
 
             checkpoint_tuple = _parse_checkpoint_data(self.cosmos_serde, key, data)
             if checkpoint_tuple is None:
@@ -555,19 +559,18 @@ class CosmosDBSaver(BaseCheckpointSaver):
         partition_key = _make_checkpoint_writes_key(
             thread_id, checkpoint_ns, checkpoint_id, "", None
         )
-        query = "SELECT * FROM c WHERE c.partition_key=@partition_key"
+        query = (
+            "SELECT * FROM c WHERE c.partition_key=@partition_key " "ORDER BY c.id ASC"
+        )
         parameters = [{"name": "@partition_key", "value": partition_key}]
         writes = await self._query_items(query, parameters)
 
         parsed_keys = [_parse_checkpoint_writes_key(write["id"]) for write in writes]
-        sorted_writes_keys: list[tuple[dict[str, Any], dict[str, str]]] = sorted(
-            zip(writes, parsed_keys, strict=True), key=lambda x: int(x[1]["idx"])
-        )
         return _load_writes(
             self.cosmos_serde,
             {
                 (parsed_key["task_id"], parsed_key["idx"]): write
-                for write, parsed_key in sorted_writes_keys
+                for write, parsed_key in zip(writes, parsed_keys, strict=True)
             },
         )
 
@@ -582,18 +585,18 @@ class CosmosDBSaver(BaseCheckpointSaver):
             return _make_checkpoint_key(thread_id, checkpoint_ns, checkpoint_id)
 
         partition_key = _make_checkpoint_key(thread_id, checkpoint_ns, "")
-        query = "SELECT c.id FROM c WHERE c.partition_key=@partition_key"
+        query = (
+            "SELECT TOP 1 c.id FROM c "
+            "WHERE c.partition_key=@partition_key "
+            "ORDER BY c.id DESC"
+        )
         parameters = [{"name": "@partition_key", "value": partition_key}]
-        all_keys = await self._query_items(query, parameters)
+        items = await self._query_items(query, parameters)
 
-        if not all_keys:
+        if not items:
             return None
 
-        latest_key: dict[str, Any] = max(
-            all_keys,
-            key=lambda k: _parse_checkpoint_key(k["id"])["checkpoint_id"],
-        )
-        return latest_key["id"]
+        return items[0]["id"]
 
 
 __all__ = ["CosmosDBSaver"]

--- a/libs/azure-cosmosdb/tests/unit_tests/test_checkpoint_server_side_queries.py
+++ b/libs/azure-cosmosdb/tests/unit_tests/test_checkpoint_server_side_queries.py
@@ -1,0 +1,279 @@
+"""Tests that checkpoint saver methods push sorting, filtering, and limiting
+to CosmosDB server-side queries instead of fetching all items and processing
+in Python.
+
+These tests mock the CosmosDB container to capture the SQL queries issued and
+verify that ORDER BY, TOP, and WHERE clauses are used appropriately.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from langchain_azure_cosmosdb._langgraph_checkpoint_store import (
+    CosmosDBSaverSync,
+    _CosmosSerializer,
+    _make_checkpoint_key,
+    _make_checkpoint_writes_key,
+)
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _b64(val: str) -> str:
+    return base64.b64encode(val.encode()).decode()
+
+
+def _make_serde() -> _CosmosSerializer:
+    return _CosmosSerializer(JsonPlusSerializer())
+
+
+def _make_fake_checkpoint_item(
+    thread_id: str, checkpoint_ns: str, checkpoint_id: str, serde: _CosmosSerializer
+) -> dict[str, Any]:
+    """Build a checkpoint document as CosmosDB would store it."""
+    key = _make_checkpoint_key(thread_id, checkpoint_ns, checkpoint_id)
+    partition_key = _make_checkpoint_key(thread_id, checkpoint_ns, "")
+    cp_type, cp_data = serde.dumps_typed(
+        {
+            "v": 1,
+            "id": checkpoint_id,
+            "ts": checkpoint_id,
+            "channel_values": {},
+            "channel_versions": {},
+            "versions_seen": {},
+            "pending_sends": [],
+        }
+    )
+    md_data = serde.dumps_typed({"source": "input", "step": 1})
+    return {
+        "id": key,
+        "partition_key": partition_key,
+        "thread_id": thread_id,
+        "checkpoint": cp_data,
+        "type": cp_type,
+        "metadata": md_data,
+        "parent_checkpoint_id": "",
+    }
+
+
+def _make_fake_write_item(
+    thread_id: str,
+    checkpoint_ns: str,
+    checkpoint_id: str,
+    task_id: str,
+    idx: int,
+    channel: str,
+    serde: _CosmosSerializer,
+) -> dict[str, Any]:
+    key = _make_checkpoint_writes_key(
+        thread_id, checkpoint_ns, checkpoint_id, task_id, idx
+    )
+    partition_key = _make_checkpoint_writes_key(
+        thread_id, checkpoint_ns, checkpoint_id, "", None
+    )
+    type_, value = serde.dumps_typed(f"value-{idx}")
+    return {
+        "id": key,
+        "partition_key": partition_key,
+        "thread_id": thread_id,
+        "channel": channel,
+        "type": type_,
+        "value": value,
+    }
+
+
+def _build_saver_with_mock_container() -> tuple[CosmosDBSaverSync, MagicMock]:
+    """Construct a CosmosDBSaverSync with a mocked CosmosDB container."""
+    with patch.object(CosmosDBSaverSync, "__init__", lambda self: None):
+        saver = CosmosDBSaverSync.__new__(CosmosDBSaverSync)
+    saver.serde = JsonPlusSerializer()
+    saver.cosmos_serde = _CosmosSerializer(saver.serde)
+    container = MagicMock()
+    saver.container = container
+    # Also set client/database to avoid AttributeError in any code path
+    saver.client = MagicMock()
+    saver.database = MagicMock()
+    return saver, container
+
+
+# ===================================================================
+# _get_checkpoint_key: should use TOP 1 + ORDER BY DESC
+# ===================================================================
+
+
+class TestGetCheckpointKeyServerSide:
+    def test_with_explicit_id_skips_query(self) -> None:
+        saver, container = _build_saver_with_mock_container()
+        result = saver._get_checkpoint_key(container, "t1", "ns", "cp-123")
+        assert result == _make_checkpoint_key("t1", "ns", "cp-123")
+        container.query_items.assert_not_called()
+
+    def test_without_id_uses_top_1_order_by(self) -> None:
+        """When no checkpoint_id is given, the query should use
+        ORDER BY c.id DESC and TOP 1 to let CosmosDB return only
+        the latest checkpoint instead of fetching all."""
+        saver, container = _build_saver_with_mock_container()
+        latest_key = _make_checkpoint_key("t1", "ns", "cp-003")
+        container.query_items.return_value = [{"id": latest_key}]
+
+        result = saver._get_checkpoint_key(container, "t1", "ns", None)
+
+        assert result == latest_key
+        call_args = container.query_items.call_args
+        query = call_args.kwargs.get("query") or call_args[1].get("query")
+        assert "ORDER BY" in query.upper(), f"Expected ORDER BY in query, got: {query}"
+        assert (
+            "TOP" in query.upper() or "OFFSET" in query.upper()
+        ), f"Expected TOP or OFFSET 0 LIMIT 1 in query, got: {query}"
+
+    def test_without_id_returns_none_when_empty(self) -> None:
+        saver, container = _build_saver_with_mock_container()
+        container.query_items.return_value = []
+        result = saver._get_checkpoint_key(container, "t1", "ns", None)
+        assert result is None
+
+
+# ===================================================================
+# list: should push ORDER BY, before-filter, and limit to CosmosDB
+# ===================================================================
+
+
+class TestListServerSide:
+    def test_list_uses_order_by(self) -> None:
+        """list() should push ORDER BY to CosmosDB, not sort in Python."""
+        saver, container = _build_saver_with_mock_container()
+        serde = saver.cosmos_serde
+        items = [
+            _make_fake_checkpoint_item("t1", "", f"cp-{i:03d}", serde) for i in range(3)
+        ]
+        # First call returns checkpoint items; subsequent calls return no writes
+        container.query_items.side_effect = [items] + [[] for _ in range(len(items))]
+
+        config: RunnableConfig = {
+            "configurable": {"thread_id": "t1", "checkpoint_ns": ""}
+        }
+        list(saver.list(config))
+
+        call_args = container.query_items.call_args_list[0]
+        query = call_args.kwargs.get("query") or call_args[1].get("query")
+        assert "ORDER BY" in query.upper(), f"Expected ORDER BY in query, got: {query}"
+
+    def test_list_pushes_before_filter_to_query(self) -> None:
+        """When 'before' is specified, it should be in the WHERE clause."""
+        saver, container = _build_saver_with_mock_container()
+        serde = saver.cosmos_serde
+        items = [
+            _make_fake_checkpoint_item("t1", "", "cp-001", serde),
+        ]
+        # First call returns checkpoint items; second returns no writes
+        container.query_items.side_effect = [items, []]
+
+        config: RunnableConfig = {
+            "configurable": {"thread_id": "t1", "checkpoint_ns": ""}
+        }
+        before: RunnableConfig = {
+            "configurable": {
+                "thread_id": "t1",
+                "checkpoint_ns": "",
+                "checkpoint_id": "cp-002",
+            }
+        }
+        list(saver.list(config, before=before))
+
+        call_args = container.query_items.call_args_list[0]
+        query = call_args.kwargs.get("query") or call_args[1].get("query")
+        # The before checkpoint_id should appear in the query as a filter
+        params = call_args.kwargs.get("parameters") or call_args[1].get("parameters")
+        param_values = [p["value"] for p in params]
+        assert "cp-002" in query or "cp-002" in str(
+            param_values
+        ), f"Expected before_id in query or params. Query: {query}, Params: {params}"
+
+    def test_list_pushes_limit_to_query(self) -> None:
+        """When 'limit' is specified, the query should use TOP or LIMIT."""
+        saver, container = _build_saver_with_mock_container()
+        serde = saver.cosmos_serde
+        items = [_make_fake_checkpoint_item("t1", "", "cp-001", serde)]
+        # First call returns checkpoint items; second returns no writes
+        container.query_items.side_effect = [items, []]
+
+        config: RunnableConfig = {
+            "configurable": {"thread_id": "t1", "checkpoint_ns": ""}
+        }
+        list(saver.list(config, limit=5))
+
+        call_args = container.query_items.call_args_list[0]
+        query = call_args.kwargs.get("query") or call_args[1].get("query")
+        assert (
+            "TOP" in query.upper() or "LIMIT" in query.upper()
+        ), f"Expected TOP or LIMIT in query, got: {query}"
+
+    def test_list_returns_results_in_descending_order(self) -> None:
+        """Results should come back newest first regardless of storage order."""
+        saver, container = _build_saver_with_mock_container()
+        serde = saver.cosmos_serde
+        # Simulate CosmosDB returning items already sorted DESC by ORDER BY
+        items = [
+            _make_fake_checkpoint_item("t1", "", f"cp-{i:03d}", serde)
+            for i in [3, 2, 1]
+        ]
+        # First call returns checkpoint items; subsequent calls return no writes
+        container.query_items.side_effect = [items] + [[] for _ in range(len(items))]
+
+        config: RunnableConfig = {
+            "configurable": {"thread_id": "t1", "checkpoint_ns": ""}
+        }
+        results = list(saver.list(config))
+
+        ids = [r.config["configurable"]["checkpoint_id"] for r in results]
+        assert ids == sorted(
+            ids, reverse=True
+        ), f"Expected descending order, got: {ids}"
+
+
+# ===================================================================
+# _load_pending_writes: should use ORDER BY for idx
+# ===================================================================
+
+
+class TestLoadPendingWritesServerSide:
+    def test_uses_order_by_for_idx(self) -> None:
+        """_load_pending_writes should ORDER BY in the query, not sort
+        in Python after fetching all writes."""
+        saver, container = _build_saver_with_mock_container()
+        serde = saver.cosmos_serde
+        writes = [
+            _make_fake_write_item("t1", "", "cp-001", "task1", i, f"ch{i}", serde)
+            for i in range(3)
+        ]
+        container.query_items.return_value = writes
+
+        saver._load_pending_writes("t1", "", "cp-001")
+
+        call_args = container.query_items.call_args
+        query = call_args.kwargs.get("query") or call_args[1].get("query")
+        assert "ORDER BY" in query.upper(), f"Expected ORDER BY in query, got: {query}"
+
+    def test_returns_writes_in_idx_order(self) -> None:
+        """Writes must come back sorted by idx. Since we now rely on
+        server-side ORDER BY, the mock simulates correct server ordering."""
+        saver, container = _build_saver_with_mock_container()
+        serde = saver.cosmos_serde
+        # Server returns writes already sorted by id ASC (via ORDER BY)
+        writes = [
+            _make_fake_write_item("t1", "", "cp-001", "task1", i, f"ch{i}", serde)
+            for i in [0, 1, 2]
+        ]
+        container.query_items.return_value = writes
+
+        result = saver._load_pending_writes("t1", "", "cp-001")
+
+        channels = [r[1] for r in result]
+        assert channels == ["ch0", "ch1", "ch2"]


### PR DESCRIPTION
Optimize _get_checkpoint_key, list/alist, and _load_pending_writes in both sync and async checkpoint savers to use server-side SQL clauses instead of fetching all items and processing in Python:

- _get_checkpoint_key: SELECT TOP 1 ... ORDER BY c.id DESC
- list/alist: ORDER BY c.id DESC, WHERE c.id < @before_key, TOP N
- _load_pending_writes: ORDER BY c.id ASC

This reduces RU consumption and latency as checkpoint history grows, avoiding O(N) full-partition scans for every get_tuple and list call.