### PR TITLE
[COSMOS]:Adding samples for CosmosDB integrations

### DIFF
--- a/libs/azure-cosmosdb/README.md
+++ b/libs/azure-cosmosdb/README.md
@@ -1,6 +1,6 @@
 # langchain-azure-cosmosdb
 
-Azure CosmosDB integrations for LangChain and LangGraph.
+Azure CosmosDB NoSQL integrations for [LangChain](https://python.langchain.com/) and [LangGraph](https://langchain-ai.github.io/langgraph/).
 
 ## Installation
 
@@ -8,26 +8,246 @@ Azure CosmosDB integrations for LangChain and LangGraph.
 pip install langchain-azure-cosmosdb
 ```
 
-## Features
+## Integrations
 
-- **Vector Store**: `AzureCosmosDBNoSqlVectorSearch` — Vector, full-text, and hybrid search with Azure CosmosDB NoSQL
-- **Semantic Cache**: `AzureCosmosDBNoSqlSemanticCache` — LLM response caching backed by CosmosDB NoSQL
-- **Chat History**: `CosmosDBChatMessageHistory` — Persistent chat message history with CosmosDB NoSQL
-- **Query Constructors**: `AzureCosmosDbNoSQLTranslator` — Structured query to CosmosDB NoSQL translation
-- **LangGraph Checkpoint**: `CosmosDBSaver` / `CosmosDBSaverSync` — LangGraph state persistence with CosmosDB
+| Integration | Sync | Async | Description |
+|---|---|---|---|
+| **Vector Store** | `AzureCosmosDBNoSqlVectorSearch` | `AsyncAzureCosmosDBNoSqlVectorSearch` | Vector, full-text, hybrid, and weighted hybrid search |
+| **Semantic Cache** | `AzureCosmosDBNoSqlSemanticCache` | `AsyncAzureCosmosDBNoSqlSemanticCache` | LLM response caching backed by CosmosDB |
+| **Chat History** | `CosmosDBChatMessageHistory` | `AsyncCosmosDBChatMessageHistory` | Persistent chat message history |
+| **LangGraph Checkpointer** | `CosmosDBSaverSync` | `CosmosDBSaver` | LangGraph graph state persistence |
+| **LangGraph Cache** | `CosmosDBCacheSync` | `CosmosDBCache` | LangGraph node-level result caching |
+| **LangGraph Store** | `CosmosDBStore` | `AsyncCosmosDBStore` | LangGraph long-term memory with optional vector search |
 
-## Quick Start
+## Usage
+
+### Vector Store
 
 ```python
-from langchain_azure_cosmosdb import (
-    AzureCosmosDBNoSqlVectorSearch,
-    AzureCosmosDBNoSqlSemanticCache,
-    CosmosDBChatMessageHistory,
-    CosmosDBSaver,
-    CosmosDBSaverSync,
+from azure.cosmos import CosmosClient, PartitionKey
+from langchain_azure_cosmosdb import AzureCosmosDBNoSqlVectorSearch
+
+cosmos_client = CosmosClient("<endpoint>", "<key>")
+
+vectorstore = AzureCosmosDBNoSqlVectorSearch(
+    cosmos_client=cosmos_client,
+    embedding=embedding,
+    vector_embedding_policy={
+        "vectorEmbeddings": [{
+            "path": "/embedding",
+            "dataType": "float32",
+            "distanceFunction": "cosine",
+            "dimensions": 1536,
+        }]
+    },
+    indexing_policy={
+        "indexingMode": "consistent",
+        "includedPaths": [{"path": "/*"}],
+        "excludedPaths": [{"path": '/"_etag"/?'}],
+        "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}],
+    },
+    cosmos_container_properties={"partition_key": PartitionKey(path="/id")},
+    cosmos_database_properties={"id": "my-database"},
+    vector_search_fields={"text_field": "text", "embedding_field": "embedding"},
+    database_name="my-database",
+    container_name="my-container",
 )
+
+# Add documents
+vectorstore.add_texts(["Azure CosmosDB is a multi-model database."])
+
+# Search
+results = vectorstore.similarity_search("What is CosmosDB?", k=3)
 ```
 
-See the [LangChain Azure documentation](https://github.com/langchain-ai/langchain-azure) for detailed usage guides.
+### Semantic Cache
+
+```python
+from azure.cosmos import CosmosClient, PartitionKey
+from langchain_core.globals import set_llm_cache
+from langchain_azure_cosmosdb import AzureCosmosDBNoSqlSemanticCache
+
+cosmos_client = CosmosClient("<endpoint>", "<key>")
+
+cache = AzureCosmosDBNoSqlSemanticCache(
+    cosmos_client=cosmos_client,
+    embedding=embedding,
+    vector_embedding_policy=vector_embedding_policy,
+    indexing_policy=indexing_policy,
+    cosmos_container_properties={"partition_key": PartitionKey(path="/id")},
+    cosmos_database_properties={"id": "cache-db"},
+    vector_search_fields={"text_field": "text", "embedding_field": "embedding"},
+    database_name="cache-db",
+    container_name="cache-container",
+)
+
+set_llm_cache(cache)
+
+# First call hits LLM, second call returns cached result
+response = llm.invoke("What is CosmosDB?")
+```
+
+### Chat Message History
+
+```python
+from langchain_azure_cosmosdb import CosmosDBChatMessageHistory
+
+history = CosmosDBChatMessageHistory(
+    cosmos_endpoint="<endpoint>",
+    credential="<key>",  # or a TokenCredential for AAD
+    cosmos_database="chat-db",
+    cosmos_container="chat-container",
+    session_id="session-001",
+    user_id="user-alice",
+    ttl=3600,  # optional: messages expire after 1 hour
+)
+history.prepare_cosmos()
+
+history.add_user_message("Hello!")
+history.add_ai_message("Hi there!")
+print(history.messages)
+```
+
+### LangGraph Checkpointer
+
+#### Sync
+
+```python
+from langchain_azure_cosmosdb import CosmosDBSaverSync
+
+# Sync — uses COSMOSDB_ENDPOINT / COSMOSDB_KEY env vars or explicit params
+checkpointer = CosmosDBSaverSync(
+    database_name="langgraph-db",
+    container_name="checkpoints",
+    endpoint="<endpoint>",
+    key="<key>",
+)
+
+graph = workflow.compile(checkpointer=checkpointer)
+result = graph.invoke(input, config={"configurable": {"thread_id": "1"}})
+```
+
+#### Async
+
+```python
+from langchain_azure_cosmosdb import CosmosDBSaver
+
+# Async — use as a context manager
+async with CosmosDBSaver.from_conn_info(
+    endpoint="<endpoint>",
+    key="<key>",
+    database_name="langgraph-db",
+    container_name="checkpoints",
+) as checkpointer:
+    graph = workflow.compile(checkpointer=checkpointer)
+    result = await graph.ainvoke(input, config={"configurable": {"thread_id": "1"}})
+```
+
+### LangGraph Cache
+
+#### Sync
+
+```python
+from langchain_azure_cosmosdb import CosmosDBCacheSync
+
+cache = CosmosDBCacheSync(
+    database_name="langgraph-db",
+    container_name="cache",
+    endpoint="<endpoint>",
+    key="<key>",
+)
+
+graph = workflow.compile(cache=cache)
+```
+
+#### Async
+
+```python
+from langchain_azure_cosmosdb import CosmosDBCache
+
+async with CosmosDBCache.from_conn_info(
+    endpoint="<endpoint>",
+    key="<key>",
+    database_name="langgraph-db",
+    container_name="cache",
+) as cache:
+    graph = workflow.compile(cache=cache)
+    result = await graph.ainvoke(input, config={"configurable": {"thread_id": "1"}})
+```
+
+### LangGraph Store (Long-Term Memory)
+
+#### Sync
+
+```python
+from langchain_azure_cosmosdb import CosmosDBStore
+
+store = CosmosDBStore.from_endpoint(
+    endpoint="<endpoint>",
+    credential="<key>",
+    database_name="langgraph-db",
+    container_name="store",
+    index={
+        "dims": 1536,
+        "embed": embedding,
+        "fields": ["text"],
+    },
+)
+store.setup()
+
+# Store items under namespaces
+store.put(("users", "alice", "preferences"), "coffee", {"text": "Dark roast"})
+item = store.get(("users", "alice", "preferences"), "coffee")
+
+# Semantic search
+results = store.search(("users",), query="beverage preferences", limit=3)
+```
+
+#### Async
+
+```python
+from langchain_azure_cosmosdb import AsyncCosmosDBStore
+
+async with AsyncCosmosDBStore.from_endpoint(
+    endpoint="<endpoint>",
+    credential="<key>",
+    database_name="langgraph-db",
+    container_name="store",
+    index={
+        "dims": 1536,
+        "embed": embedding,
+        "fields": ["text"],
+    },
+) as store:
+    await store.setup()
+
+    await store.aput(("users", "alice", "preferences"), "coffee", {"text": "Dark roast"})
+    item = await store.aget(("users", "alice", "preferences"), "coffee")
+
+    results = await store.asearch(("users",), query="beverage preferences", limit=3)
+```
+
+## Samples
+
+See the [samples/cosmosdb-nosql/](../../samples/cosmosdb-nosql/) directory for runnable end-to-end examples of every integration.
 
 ## Changelog
+
+### 1.0.0
+
+Initial release of `langchain-azure-cosmosdb` — a standalone package consolidating all Azure CosmosDB NoSQL integrations for LangChain and LangGraph.
+
+**LangChain Integrations:**
+- `AzureCosmosDBNoSqlVectorSearch` / `AsyncAzureCosmosDBNoSqlVectorSearch` — Vector, full-text, hybrid, and weighted hybrid search
+- `AzureCosmosDBNoSqlSemanticCache` / `AsyncAzureCosmosDBNoSqlSemanticCache` — LLM semantic response caching
+- `CosmosDBChatMessageHistory` / `AsyncCosmosDBChatMessageHistory` — Persistent chat message history with TTL support
+
+**LangGraph Integrations:**
+- `CosmosDBSaverSync` / `CosmosDBSaver` — Graph state checkpointing
+- `CosmosDBCacheSync` / `CosmosDBCache` — Node-level result caching
+- `CosmosDBStore` / `AsyncCosmosDBStore` — Long-term memory store with optional vector search
+
+**Highlights:**
+- Full sync and async support for all integrations
+- Microsoft Entra ID (AAD / Managed Identity) authentication across all integrations
+- User agent tracking for all CosmosDB client instances

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_vectorstore.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_vectorstore.py
@@ -31,6 +31,8 @@ from pydantic import ConfigDict, model_validator
 if TYPE_CHECKING:
     from azure.cosmos.aio import ContainerProxy, CosmosClient, DatabaseProxy
 
+USER_AGENT = "langchain-azure-cosmosdb-vectorstore"
+
 # ruff: noqa: E501
 
 
@@ -266,6 +268,74 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
             full_text_search_enabled=full_text_search_enabled,
             table_alias=table_alias,
         )
+
+    @classmethod
+    async def from_connection_string_and_aad(
+        cls,
+        connection_string: str,
+        credential: Any,
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> AsyncAzureCosmosDBNoSqlVectorSearch:
+        """Create vectorstore from a connection string with AAD credential.
+
+        Args:
+            connection_string: CosmosDB connection string (endpoint).
+            credential: Azure credential (e.g., DefaultAzureCredential).
+            texts: The texts to insert.
+            embedding: The embedding model to use.
+            metadatas: Optional metadata dicts for the texts.
+            ids: Optional ids for the texts.
+            **kwargs: Additional keyword arguments passed to ``create``.
+
+        Returns:
+            An initialised AsyncAzureCosmosDBNoSqlVectorSearch.
+        """
+        from azure.cosmos.aio import CosmosClient as AsyncCosmosClient
+
+        cosmos_client = AsyncCosmosClient(
+            connection_string, credential, user_agent=USER_AGENT
+        )
+        kwargs["cosmos_client"] = cosmos_client
+        vectorstore = await cls._afrom_kwargs(embedding, **kwargs)
+        await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
+        return vectorstore
+
+    @classmethod
+    async def from_connection_string_and_key(
+        cls,
+        connection_string: str,
+        key: str,
+        texts: List[str],
+        embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> AsyncAzureCosmosDBNoSqlVectorSearch:
+        """Create vectorstore from a connection string with access key.
+
+        Args:
+            connection_string: CosmosDB connection string (endpoint).
+            key: CosmosDB access key.
+            texts: The texts to insert.
+            embedding: The embedding model to use.
+            metadatas: Optional metadata dicts for the texts.
+            ids: Optional ids for the texts.
+            **kwargs: Additional keyword arguments passed to ``create``.
+
+        Returns:
+            An initialised AsyncAzureCosmosDBNoSqlVectorSearch.
+        """
+        from azure.cosmos.aio import CosmosClient as AsyncCosmosClient
+
+        cosmos_client = AsyncCosmosClient(connection_string, key, user_agent=USER_AGENT)
+        kwargs["cosmos_client"] = cosmos_client
+        vectorstore = await cls._afrom_kwargs(embedding, **kwargs)
+        await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
+        return vectorstore
 
     @property
     def embeddings(self) -> Embeddings:

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_vectorstore.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_vectorstore.py
@@ -270,9 +270,9 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
         )
 
     @classmethod
-    async def from_connection_string_and_aad(
+    async def from_endpoint_and_aad(
         cls,
-        connection_string: str,
+        endpoint: str,
         credential: Any,
         texts: List[str],
         embedding: Embeddings,
@@ -280,10 +280,10 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
         ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> AsyncAzureCosmosDBNoSqlVectorSearch:
-        """Create vectorstore from a connection string with AAD credential.
+        """Create vectorstore from an endpoint with AAD credential.
 
         Args:
-            connection_string: CosmosDB connection string (endpoint).
+            endpoint: CosmosDB account endpoint URL.
             credential: Azure credential (e.g., DefaultAzureCredential).
             texts: The texts to insert.
             embedding: The embedding model to use.
@@ -296,20 +296,21 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
         """
         from azure.cosmos.aio import CosmosClient as AsyncCosmosClient
 
-        cosmos_client = AsyncCosmosClient(
-            connection_string, credential, user_agent=USER_AGENT
-        )
-        kwargs["cosmos_client"] = cosmos_client
-        vectorstore = await cls._afrom_kwargs(embedding, **kwargs)
-        await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
-        # Store reference so callers can close the client when done.
-        vectorstore._owns_client = True
-        return vectorstore
+        cosmos_client = AsyncCosmosClient(endpoint, credential, user_agent=USER_AGENT)
+        try:
+            kwargs["cosmos_client"] = cosmos_client
+            vectorstore = await cls._afrom_kwargs(embedding, **kwargs)
+            await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
+            vectorstore._owns_client = True
+            return vectorstore
+        except BaseException:
+            await cosmos_client.close()
+            raise
 
     @classmethod
-    async def from_connection_string_and_key(
+    async def from_endpoint_and_key(
         cls,
-        connection_string: str,
+        endpoint: str,
         key: str,
         texts: List[str],
         embedding: Embeddings,
@@ -317,10 +318,10 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
         ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> AsyncAzureCosmosDBNoSqlVectorSearch:
-        """Create vectorstore from a connection string with access key.
+        """Create vectorstore from an endpoint with access key.
 
         Args:
-            connection_string: CosmosDB connection string (endpoint).
+            endpoint: CosmosDB account endpoint URL.
             key: CosmosDB access key.
             texts: The texts to insert.
             embedding: The embedding model to use.
@@ -333,20 +334,24 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
         """
         from azure.cosmos.aio import CosmosClient as AsyncCosmosClient
 
-        cosmos_client = AsyncCosmosClient(connection_string, key, user_agent=USER_AGENT)
-        kwargs["cosmos_client"] = cosmos_client
-        vectorstore = await cls._afrom_kwargs(embedding, **kwargs)
-        await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
-        # Store reference so callers can close the client when done.
-        vectorstore._owns_client = True
-        return vectorstore
+        cosmos_client = AsyncCosmosClient(endpoint, key, user_agent=USER_AGENT)
+        try:
+            kwargs["cosmos_client"] = cosmos_client
+            vectorstore = await cls._afrom_kwargs(embedding, **kwargs)
+            await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
+            vectorstore._owns_client = True
+            return vectorstore
+        except BaseException:
+            await cosmos_client.close()
+            raise
 
     async def close(self) -> None:
         """Close the underlying CosmosDB client if owned by this instance.
 
-        Call this when the vectorstore was created via
-        ``from_connection_string_and_aad`` or
-        ``from_connection_string_and_key`` to release the connection.
+        Call this when the vectorstore was created via a factory method
+        (``from_connection_string_and_aad`` or
+        ``from_connection_string_and_key``) to release the connection.
+        Alternatively, use the instance as an async context manager.
         """
         if getattr(self, "_owns_client", False) and self._cosmos_client is not None:
             await self._cosmos_client.close()

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_vectorstore.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_vectorstore.py
@@ -302,6 +302,8 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
         kwargs["cosmos_client"] = cosmos_client
         vectorstore = await cls._afrom_kwargs(embedding, **kwargs)
         await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
+        # Store reference so callers can close the client when done.
+        vectorstore._owns_client = True
         return vectorstore
 
     @classmethod
@@ -335,7 +337,27 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
         kwargs["cosmos_client"] = cosmos_client
         vectorstore = await cls._afrom_kwargs(embedding, **kwargs)
         await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
+        # Store reference so callers can close the client when done.
+        vectorstore._owns_client = True
         return vectorstore
+
+    async def close(self) -> None:
+        """Close the underlying CosmosDB client if owned by this instance.
+
+        Call this when the vectorstore was created via
+        ``from_connection_string_and_aad`` or
+        ``from_connection_string_and_key`` to release the connection.
+        """
+        if getattr(self, "_owns_client", False) and self._cosmos_client is not None:
+            await self._cosmos_client.close()
+
+    async def __aenter__(self) -> AsyncAzureCosmosDBNoSqlVectorSearch:
+        """Enter async context manager."""
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        """Exit async context manager and close client if owned."""
+        await self.close()
 
     @property
     def embeddings(self) -> Embeddings:

--- a/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_vectorstore.py
+++ b/libs/azure-cosmosdb/src/langchain_azure_cosmosdb/aio/_vectorstore.py
@@ -303,7 +303,7 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
             await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
             vectorstore._owns_client = True
             return vectorstore
-        except BaseException:
+        except Exception:
             await cosmos_client.close()
             raise
 
@@ -341,7 +341,7 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
             await vectorstore.aadd_texts(texts=texts, metadatas=metadatas, ids=ids)
             vectorstore._owns_client = True
             return vectorstore
-        except BaseException:
+        except Exception:
             await cosmos_client.close()
             raise
 
@@ -349,8 +349,8 @@ class AsyncAzureCosmosDBNoSqlVectorSearch(VectorStore):
         """Close the underlying CosmosDB client if owned by this instance.
 
         Call this when the vectorstore was created via a factory method
-        (``from_connection_string_and_aad`` or
-        ``from_connection_string_and_key``) to release the connection.
+        (``from_endpoint_and_aad`` or
+        ``from_endpoint_and_key``) to release the connection.
         Alternatively, use the instance as an async context manager.
         """
         if getattr(self, "_owns_client", False) and self._cosmos_client is not None:

--- a/libs/azure-cosmosdb/tests/unit_tests/aio/test_vectorstore.py
+++ b/libs/azure-cosmosdb/tests/unit_tests/aio/test_vectorstore.py
@@ -267,3 +267,128 @@ def test_from_texts_raises() -> None:
         AsyncAzureCosmosDBNoSqlVectorSearch.from_texts(
             texts=["hello"], embedding=FakeEmbeddings()
         )
+
+
+# ---- factory method & client ownership tests --------------------------------
+
+
+async def test_from_endpoint_and_aad_sets_owns_client() -> None:
+    """Factory method sets _owns_client and stores the client."""
+    from unittest.mock import patch
+
+    mock_client = AsyncMock()
+    mock_db = AsyncMock()
+    mock_container = AsyncMock()
+    mock_client.create_database_if_not_exists = AsyncMock(return_value=mock_db)
+    mock_db.create_container_if_not_exists = AsyncMock(return_value=mock_container)
+    mock_container.create_item = AsyncMock(
+        return_value={"id": "1", "text": "t", "embedding": [0.1]}
+    )
+
+    with patch(
+        "azure.cosmos.aio.CosmosClient",
+        return_value=mock_client,
+    ):
+        store = await AsyncAzureCosmosDBNoSqlVectorSearch.from_endpoint_and_aad(
+            endpoint="https://fake.documents.azure.com:443/",
+            credential=MagicMock(),
+            texts=["hello"],
+            embedding=FakeEmbeddings(),
+            vector_embedding_policy=DEFAULT_VEC_POLICY,
+            indexing_policy=DEFAULT_IDX_POLICY,
+            cosmos_container_properties=DEFAULT_CONTAINER_PROPS,
+            cosmos_database_properties={"id": "testdb"},
+            vector_search_fields=DEFAULT_VS_FIELDS,
+        )
+        assert store._owns_client is True
+
+
+async def test_from_endpoint_and_key_sets_owns_client() -> None:
+    """Factory method with key sets _owns_client."""
+    from unittest.mock import patch
+
+    mock_client = AsyncMock()
+    mock_db = AsyncMock()
+    mock_container = AsyncMock()
+    mock_client.create_database_if_not_exists = AsyncMock(return_value=mock_db)
+    mock_db.create_container_if_not_exists = AsyncMock(return_value=mock_container)
+    mock_container.create_item = AsyncMock(
+        return_value={"id": "1", "text": "t", "embedding": [0.1]}
+    )
+
+    with patch(
+        "azure.cosmos.aio.CosmosClient",
+        return_value=mock_client,
+    ):
+        store = await AsyncAzureCosmosDBNoSqlVectorSearch.from_endpoint_and_key(
+            endpoint="https://fake.documents.azure.com:443/",
+            key="fakekey",
+            texts=["hello"],
+            embedding=FakeEmbeddings(),
+            vector_embedding_policy=DEFAULT_VEC_POLICY,
+            indexing_policy=DEFAULT_IDX_POLICY,
+            cosmos_container_properties=DEFAULT_CONTAINER_PROPS,
+            cosmos_database_properties={"id": "testdb"},
+            vector_search_fields=DEFAULT_VS_FIELDS,
+        )
+        assert store._owns_client is True
+
+
+async def test_close_closes_client_when_owned() -> None:
+    """close() calls client.close() when _owns_client is True."""
+    store = _make_store()
+    store._owns_client = True
+    store._cosmos_client = AsyncMock()
+
+    await store.close()
+    store._cosmos_client.close.assert_awaited_once()
+
+
+async def test_close_skips_when_not_owned() -> None:
+    """close() does nothing when _owns_client is False."""
+    store = _make_store()
+    store._cosmos_client = AsyncMock()
+
+    await store.close()
+    store._cosmos_client.close.assert_not_awaited()
+
+
+async def test_context_manager_calls_close() -> None:
+    """__aexit__ calls close()."""
+    store = _make_store()
+    store._owns_client = True
+    store._cosmos_client = AsyncMock()
+
+    async with store:
+        pass
+
+    store._cosmos_client.close.assert_awaited_once()
+
+
+async def test_factory_cleans_up_on_error() -> None:
+    """Client is closed if _afrom_kwargs raises."""
+    from unittest.mock import patch
+
+    mock_client = AsyncMock()
+    # Make create_database_if_not_exists raise to simulate failure
+    mock_client.create_database_if_not_exists = AsyncMock(
+        side_effect=RuntimeError("simulated failure")
+    )
+
+    with patch(
+        "azure.cosmos.aio.CosmosClient",
+        return_value=mock_client,
+    ):
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            await AsyncAzureCosmosDBNoSqlVectorSearch.from_endpoint_and_key(
+                endpoint="https://fake.documents.azure.com:443/",
+                key="fakekey",
+                texts=["hello"],
+                embedding=FakeEmbeddings(),
+                vector_embedding_policy=DEFAULT_VEC_POLICY,
+                indexing_policy=DEFAULT_IDX_POLICY,
+                cosmos_container_properties=DEFAULT_CONTAINER_PROPS,
+                cosmos_database_properties={"id": "testdb"},
+                vector_search_fields=DEFAULT_VS_FIELDS,
+            )
+        mock_client.close.assert_awaited_once()

--- a/samples/cosmosdb-nosql/.env.example
+++ b/samples/cosmosdb-nosql/.env.example
@@ -1,0 +1,10 @@
+# Azure CosmosDB
+COSMOSDB_ENDPOINT=https://your-account.documents.azure.com:443/
+COSMOSDB_KEY=your-key-here
+
+# Azure OpenAI (for embeddings + chat)
+AZURE_OPENAI_ENDPOINT=https://your-openai.openai.azure.com/
+AZURE_OPENAI_API_KEY=your-openai-key
+AZURE_OPENAI_API_VERSION=2024-12-01-preview
+AZURE_OPENAI_CHAT_DEPLOYMENT=gpt-4o-mini
+AZURE_OPENAI_EMBEDDING_DEPLOYMENT=text-embedding-3-small

--- a/samples/cosmosdb-nosql/README.md
+++ b/samples/cosmosdb-nosql/README.md
@@ -1,0 +1,77 @@
+# Azure CosmosDB NoSQL Samples
+
+Sample scripts demonstrating all `langchain-azure-cosmosdb` integrations — LangChain vector store, semantic cache, chat history, and LangGraph checkpointer, cache, and store.
+
+## Prerequisites
+
+- **Azure CosmosDB NoSQL** account ([create one](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/quickstart-portal))
+- **Azure OpenAI** deployment with a chat model and an embedding model ([quickstart](https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart))
+- Python 3.10+
+
+## Setup
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Configure environment
+cp .env.example .env
+# Edit .env with your CosmosDB and Azure OpenAI credentials
+```
+
+## Samples
+
+### LangChain Integrations
+
+| Sample | Description | Run |
+|--------|-------------|-----|
+| [langchain_vectorstore.py](langchain_vectorstore.py) | Vector, full-text, hybrid, and weighted hybrid search | `python langchain_vectorstore.py` |
+| [langchain_semantic_cache.py](langchain_semantic_cache.py) | LLM semantic caching with cache hit/miss demo | `python langchain_semantic_cache.py` |
+| [langchain_chat_history.py](langchain_chat_history.py) | Chat message history with multi-session and TTL | `python langchain_chat_history.py` |
+| [langchain_rag_chatbot.py](langchain_rag_chatbot.py) | End-to-end RAG chatbot (vectorstore + chat history) | `python langchain_rag_chatbot.py` |
+
+### LangGraph Integrations
+
+| Sample | Description | Run |
+|--------|-------------|-----|
+| [langgraph_checkpointer.py](langgraph_checkpointer.py) | Sync checkpointer with state persistence and history | `python langgraph_checkpointer.py` |
+| [langgraph_checkpointer_async.py](langgraph_checkpointer_async.py) | Async checkpointer with `from_conn_info` context manager | `python langgraph_checkpointer_async.py` |
+| [langgraph_cache.py](langgraph_cache.py) | Sync graph caching with TTL | `python langgraph_cache.py` |
+| [langgraph_cache_async.py](langgraph_cache_async.py) | Async graph caching | `python langgraph_cache_async.py` |
+| [langgraph_store.py](langgraph_store.py) | Sync long-term memory store with semantic search | `python langgraph_store.py` |
+| [langgraph_store_async.py](langgraph_store_async.py) | Async long-term memory store | `python langgraph_store_async.py` |
+
+## Sample Descriptions
+
+### langchain_vectorstore.py
+Creates an `AzureCosmosDBNoSqlVectorSearch` with Azure OpenAI embeddings, adds documents, and demonstrates all search types: vector similarity, full-text, hybrid, and weighted hybrid search.
+
+### langchain_semantic_cache.py
+Sets up `AzureCosmosDBNoSqlSemanticCache` as the global LangChain LLM cache. Shows cache misses (first call hits LLM) vs cache hits (subsequent calls return cached results) with latency comparison.
+
+### langchain_chat_history.py
+Uses `CosmosDBChatMessageHistory` to store and retrieve conversation history. Demonstrates multi-session support (independent histories per session) and TTL-based message expiration.
+
+### langchain_rag_chatbot.py
+End-to-end RAG chatbot combining the vector store for document retrieval with chat history for conversation memory. Loads sample CosmosDB knowledge base documents and runs an interactive chat loop.
+
+### langgraph_checkpointer.py / langgraph_checkpointer_async.py
+Builds a LangGraph chatbot with `CosmosDBSaverSync` (or `CosmosDBSaver` for async) as the checkpointer. Demonstrates multi-turn memory within a thread, state inspection with `get_state()`, state history traversal, and thread isolation.
+
+### langgraph_cache.py / langgraph_cache_async.py
+Compiles a LangGraph graph with `CosmosDBCacheSync` (or `CosmosDBCache` for async) to cache node results. Shows how the second invocation with the same input returns cached results significantly faster.
+
+### langgraph_store.py / langgraph_store_async.py
+Uses `CosmosDBStore` (or `AsyncCosmosDBStore` for async) for LangGraph long-term memory. Demonstrates namespace-based organization, put/get/search/delete operations, and semantic search over stored items using vector embeddings.
+
+## Cleanup
+
+Each sample cleans up its own CosmosDB database at the end. If a sample is interrupted, you can manually delete the database from the Azure Portal.
+
+## Learn More
+
+- [langchain-azure-cosmosdb package](https://pypi.org/project/langchain-azure-cosmosdb/)
+- [Azure CosmosDB Vector Search](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search)
+- [Azure CosmosDB Hybrid Search](https://learn.microsoft.com/en-us/azure/cosmos-db/gen-ai/hybrid-search)
+- [LangChain Documentation](https://python.langchain.com/)
+- [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)

--- a/samples/cosmosdb-nosql/langchain_chat_history.py
+++ b/samples/cosmosdb-nosql/langchain_chat_history.py
@@ -56,7 +56,10 @@ def main() -> None:
 
         print(f"  Stored {len(history.messages)} messages")
         for msg in history.messages:
-            print(f"  [{msg.type}] {msg.content[:80]}...")
+            content = msg.content
+            if len(content) > 80:
+                content = content[:80] + "..."
+            print(f"  [{msg.type}] {content}")
         print()
 
         # --- Session 2: Different session, same user ---
@@ -112,8 +115,11 @@ def main() -> None:
     finally:
         # --- Cleanup ---
         print("Cleaning up...")
-        client.delete_database(DATABASE_NAME)
-        print("Done! Database deleted.")
+        try:
+            client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langchain_chat_history.py
+++ b/samples/cosmosdb-nosql/langchain_chat_history.py
@@ -1,0 +1,120 @@
+"""Azure CosmosDB Chat Message History sample.
+
+Demonstrates storing and retrieving chat message history in CosmosDB,
+including multi-session support and TTL-based expiration.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT - CosmosDB account endpoint
+    COSMOSDB_KEY      - CosmosDB account key
+"""
+
+import os
+
+from azure.cosmos import CosmosClient
+from dotenv import load_dotenv
+
+from langchain_azure_cosmosdb import CosmosDBChatMessageHistory
+
+load_dotenv()
+
+DATABASE_NAME = "sample-chathistory-db"
+
+
+def main() -> None:
+    """Run chat history sample."""
+    client = CosmosClient(
+        os.environ["COSMOSDB_ENDPOINT"],
+        os.environ["COSMOSDB_KEY"],
+    )
+    try:
+        # --- Session 1: Add messages ---
+        print("=== Session 1: Adding messages ===")
+        history = CosmosDBChatMessageHistory(
+            cosmos_endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            credential=os.environ["COSMOSDB_KEY"],
+            cosmos_database=DATABASE_NAME,
+            cosmos_container="sample-chathistory-container",
+            session_id="session-001",
+            user_id="user-alice",
+        )
+        history.prepare_cosmos()
+
+        history.add_user_message("Hi! I'm planning a trip to Tokyo.")
+        history.add_ai_message(
+            "That sounds exciting! Tokyo has amazing food, temples, and technology. "
+            "When are you planning to go?"
+        )
+        history.add_user_message("Sometime in April for cherry blossom season.")
+        history.add_ai_message(
+            "Great choice! Late March to mid-April is peak cherry blossom season. "
+            "I recommend visiting Ueno Park and Shinjuku Gyoen."
+        )
+
+        print(f"  Stored {len(history.messages)} messages")
+        for msg in history.messages:
+            print(f"  [{msg.type}] {msg.content[:80]}...")
+        print()
+
+        # --- Session 2: Different session, same user ---
+        print("=== Session 2: New session for same user ===")
+        history2 = CosmosDBChatMessageHistory(
+            cosmos_endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            credential=os.environ["COSMOSDB_KEY"],
+            cosmos_database=DATABASE_NAME,
+            cosmos_container="sample-chathistory-container",
+            session_id="session-002",
+            user_id="user-alice",
+        )
+        history2.prepare_cosmos()
+
+        history2.add_user_message("What about restaurants in Tokyo?")
+        history2.add_ai_message(
+            "Tokyo has more Michelin-starred restaurants than any other city! "
+            "Try Tsukiji Outer Market for fresh sushi."
+        )
+
+        print(f"  Session 2 has {len(history2.messages)} messages (independent)")
+        print(f"  Session 1 still has {len(history.messages)} messages")
+        print()
+
+        # --- Retrieve messages from Session 1 ---
+        print("=== Retrieving Session 1 messages ===")
+        for msg in history.messages:
+            print(f"  [{msg.type}] {msg.content}")
+        print()
+
+        # --- Clear Session 1 ---
+        print("=== Clearing Session 1 ===")
+        history.clear()
+        print(f"  Session 1 messages after clear: {len(history.messages)}")
+        print(f"  Session 2 messages (unaffected): {len(history2.messages)}")
+        print()
+
+        # --- TTL example ---
+        print("=== TTL Example ===")
+        history_ttl = CosmosDBChatMessageHistory(
+            cosmos_endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            credential=os.environ["COSMOSDB_KEY"],
+            cosmos_database=DATABASE_NAME,
+            cosmos_container="sample-chathistory-container",
+            session_id="session-ttl",
+            user_id="user-bob",
+            ttl=3600,  # messages expire after 1 hour
+        )
+        history_ttl.prepare_cosmos()
+        history_ttl.add_user_message("This message will expire in 1 hour.")
+        print("  Added message with TTL=3600s")
+        print()
+    finally:
+        # --- Cleanup ---
+        print("Cleaning up...")
+        client.delete_database(DATABASE_NAME)
+        print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/cosmosdb-nosql/langchain_rag_chatbot.py
+++ b/samples/cosmosdb-nosql/langchain_rag_chatbot.py
@@ -97,7 +97,7 @@ def main() -> None:
     )
     try:
         llm = AzureChatOpenAI(
-            api_version="2024-12-01-preview",
+            api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview"),
             azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
             api_key=os.environ["AZURE_OPENAI_API_KEY"],
             azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
@@ -169,8 +169,11 @@ def main() -> None:
     finally:
         # Cleanup
         print("Cleaning up...")
-        cosmos_client.delete_database(DATABASE_NAME)
-        print("Done! Database deleted.")
+        try:
+            cosmos_client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langchain_rag_chatbot.py
+++ b/samples/cosmosdb-nosql/langchain_rag_chatbot.py
@@ -22,7 +22,6 @@ from azure.cosmos import CosmosClient, PartitionKey
 from dotenv import load_dotenv
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.runnables import RunnablePassthrough
 from langchain_openai import AzureChatOpenAI, AzureOpenAIEmbeddings
 
 from langchain_azure_cosmosdb import (

--- a/samples/cosmosdb-nosql/langchain_rag_chatbot.py
+++ b/samples/cosmosdb-nosql/langchain_rag_chatbot.py
@@ -1,0 +1,177 @@
+"""RAG Chatbot with CosmosDB Vector Store and Chat History.
+
+End-to-end sample combining AzureCosmosDBNoSqlVectorSearch for retrieval
+and CosmosDBChatMessageHistory for conversation memory.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT                  - CosmosDB account endpoint
+    COSMOSDB_KEY                       - CosmosDB account key
+    AZURE_OPENAI_ENDPOINT              - Azure OpenAI endpoint
+    AZURE_OPENAI_API_KEY               - Azure OpenAI API key
+    AZURE_OPENAI_CHAT_DEPLOYMENT       - Chat model deployment name
+    AZURE_OPENAI_EMBEDDING_DEPLOYMENT  - Embedding model deployment name
+"""
+
+import os
+
+from azure.cosmos import CosmosClient, PartitionKey
+from dotenv import load_dotenv
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.runnables import RunnablePassthrough
+from langchain_openai import AzureChatOpenAI, AzureOpenAIEmbeddings
+
+from langchain_azure_cosmosdb import (
+    AzureCosmosDBNoSqlVectorSearch,
+    CosmosDBChatMessageHistory,
+)
+
+load_dotenv()
+
+DATABASE_NAME = "sample-rag-chatbot-db"
+VS_CONTAINER = "rag-vectorstore"
+HISTORY_CONTAINER = "rag-chathistory"
+
+
+def create_vectorstore(cosmos_client: CosmosClient) -> AzureCosmosDBNoSqlVectorSearch:
+    """Create and populate a vector store with sample documents."""
+    embedding = AzureOpenAIEmbeddings(
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_key=os.environ["AZURE_OPENAI_API_KEY"],
+        azure_deployment=os.environ["AZURE_OPENAI_EMBEDDING_DEPLOYMENT"],
+    )
+
+    vectorstore = AzureCosmosDBNoSqlVectorSearch(
+        cosmos_client=cosmos_client,
+        embedding=embedding,
+        vector_embedding_policy={
+            "vectorEmbeddings": [
+                {
+                    "path": "/embedding",
+                    "dataType": "float32",
+                    "distanceFunction": "cosine",
+                    "dimensions": 1536,
+                }
+            ]
+        },
+        indexing_policy={
+            "indexingMode": "consistent",
+            "includedPaths": [{"path": "/*"}],
+            "excludedPaths": [{"path": '/"_etag"/?'}],
+            "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}],
+        },
+        cosmos_container_properties={"partition_key": PartitionKey(path="/id")},
+        cosmos_database_properties={"id": DATABASE_NAME},
+        vector_search_fields={"text_field": "text", "embedding_field": "embedding"},
+        database_name=DATABASE_NAME,
+        container_name=VS_CONTAINER,
+    )
+
+    # Add sample knowledge base
+    docs = [
+        "Azure CosmosDB is a globally distributed, multi-model database. "
+        "It supports NoSQL, MongoDB, PostgreSQL, and Apache Gremlin APIs.",
+        "CosmosDB offers single-digit millisecond response times and "
+        "99.999% availability SLA with turnkey global distribution.",
+        "CosmosDB vector search supports DiskANN, flat, and quantized flat "
+        "index types for efficient similarity search on embeddings.",
+        "CosmosDB pricing is based on Request Units (RUs). You can choose "
+        "between provisioned throughput and serverless modes.",
+        "CosmosDB supports automatic indexing of all properties by default. "
+        "You can customize indexing policy for better performance.",
+    ]
+    vectorstore.add_texts(texts=docs)
+    print(f"Loaded {len(docs)} documents into vector store.\n")
+    return vectorstore
+
+
+def main() -> None:
+    """Run the RAG chatbot."""
+    cosmos_client = CosmosClient(
+        os.environ["COSMOSDB_ENDPOINT"],
+        os.environ["COSMOSDB_KEY"],
+    )
+    try:
+        llm = AzureChatOpenAI(
+            api_version="2024-12-01-preview",
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
+        )
+
+        # Set up vector store and retriever
+        vectorstore = create_vectorstore(cosmos_client)
+        retriever = vectorstore.as_retriever(search_kwargs={"k": 3})
+
+        # Set up chat history
+        history = CosmosDBChatMessageHistory(
+            cosmos_endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            credential=os.environ["COSMOSDB_KEY"],
+            cosmos_database=DATABASE_NAME,
+            cosmos_container=HISTORY_CONTAINER,
+            session_id="rag-session-001",
+            user_id="demo-user",
+        )
+        history.prepare_cosmos()
+
+        # Build the RAG chain
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "You are a helpful assistant that answers questions about "
+                    "Azure CosmosDB using the provided context. Be concise.\n\n"
+                    "Context:\n{context}",
+                ),
+                MessagesPlaceholder("history"),
+                ("human", "{question}"),
+            ]
+        )
+
+        def format_docs(docs: list) -> str:
+            return "\n\n".join(doc.page_content for doc in docs)
+
+        chain = (
+            {
+                "context": lambda x: format_docs(retriever.invoke(x["question"])),
+                "question": lambda x: x["question"],
+                "history": lambda x: x["history"],
+            }
+            | prompt
+            | llm
+            | StrOutputParser()
+        )
+
+        # Interactive chat loop
+        print(
+            "CosmosDB RAG Chatbot ready! Ask questions about Azure CosmosDB.\n"
+            "Press Enter to quit.\n"
+        )
+
+        while True:
+            user_input = input("You: ")
+            if not user_input.strip():
+                print("\nGoodbye!")
+                break
+
+            history.add_user_message(user_input)
+
+            response = chain.invoke(
+                {"question": user_input, "history": history.messages[:-1]}
+            )
+
+            history.add_ai_message(response)
+            print(f"AI: {response}\n")
+    finally:
+        # Cleanup
+        print("Cleaning up...")
+        cosmos_client.delete_database(DATABASE_NAME)
+        print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/cosmosdb-nosql/langchain_semantic_cache.py
+++ b/samples/cosmosdb-nosql/langchain_semantic_cache.py
@@ -46,7 +46,7 @@ def main() -> None:
         )
 
         llm = AzureChatOpenAI(
-            api_version="2024-12-01-preview",
+            api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview"),
             azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
             api_key=os.environ["AZURE_OPENAI_API_KEY"],
             azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
@@ -123,8 +123,11 @@ def main() -> None:
     finally:
         # --- Cleanup ---
         print("Cleaning up...")
-        cosmos_client.delete_database(DATABASE_NAME)
-        print("Done! Database deleted.")
+        try:
+            cosmos_client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langchain_semantic_cache.py
+++ b/samples/cosmosdb-nosql/langchain_semantic_cache.py
@@ -1,0 +1,131 @@
+"""Azure CosmosDB NoSQL Semantic Cache sample.
+
+Demonstrates using CosmosDB as a semantic cache for LLM responses, showing
+cache hits and misses with latency comparison.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT                  - CosmosDB account endpoint
+    COSMOSDB_KEY                       - CosmosDB account key
+    AZURE_OPENAI_ENDPOINT              - Azure OpenAI endpoint
+    AZURE_OPENAI_API_KEY               - Azure OpenAI API key
+    AZURE_OPENAI_CHAT_DEPLOYMENT       - Chat model deployment name
+    AZURE_OPENAI_EMBEDDING_DEPLOYMENT  - Embedding model deployment name
+"""
+
+import os
+import time
+
+from azure.cosmos import CosmosClient, PartitionKey
+from dotenv import load_dotenv
+from langchain_core.globals import set_llm_cache
+from langchain_openai import AzureChatOpenAI, AzureOpenAIEmbeddings
+
+from langchain_azure_cosmosdb import AzureCosmosDBNoSqlSemanticCache
+
+load_dotenv()
+
+DATABASE_NAME = "sample-cache-db"
+CONTAINER_NAME = "sample-cache-container"
+
+
+def main() -> None:
+    """Run semantic cache sample."""
+    cosmos_client = CosmosClient(
+        os.environ["COSMOSDB_ENDPOINT"],
+        os.environ["COSMOSDB_KEY"],
+    )
+    try:
+        embedding = AzureOpenAIEmbeddings(
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_deployment=os.environ["AZURE_OPENAI_EMBEDDING_DEPLOYMENT"],
+        )
+
+        llm = AzureChatOpenAI(
+            api_version="2024-12-01-preview",
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
+        )
+
+        # --- Set up semantic cache ---
+        cosmos_container_properties = {"partition_key": PartitionKey(path="/id")}
+        vector_embedding_policy = {
+            "vectorEmbeddings": [
+                {
+                    "path": "/embedding",
+                    "dataType": "float32",
+                    "distanceFunction": "cosine",
+                    "dimensions": 1536,
+                }
+            ]
+        }
+        indexing_policy = {
+            "indexingMode": "consistent",
+            "includedPaths": [{"path": "/*"}],
+            "excludedPaths": [{"path": '/"_etag"/?'}],
+            "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}],
+        }
+
+        cache = AzureCosmosDBNoSqlSemanticCache(
+            cosmos_client=cosmos_client,
+            embedding=embedding,
+            vector_embedding_policy=vector_embedding_policy,
+            indexing_policy=indexing_policy,
+            cosmos_container_properties=cosmos_container_properties,
+            cosmos_database_properties={"id": DATABASE_NAME},
+            vector_search_fields={
+                "text_field": "text",
+                "embedding_field": "embedding",
+            },
+            database_name=DATABASE_NAME,
+            container_name=CONTAINER_NAME,
+        )
+
+        set_llm_cache(cache)
+        print("Semantic cache configured.\n")
+
+        # --- First call: cache miss ---
+        prompt = "What is Azure CosmosDB in one sentence?"
+        print(f"Prompt: '{prompt}'")
+
+        start = time.time()
+        response1 = llm.invoke(prompt)
+        elapsed1 = time.time() - start
+        print(f"  Response: {response1.content}")
+        print(f"  Time: {elapsed1:.2f}s (cache MISS — called LLM)\n")
+
+        # --- Second call: cache hit (exact same prompt) ---
+        print(f"Prompt (same): '{prompt}'")
+        start = time.time()
+        response2 = llm.invoke(prompt)
+        elapsed2 = time.time() - start
+        print(f"  Response: {response2.content}")
+        print(f"  Time: {elapsed2:.2f}s (cache HIT — no LLM call)\n")
+
+        # --- Third call: semantically similar prompt ---
+        similar_prompt = "Describe Azure Cosmos DB briefly."
+        print(f"Prompt (similar): '{similar_prompt}'")
+        start = time.time()
+        response3 = llm.invoke(similar_prompt)
+        elapsed3 = time.time() - start
+        print(f"  Response: {response3.content}")
+        print(f"  Time: {elapsed3:.2f}s (likely cache HIT — semantically similar)\n")
+
+        # --- Clear cache ---
+        print("Clearing cache...")
+        cache.clear()
+        print("Cache cleared.\n")
+    finally:
+        # --- Cleanup ---
+        print("Cleaning up...")
+        cosmos_client.delete_database(DATABASE_NAME)
+        print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/cosmosdb-nosql/langchain_vectorstore.py
+++ b/samples/cosmosdb-nosql/langchain_vectorstore.py
@@ -137,8 +137,9 @@ def main() -> None:
 
         # --- Full-text search ---
         print("=== Full-Text Search ===")
-        vectorstore._search_type = "full_text_search"
-        results = vectorstore.similarity_search("framework LLM", k=3)
+        results = vectorstore.similarity_search(
+            "framework LLM", k=3, search_type="full_text_search"
+        )
         for i, doc in enumerate(results, 1):
             print(f"  {i}. {doc.page_content}")
         print()
@@ -173,8 +174,11 @@ def main() -> None:
     finally:
         # --- Cleanup ---
         print("Cleaning up...")
-        cosmos_client.delete_database(DATABASE_NAME)
-    print("Done! Database deleted.")
+        try:
+            cosmos_client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langchain_vectorstore.py
+++ b/samples/cosmosdb-nosql/langchain_vectorstore.py
@@ -1,0 +1,181 @@
+"""Azure CosmosDB NoSQL Vector Store sample.
+
+Demonstrates vector, full-text, hybrid, and weighted hybrid search using
+Azure CosmosDB NoSQL as the vector store with Azure OpenAI embeddings.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT               - CosmosDB account endpoint
+    COSMOSDB_KEY                    - CosmosDB account key
+    AZURE_OPENAI_ENDPOINT           - Azure OpenAI endpoint
+    AZURE_OPENAI_API_KEY            - Azure OpenAI API key
+    AZURE_OPENAI_EMBEDDING_DEPLOYMENT - Embedding model deployment name
+"""
+
+import os
+
+from azure.cosmos import CosmosClient, PartitionKey
+from dotenv import load_dotenv
+from langchain_openai import AzureOpenAIEmbeddings
+
+from langchain_azure_cosmosdb import AzureCosmosDBNoSqlVectorSearch
+
+load_dotenv()
+
+DATABASE_NAME = "sample-vectorstore-db"
+CONTAINER_NAME = "sample-vectorstore-container"
+
+
+def get_embedding_model() -> AzureOpenAIEmbeddings:
+    """Create an Azure OpenAI embedding model."""
+    return AzureOpenAIEmbeddings(
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_key=os.environ["AZURE_OPENAI_API_KEY"],
+        azure_deployment=os.environ["AZURE_OPENAI_EMBEDDING_DEPLOYMENT"],
+    )
+
+
+def create_vectorstore(
+    cosmos_client: CosmosClient,
+    embedding: AzureOpenAIEmbeddings,
+) -> AzureCosmosDBNoSqlVectorSearch:
+    """Create a CosmosDB vector store with vector + full-text search enabled."""
+    vector_embedding_policy = {
+        "vectorEmbeddings": [
+            {
+                "path": "/embedding",
+                "dataType": "float32",
+                "distanceFunction": "cosine",
+                "dimensions": 1536,
+            }
+        ]
+    }
+
+    full_text_policy = {
+        "defaultLanguage": "en-US",
+        "fullTextPaths": [{"path": "/text", "language": "en-US"}],
+    }
+
+    indexing_policy = {
+        "indexingMode": "consistent",
+        "includedPaths": [{"path": "/*"}],
+        "excludedPaths": [{"path": '/"_etag"/?'}],
+        "vectorIndexes": [{"path": "/embedding", "type": "diskANN"}],
+        "fullTextIndexes": [{"path": "/text"}],
+    }
+
+    cosmos_container_properties = {"partition_key": PartitionKey(path="/id")}
+    cosmos_database_properties = {"id": DATABASE_NAME}
+
+    vector_search_fields = {
+        "text_field": "text",
+        "embedding_field": "embedding",
+    }
+
+    return AzureCosmosDBNoSqlVectorSearch(
+        cosmos_client=cosmos_client,
+        embedding=embedding,
+        vector_embedding_policy=vector_embedding_policy,
+        full_text_policy=full_text_policy,
+        indexing_policy=indexing_policy,
+        cosmos_container_properties=cosmos_container_properties,
+        cosmos_database_properties=cosmos_database_properties,
+        vector_search_fields=vector_search_fields,
+        database_name=DATABASE_NAME,
+        container_name=CONTAINER_NAME,
+        full_text_search_enabled=True,
+    )
+
+
+def main() -> None:
+    """Run vector store sample."""
+    cosmos_client = CosmosClient(
+        os.environ["COSMOSDB_ENDPOINT"],
+        os.environ["COSMOSDB_KEY"],
+    )
+    try:
+        embedding = get_embedding_model()
+        vectorstore = create_vectorstore(cosmos_client, embedding)
+
+        # --- Add documents ---
+        texts = [
+            "Azure CosmosDB is a globally distributed, multi-model database service.",
+            "LangChain is a framework for building applications with LLMs.",
+            "Vector search enables similarity-based retrieval using embeddings.",
+            "Python is a versatile programming language for data science and AI.",
+            "Azure OpenAI provides access to GPT models via Azure cloud.",
+        ]
+        metadatas = [
+            {"source": "azure-docs", "topic": "database"},
+            {"source": "langchain-docs", "topic": "framework"},
+            {"source": "search-docs", "topic": "search"},
+            {"source": "python-docs", "topic": "language"},
+            {"source": "azure-docs", "topic": "ai"},
+        ]
+
+        print("Adding documents...")
+        ids = vectorstore.add_texts(texts=texts, metadatas=metadatas)
+        print(f"Added {len(ids)} documents: {ids}\n")
+
+        # --- Vector similarity search ---
+        print("=== Vector Similarity Search ===")
+        query = "What is CosmosDB?"
+        results = vectorstore.similarity_search(query, k=3)
+        for i, doc in enumerate(results, 1):
+            print(f"  {i}. {doc.page_content}")
+        print()
+
+        # --- Vector similarity search with scores ---
+        print("=== Vector Search with Scores ===")
+        results_with_scores = vectorstore.similarity_search_with_score(query, k=3)
+        for i, (doc, score) in enumerate(results_with_scores, 1):
+            print(f"  {i}. [score={score:.4f}] {doc.page_content}")
+        print()
+
+        # --- Full-text search ---
+        print("=== Full-Text Search ===")
+        vectorstore._search_type = "full_text_search"
+        results = vectorstore.similarity_search("framework LLM", k=3)
+        for i, doc in enumerate(results, 1):
+            print(f"  {i}. {doc.page_content}")
+        print()
+
+        # --- Hybrid search (vector + full-text with RRF) ---
+        print("=== Hybrid Search ===")
+        full_text_filter = [{"search_field": "text", "search_text": "Azure database"}]
+        results = vectorstore.similarity_search(
+            "Azure cloud database",
+            k=3,
+            search_type="hybrid",
+            full_text_rank_filter=full_text_filter,
+        )
+        for i, doc in enumerate(results, 1):
+            print(f"  {i}. {doc.page_content}")
+        print()
+
+        # --- Weighted hybrid search ---
+        print("=== Weighted Hybrid Search (70% vector, 30% full-text) ===")
+        results = vectorstore.similarity_search(
+            "Azure AI services",
+            k=3,
+            search_type="hybrid",
+            full_text_rank_filter=[
+                {"search_field": "text", "search_text": "Azure AI"}
+            ],
+            weights=[0.3, 0.7],  # [FullTextScore weight, VectorDistance weight]
+        )
+        for i, doc in enumerate(results, 1):
+            print(f"  {i}. {doc.page_content}")
+        print()
+    finally:
+        # --- Cleanup ---
+        print("Cleaning up...")
+        cosmos_client.delete_database(DATABASE_NAME)
+    print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/cosmosdb-nosql/langgraph_cache.py
+++ b/samples/cosmosdb-nosql/langgraph_cache.py
@@ -1,0 +1,102 @@
+"""LangGraph Cache with CosmosDB (Sync).
+
+Demonstrates using CosmosDBCacheSync to cache LangGraph graph node results,
+showing cache hits vs misses and TTL-based expiration.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT                  - CosmosDB account endpoint
+    COSMOSDB_KEY                       - CosmosDB account key
+    AZURE_OPENAI_ENDPOINT              - Azure OpenAI endpoint
+    AZURE_OPENAI_API_KEY               - Azure OpenAI API key
+    AZURE_OPENAI_CHAT_DEPLOYMENT       - Chat model deployment name
+"""
+
+import os
+import time
+from typing import Annotated
+
+from dotenv import load_dotenv
+from langchain_openai import AzureChatOpenAI
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from typing_extensions import TypedDict
+
+from langchain_azure_cosmosdb import CosmosDBCacheSync
+
+load_dotenv()
+
+DATABASE_NAME = "sample-lgcache-db"
+CONTAINER_NAME = "sample-lgcache"
+
+
+class State(TypedDict):
+    """Graph state."""
+
+    messages: Annotated[list, add_messages]
+
+
+def main() -> None:
+    """Run the LangGraph cache sample."""
+    from azure.cosmos import CosmosClient
+
+    cleanup_client = CosmosClient(
+        os.environ["COSMOSDB_ENDPOINT"],
+        os.environ["COSMOSDB_KEY"],
+    )
+    try:
+        llm = AzureChatOpenAI(
+            api_version="2024-12-01-preview",
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
+        )
+
+        # Create cache
+        cache = CosmosDBCacheSync(
+            database_name=DATABASE_NAME,
+            container_name=CONTAINER_NAME,
+            endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            key=os.environ["COSMOSDB_KEY"],
+        )
+
+        def chatbot(state: State) -> dict:
+            response = llm.invoke(state["messages"])
+            return {"messages": [response]}
+
+        graph = StateGraph(State)
+        graph.add_node("chatbot", chatbot)
+        graph.add_edge(START, "chatbot")
+        graph.add_edge("chatbot", END)
+        app = graph.compile(cache=cache)
+
+        config = {"configurable": {"thread_id": "cache-demo"}}
+        input_msg = {"messages": [("user", "What is 2 + 2?")]}
+
+        # --- First invocation: cache miss ---
+        print("=== First Invocation (cache miss) ===")
+        start = time.time()
+        result = app.invoke(input_msg, config=config)
+        elapsed = time.time() - start
+        print(f"  Response: {result['messages'][-1].content}")
+        print(f"  Time: {elapsed:.2f}s\n")
+
+        # --- Second invocation: cache hit ---
+        print("=== Second Invocation (cache hit) ===")
+        start = time.time()
+        result = app.invoke(input_msg, config=config)
+        elapsed = time.time() - start
+        print(f"  Response: {result['messages'][-1].content}")
+        print(f"  Time: {elapsed:.2f}s (should be faster)\n")
+    finally:
+        # --- Cleanup ---
+        print("Cleaning up...")
+        cleanup_client.delete_database(DATABASE_NAME)
+        print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/cosmosdb-nosql/langgraph_cache.py
+++ b/samples/cosmosdb-nosql/langgraph_cache.py
@@ -49,7 +49,7 @@ def main() -> None:
     )
     try:
         llm = AzureChatOpenAI(
-            api_version="2024-12-01-preview",
+            api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview"),
             azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
             api_key=os.environ["AZURE_OPENAI_API_KEY"],
             azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
@@ -94,8 +94,11 @@ def main() -> None:
     finally:
         # --- Cleanup ---
         print("Cleaning up...")
-        cleanup_client.delete_database(DATABASE_NAME)
-        print("Done! Database deleted.")
+        try:
+            cleanup_client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langgraph_cache_async.py
+++ b/samples/cosmosdb-nosql/langgraph_cache_async.py
@@ -46,7 +46,7 @@ async def main() -> None:
 
     try:
         llm = AzureChatOpenAI(
-            api_version="2024-12-01-preview",
+            api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview"),
             azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
             api_key=os.environ["AZURE_OPENAI_API_KEY"],
             azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
@@ -59,8 +59,8 @@ async def main() -> None:
             container_name=CONTAINER_NAME,
         ) as cache:
 
-            def chatbot(state: State) -> dict:
-                response = llm.invoke(state["messages"])
+            async def chatbot(state: State) -> dict:
+                response = await llm.ainvoke(state["messages"])
                 return {"messages": [response]}
 
             graph = StateGraph(State)
@@ -90,12 +90,15 @@ async def main() -> None:
     finally:
         # Cleanup
         print("Cleaning up...")
-        async with AsyncCosmosClient(
-            os.environ["COSMOSDB_ENDPOINT"],
-            os.environ["COSMOSDB_KEY"],
-        ) as client:
-            await client.delete_database(DATABASE_NAME)
-        print("Done! Database deleted.")
+        try:
+            async with AsyncCosmosClient(
+                os.environ["COSMOSDB_ENDPOINT"],
+                os.environ["COSMOSDB_KEY"],
+            ) as client:
+                await client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langgraph_cache_async.py
+++ b/samples/cosmosdb-nosql/langgraph_cache_async.py
@@ -1,0 +1,102 @@
+"""LangGraph Cache with CosmosDB (Async).
+
+Async version of the LangGraph cache sample using CosmosDBCache with
+the ``from_conn_info`` async context manager.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT                  - CosmosDB account endpoint
+    COSMOSDB_KEY                       - CosmosDB account key
+    AZURE_OPENAI_ENDPOINT              - Azure OpenAI endpoint
+    AZURE_OPENAI_API_KEY               - Azure OpenAI API key
+    AZURE_OPENAI_CHAT_DEPLOYMENT       - Chat model deployment name
+"""
+
+import asyncio
+import os
+import time
+from typing import Annotated
+
+from dotenv import load_dotenv
+from langchain_openai import AzureChatOpenAI
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from typing_extensions import TypedDict
+
+from langchain_azure_cosmosdb import CosmosDBCache
+
+load_dotenv()
+
+DATABASE_NAME = "sample-async-lgcache-db"
+CONTAINER_NAME = "sample-async-lgcache"
+
+
+class State(TypedDict):
+    """Graph state."""
+
+    messages: Annotated[list, add_messages]
+
+
+async def main() -> None:
+    """Run the async LangGraph cache sample."""
+    from azure.cosmos.aio import CosmosClient as AsyncCosmosClient
+
+    try:
+        llm = AzureChatOpenAI(
+            api_version="2024-12-01-preview",
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
+        )
+
+        async with CosmosDBCache.from_conn_info(
+            endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            key=os.environ["COSMOSDB_KEY"],
+            database_name=DATABASE_NAME,
+            container_name=CONTAINER_NAME,
+        ) as cache:
+
+            def chatbot(state: State) -> dict:
+                response = llm.invoke(state["messages"])
+                return {"messages": [response]}
+
+            graph = StateGraph(State)
+            graph.add_node("chatbot", chatbot)
+            graph.add_edge(START, "chatbot")
+            graph.add_edge("chatbot", END)
+            app = graph.compile(cache=cache)
+
+            config = {"configurable": {"thread_id": "async-cache-demo"}}
+            input_msg = {"messages": [("user", "What is the capital of France?")]}
+
+            # First invocation: cache miss
+            print("=== First Invocation (cache miss) ===")
+            start = time.time()
+            result = await app.ainvoke(input_msg, config=config)
+            elapsed = time.time() - start
+            print(f"  Response: {result['messages'][-1].content}")
+            print(f"  Time: {elapsed:.2f}s\n")
+
+            # Second invocation: cache hit
+            print("=== Second Invocation (cache hit) ===")
+            start = time.time()
+            result = await app.ainvoke(input_msg, config=config)
+            elapsed = time.time() - start
+            print(f"  Response: {result['messages'][-1].content}")
+            print(f"  Time: {elapsed:.2f}s (should be faster)\n")
+    finally:
+        # Cleanup
+        print("Cleaning up...")
+        async with AsyncCosmosClient(
+            os.environ["COSMOSDB_ENDPOINT"],
+            os.environ["COSMOSDB_KEY"],
+        ) as client:
+            await client.delete_database(DATABASE_NAME)
+        print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/cosmosdb-nosql/langgraph_checkpointer.py
+++ b/samples/cosmosdb-nosql/langgraph_checkpointer.py
@@ -42,7 +42,7 @@ class State(TypedDict):
 def create_graph(checkpointer: CosmosDBSaverSync) -> StateGraph:
     """Build a simple chatbot graph with CosmosDB checkpointing."""
     llm = AzureChatOpenAI(
-        api_version="2024-12-01-preview",
+        api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview"),
         azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
         api_key=os.environ["AZURE_OPENAI_API_KEY"],
         azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
@@ -124,8 +124,11 @@ def main() -> None:
     finally:
         # --- Cleanup ---
         print("Cleaning up...")
-        cleanup_client.delete_database(DATABASE_NAME)
-        print("Done! Database deleted.")
+        try:
+            cleanup_client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langgraph_checkpointer.py
+++ b/samples/cosmosdb-nosql/langgraph_checkpointer.py
@@ -17,7 +17,7 @@ Environment variables:
 """
 
 import os
-from typing import Annotated
+from typing import Annotated, Any
 
 from dotenv import load_dotenv
 from langchain_openai import AzureChatOpenAI
@@ -39,7 +39,7 @@ class State(TypedDict):
     messages: Annotated[list, add_messages]
 
 
-def create_graph(checkpointer: CosmosDBSaverSync) -> StateGraph:
+def create_graph(checkpointer: CosmosDBSaverSync) -> Any:
     """Build a simple chatbot graph with CosmosDB checkpointing."""
     llm = AzureChatOpenAI(
         api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview"),

--- a/samples/cosmosdb-nosql/langgraph_checkpointer.py
+++ b/samples/cosmosdb-nosql/langgraph_checkpointer.py
@@ -1,0 +1,132 @@
+"""LangGraph Checkpointer with CosmosDB (Sync).
+
+End-to-end sample showing a multi-turn chatbot with state persistence
+using CosmosDBSaverSync. Demonstrates thread-based memory, state
+inspection, and state history.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT                  - CosmosDB account endpoint
+    COSMOSDB_KEY                       - CosmosDB account key
+    AZURE_OPENAI_ENDPOINT              - Azure OpenAI endpoint
+    AZURE_OPENAI_API_KEY               - Azure OpenAI API key
+    AZURE_OPENAI_CHAT_DEPLOYMENT       - Chat model deployment name
+"""
+
+import os
+from typing import Annotated
+
+from dotenv import load_dotenv
+from langchain_openai import AzureChatOpenAI
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from typing_extensions import TypedDict
+
+from langchain_azure_cosmosdb import CosmosDBSaverSync
+
+load_dotenv()
+
+DATABASE_NAME = "sample-checkpointer-db"
+CONTAINER_NAME = "sample-checkpoints"
+
+
+class State(TypedDict):
+    """Graph state with message history."""
+
+    messages: Annotated[list, add_messages]
+
+
+def create_graph(checkpointer: CosmosDBSaverSync) -> StateGraph:
+    """Build a simple chatbot graph with CosmosDB checkpointing."""
+    llm = AzureChatOpenAI(
+        api_version="2024-12-01-preview",
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_key=os.environ["AZURE_OPENAI_API_KEY"],
+        azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
+    )
+
+    def chatbot(state: State) -> dict:
+        response = llm.invoke(state["messages"])
+        return {"messages": [response]}
+
+    graph = StateGraph(State)
+    graph.add_node("chatbot", chatbot)
+    graph.add_edge(START, "chatbot")
+    graph.add_edge("chatbot", END)
+
+    return graph.compile(checkpointer=checkpointer)
+
+
+def main() -> None:
+    """Run the checkpointer sample."""
+    from azure.cosmos import CosmosClient
+
+    cleanup_client = CosmosClient(
+        os.environ["COSMOSDB_ENDPOINT"],
+        os.environ["COSMOSDB_KEY"],
+    )
+    try:
+        # --- Create checkpointer ---
+        checkpointer = CosmosDBSaverSync(
+            database_name=DATABASE_NAME,
+            container_name=CONTAINER_NAME,
+            endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            key=os.environ["COSMOSDB_KEY"],
+        )
+
+        graph = create_graph(checkpointer)
+        thread_config = {"configurable": {"thread_id": "demo-thread-1"}}
+
+        # --- Turn 1 ---
+        print("=== Turn 1 ===")
+        result = graph.invoke(
+            {"messages": [("user", "Hi! My name is Alice.")]},
+            config=thread_config,
+        )
+        print(f"AI: {result['messages'][-1].content}\n")
+
+        # --- Turn 2: The bot should remember the name ---
+        print("=== Turn 2 (bot should remember name) ===")
+        result = graph.invoke(
+            {"messages": [("user", "What's my name?")]},
+            config=thread_config,
+        )
+        print(f"AI: {result['messages'][-1].content}\n")
+
+        # --- Inspect current state ---
+        print("=== Current State ===")
+        state = graph.get_state(thread_config)
+        print(f"  Thread ID: {state.config['configurable']['thread_id']}")
+        print(f"  Checkpoint ID: {state.config['configurable']['checkpoint_id']}")
+        print(f"  Number of messages: {len(state.values['messages'])}")
+        print(f"  Next nodes: {state.next}\n")
+
+        # --- State history ---
+        print("=== State History ===")
+        for i, snapshot in enumerate(graph.get_state_history(thread_config)):
+            print(
+                f"  Checkpoint {i}: step={snapshot.metadata.get('step', '?')}, "
+                f"messages={len(snapshot.values.get('messages', []))}"
+            )
+        print()
+
+        # --- Different thread (no memory from thread 1) ---
+        print("=== New Thread (no memory) ===")
+        thread_config_2 = {"configurable": {"thread_id": "demo-thread-2"}}
+        result = graph.invoke(
+            {"messages": [("user", "What's my name?")]},
+            config=thread_config_2,
+        )
+        print(f"AI: {result['messages'][-1].content}\n")
+    finally:
+        # --- Cleanup ---
+        print("Cleaning up...")
+        cleanup_client.delete_database(DATABASE_NAME)
+        print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/cosmosdb-nosql/langgraph_checkpointer_async.py
+++ b/samples/cosmosdb-nosql/langgraph_checkpointer_async.py
@@ -1,0 +1,120 @@
+"""LangGraph Checkpointer with CosmosDB (Async).
+
+Async version of the checkpointer sample using CosmosDBSaver with the
+``from_conn_info`` async context manager.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT                  - CosmosDB account endpoint
+    COSMOSDB_KEY                       - CosmosDB account key
+    AZURE_OPENAI_ENDPOINT              - Azure OpenAI endpoint
+    AZURE_OPENAI_API_KEY               - Azure OpenAI API key
+    AZURE_OPENAI_CHAT_DEPLOYMENT       - Chat model deployment name
+"""
+
+import asyncio
+import os
+from typing import Annotated
+
+from dotenv import load_dotenv
+from langchain_openai import AzureChatOpenAI
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from typing_extensions import TypedDict
+
+from langchain_azure_cosmosdb import CosmosDBSaver
+
+load_dotenv()
+
+DATABASE_NAME = "sample-async-checkpointer-db"
+CONTAINER_NAME = "sample-async-checkpoints"
+
+
+class State(TypedDict):
+    """Graph state with message history."""
+
+    messages: Annotated[list, add_messages]
+
+
+async def main() -> None:
+    """Run the async checkpointer sample."""
+    from azure.cosmos.aio import CosmosClient as AsyncCosmosClient
+
+    try:
+        llm = AzureChatOpenAI(
+            api_version="2024-12-01-preview",
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
+        )
+
+        def chatbot(state: State) -> dict:
+            response = llm.invoke(state["messages"])
+            return {"messages": [response]}
+
+        # --- Use async context manager ---
+        async with CosmosDBSaver.from_conn_info(
+            endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            key=os.environ["COSMOSDB_KEY"],
+            database_name=DATABASE_NAME,
+            container_name=CONTAINER_NAME,
+        ) as checkpointer:
+            graph = StateGraph(State)
+            graph.add_node("chatbot", chatbot)
+            graph.add_edge(START, "chatbot")
+            graph.add_edge("chatbot", END)
+            app = graph.compile(checkpointer=checkpointer)
+
+            thread_config = {"configurable": {"thread_id": "async-demo-thread"}}
+
+            # Turn 1
+            print("=== Turn 1 (async) ===")
+            result = await app.ainvoke(
+                {"messages": [("user", "Hi! I love hiking in the mountains.")]},
+                config=thread_config,
+            )
+            print(f"AI: {result['messages'][-1].content}\n")
+
+            # Turn 2: bot should remember
+            print("=== Turn 2 (bot should remember) ===")
+            result = await app.ainvoke(
+                {"messages": [("user", "What hobby did I mention?")]},
+                config=thread_config,
+            )
+            print(f"AI: {result['messages'][-1].content}\n")
+
+            # Inspect state
+            print("=== Current State ===")
+            state = await app.aget_state(thread_config)
+            print(f"  Messages: {len(state.values['messages'])}")
+            print(
+                f"  Checkpoint: {state.config['configurable']['checkpoint_id']}\n"
+            )
+
+            # State history
+            print("=== State History ===")
+            i = 0
+            async for snapshot in app.aget_state_history(thread_config):
+                print(
+                    f"  Checkpoint {i}: "
+                    f"step={snapshot.metadata.get('step', '?')}, "
+                    f"messages={len(snapshot.values.get('messages', []))}"
+                )
+                i += 1
+            print()
+    finally:
+        # Cleanup
+        print("Cleaning up...")
+        async with AsyncCosmosClient(
+            os.environ["COSMOSDB_ENDPOINT"],
+            os.environ["COSMOSDB_KEY"],
+        ) as client:
+            await client.delete_database(DATABASE_NAME)
+        print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/cosmosdb-nosql/langgraph_checkpointer_async.py
+++ b/samples/cosmosdb-nosql/langgraph_checkpointer_async.py
@@ -45,14 +45,14 @@ async def main() -> None:
 
     try:
         llm = AzureChatOpenAI(
-            api_version="2024-12-01-preview",
+            api_version=os.environ.get("AZURE_OPENAI_API_VERSION", "2024-12-01-preview"),
             azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
             api_key=os.environ["AZURE_OPENAI_API_KEY"],
             azure_deployment=os.environ["AZURE_OPENAI_CHAT_DEPLOYMENT"],
         )
 
-        def chatbot(state: State) -> dict:
-            response = llm.invoke(state["messages"])
+        async def chatbot(state: State) -> dict:
+            response = await llm.ainvoke(state["messages"])
             return {"messages": [response]}
 
         # --- Use async context manager ---
@@ -108,12 +108,15 @@ async def main() -> None:
     finally:
         # Cleanup
         print("Cleaning up...")
-        async with AsyncCosmosClient(
-            os.environ["COSMOSDB_ENDPOINT"],
-            os.environ["COSMOSDB_KEY"],
-        ) as client:
-            await client.delete_database(DATABASE_NAME)
-        print("Done! Database deleted.")
+        try:
+            async with AsyncCosmosClient(
+                os.environ["COSMOSDB_ENDPOINT"],
+                os.environ["COSMOSDB_KEY"],
+            ) as client:
+                await client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langgraph_store.py
+++ b/samples/cosmosdb-nosql/langgraph_store.py
@@ -1,0 +1,134 @@
+"""LangGraph Store with CosmosDB (Sync) — Long-Term Memory.
+
+End-to-end sample demonstrating CosmosDBStore for LangGraph long-term memory.
+Shows put/get/search/delete operations, namespace organization, and
+optional semantic search over stored items.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT                  - CosmosDB account endpoint
+    COSMOSDB_KEY                       - CosmosDB account key
+    AZURE_OPENAI_ENDPOINT              - Azure OpenAI endpoint
+    AZURE_OPENAI_API_KEY               - Azure OpenAI API key
+    AZURE_OPENAI_EMBEDDING_DEPLOYMENT  - Embedding model deployment name
+"""
+
+import os
+
+from dotenv import load_dotenv
+from langchain_openai import AzureOpenAIEmbeddings
+
+from langchain_azure_cosmosdb import CosmosDBStore
+
+load_dotenv()
+
+DATABASE_NAME = "sample-lgstore-db"
+CONTAINER_NAME = "sample-lgstore"
+
+
+def main() -> None:
+    """Run the LangGraph store sample."""
+    from azure.cosmos import CosmosClient
+
+    cleanup_client = CosmosClient(
+        os.environ["COSMOSDB_ENDPOINT"],
+        os.environ["COSMOSDB_KEY"],
+    )
+    try:
+        embedding = AzureOpenAIEmbeddings(
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_deployment=os.environ["AZURE_OPENAI_EMBEDDING_DEPLOYMENT"],
+        )
+
+        # --- Create store with vector search enabled ---
+        store = CosmosDBStore.from_endpoint(
+            endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            credential=os.environ["COSMOSDB_KEY"],
+            database_name=DATABASE_NAME,
+            container_name=CONTAINER_NAME,
+            index={
+                "dims": 1536,
+                "embed": embedding,
+                "fields": ["text"],
+            },
+        )
+        store.setup()
+        print("Store created and initialized.\n")
+
+        # --- Put: Store items under namespaces ---
+        print("=== Storing Items ===")
+        store.put(
+            ("users", "alice", "preferences"),
+            "coffee",
+            {"text": "Alice prefers dark roast coffee with oat milk."},
+        )
+        store.put(
+            ("users", "alice", "preferences"),
+            "travel",
+            {"text": "Alice likes budget travel and staying in hostels."},
+        )
+        store.put(
+            ("users", "alice", "notes"),
+            "meeting-2024-01",
+            {"text": "Discussed Q1 roadmap. Alice will lead the backend migration."},
+        )
+        store.put(
+            ("users", "bob", "preferences"),
+            "coffee",
+            {"text": "Bob drinks green tea, no coffee."},
+        )
+        print("  Stored 4 items across 3 namespaces.\n")
+
+        # --- Get: Retrieve a specific item ---
+        print("=== Get Item ===")
+        item = store.get(("users", "alice", "preferences"), "coffee")
+        if item:
+            print(f"  Key: {item.key}")
+            print(f"  Value: {item.value}")
+            print(f"  Namespace: {item.namespace}")
+            print(f"  Updated: {item.updated_at}\n")
+
+        # --- Search: Find items by namespace prefix ---
+        print("=== Search by Namespace ===")
+        results = store.search(("users", "alice"), limit=10)
+        print(f"  Found {len(results)} items under ('users', 'alice'):")
+        for r in results:
+            print(f"    [{'/'.join(r.namespace)}] {r.key}: {r.value}")
+        print()
+
+        # --- Semantic search ---
+        print("=== Semantic Search ===")
+        results = store.search(
+            ("users",),
+            query="What kind of beverages do people like?",
+            limit=3,
+        )
+        print(f"  Found {len(results)} results:")
+        for r in results:
+            score = getattr(r, "score", None)
+            print(f"    [score={score:.4f}] {r.key}: {r.value['text']}")
+        print()
+
+        # --- List namespaces ---
+        print("=== List Namespaces ===")
+        namespaces = store.list_namespaces(prefix=("users",))
+        print(f"  Namespaces under ('users',): {namespaces}\n")
+
+        # --- Delete ---
+        print("=== Delete Item ===")
+        store.delete(("users", "alice", "preferences"), "travel")
+        item = store.get(("users", "alice", "preferences"), "travel")
+        print(f"  After delete, item exists: {item is not None}\n")
+    finally:
+        # --- Cleanup ---
+        print("Cleaning up...")
+        cleanup_client.delete_database(DATABASE_NAME)
+        print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/cosmosdb-nosql/langgraph_store.py
+++ b/samples/cosmosdb-nosql/langgraph_store.py
@@ -110,7 +110,8 @@ def main() -> None:
         print(f"  Found {len(results)} results:")
         for r in results:
             score = getattr(r, "score", None)
-            print(f"    [score={score:.4f}] {r.key}: {r.value['text']}")
+            score_str = f"{score:.4f}" if score is not None else "N/A"
+            print(f"    [score={score_str}] {r.key}: {r.value['text']}")
         print()
 
         # --- List namespaces ---
@@ -126,8 +127,11 @@ def main() -> None:
     finally:
         # --- Cleanup ---
         print("Cleaning up...")
-        cleanup_client.delete_database(DATABASE_NAME)
-        print("Done! Database deleted.")
+        try:
+            cleanup_client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langgraph_store_async.py
+++ b/samples/cosmosdb-nosql/langgraph_store_async.py
@@ -1,7 +1,7 @@
 """LangGraph Store with CosmosDB (Async) — Long-Term Memory.
 
 Async version of the LangGraph store sample using AsyncCosmosDBStore
-with the ``from_conn_info`` async context manager.
+with the ``from_endpoint`` async context manager.
 
 Prerequisites:
     pip install -r requirements.txt

--- a/samples/cosmosdb-nosql/langgraph_store_async.py
+++ b/samples/cosmosdb-nosql/langgraph_store_async.py
@@ -99,7 +99,8 @@ async def main() -> None:
             print(f"  Found {len(results)} results:")
             for r in results:
                 score = getattr(r, "score", None)
-                print(f"    [score={score:.4f}] {r.key}: {r.value['text']}")
+                score_str = f"{score:.4f}" if score is not None else "N/A"
+                print(f"    [score={score_str}] {r.key}: {r.value['text']}")
             print()
 
             # --- Delete ---
@@ -110,12 +111,15 @@ async def main() -> None:
     finally:
         # Cleanup
         print("Cleaning up...")
-        async with AsyncCosmosClient(
-            os.environ["COSMOSDB_ENDPOINT"],
-            os.environ["COSMOSDB_KEY"],
-        ) as client:
-            await client.delete_database(DATABASE_NAME)
-        print("Done! Database deleted.")
+        try:
+            async with AsyncCosmosClient(
+                os.environ["COSMOSDB_ENDPOINT"],
+                os.environ["COSMOSDB_KEY"],
+            ) as client:
+                await client.delete_database(DATABASE_NAME)
+            print("Done! Database deleted.")
+        except Exception:
+            print("Database may not have been created; skipping cleanup.")
 
 
 if __name__ == "__main__":

--- a/samples/cosmosdb-nosql/langgraph_store_async.py
+++ b/samples/cosmosdb-nosql/langgraph_store_async.py
@@ -1,0 +1,122 @@
+"""LangGraph Store with CosmosDB (Async) — Long-Term Memory.
+
+Async version of the LangGraph store sample using AsyncCosmosDBStore
+with the ``from_conn_info`` async context manager.
+
+Prerequisites:
+    pip install -r requirements.txt
+    cp .env.example .env  # fill in your values
+
+Environment variables:
+    COSMOSDB_ENDPOINT                  - CosmosDB account endpoint
+    COSMOSDB_KEY                       - CosmosDB account key
+    AZURE_OPENAI_ENDPOINT              - Azure OpenAI endpoint
+    AZURE_OPENAI_API_KEY               - Azure OpenAI API key
+    AZURE_OPENAI_EMBEDDING_DEPLOYMENT  - Embedding model deployment name
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from langchain_openai import AzureOpenAIEmbeddings
+
+from langchain_azure_cosmosdb import AsyncCosmosDBStore
+
+load_dotenv()
+
+DATABASE_NAME = "sample-async-lgstore-db"
+CONTAINER_NAME = "sample-async-lgstore"
+
+
+async def main() -> None:
+    """Run the async LangGraph store sample."""
+    from azure.cosmos.aio import CosmosClient as AsyncCosmosClient
+
+    try:
+        embedding = AzureOpenAIEmbeddings(
+            azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+            api_key=os.environ["AZURE_OPENAI_API_KEY"],
+            azure_deployment=os.environ["AZURE_OPENAI_EMBEDDING_DEPLOYMENT"],
+        )
+
+        # --- Create async store with vector search ---
+        async with AsyncCosmosDBStore.from_endpoint(
+            endpoint=os.environ["COSMOSDB_ENDPOINT"],
+            credential=os.environ["COSMOSDB_KEY"],
+            database_name=DATABASE_NAME,
+            container_name=CONTAINER_NAME,
+            index={
+                "dims": 1536,
+                "embed": embedding,
+                "fields": ["text"],
+            },
+        ) as store:
+            await store.setup()
+            print("Async store created and initialized.\n")
+
+            # --- Put items ---
+            print("=== Storing Items (async) ===")
+            await store.aput(
+                ("users", "carol", "preferences"),
+                "food",
+                {"text": "Carol is vegetarian and loves Thai food."},
+            )
+            await store.aput(
+                ("users", "carol", "preferences"),
+                "music",
+                {"text": "Carol enjoys jazz and classical music."},
+            )
+            await store.aput(
+                ("users", "carol", "notes"),
+                "project-alpha",
+                {"text": "Carol is leading Project Alpha, launching in Q3."},
+            )
+            print("  Stored 3 items.\n")
+
+            # --- Get ---
+            print("=== Get Item (async) ===")
+            item = await store.aget(("users", "carol", "preferences"), "food")
+            if item:
+                print(f"  Key: {item.key}")
+                print(f"  Value: {item.value}\n")
+
+            # --- Search ---
+            print("=== Search by Namespace (async) ===")
+            results = await store.asearch(("users", "carol"), limit=10)
+            print(f"  Found {len(results)} items:")
+            for r in results:
+                print(f"    [{'/'.join(r.namespace)}] {r.key}: {r.value}")
+            print()
+
+            # --- Semantic search ---
+            print("=== Semantic Search (async) ===")
+            results = await store.asearch(
+                ("users",),
+                query="What kind of food does someone like?",
+                limit=3,
+            )
+            print(f"  Found {len(results)} results:")
+            for r in results:
+                score = getattr(r, "score", None)
+                print(f"    [score={score:.4f}] {r.key}: {r.value['text']}")
+            print()
+
+            # --- Delete ---
+            print("=== Delete Item (async) ===")
+            await store.adelete(("users", "carol", "preferences"), "music")
+            item = await store.aget(("users", "carol", "preferences"), "music")
+            print(f"  After delete, item exists: {item is not None}\n")
+    finally:
+        # Cleanup
+        print("Cleaning up...")
+        async with AsyncCosmosClient(
+            os.environ["COSMOSDB_ENDPOINT"],
+            os.environ["COSMOSDB_KEY"],
+        ) as client:
+            await client.delete_database(DATABASE_NAME)
+        print("Done! Database deleted.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/cosmosdb-nosql/requirements.txt
+++ b/samples/cosmosdb-nosql/requirements.txt
@@ -1,0 +1,4 @@
+langchain-azure-cosmosdb
+langchain-openai
+langgraph
+python-dotenv


### PR DESCRIPTION
## Add CosmosDB samples and improve package documentation

### Description

Adds comprehensive end-to-end samples for all `langchain-azure-cosmosdb` integrations and updates the package README with full usage documentation.

### Samples (`samples/cosmosdb-nosql/`)

10 runnable sample scripts covering every integration, with `try/finally` cleanup to ensure CosmosDB resources are always deleted:

**LangChain:**
| Sample | Integration |
|--------|------------|
| `langchain_vectorstore.py` | Vector, full-text, hybrid, and weighted hybrid search |
| `langchain_semantic_cache.py` | LLM semantic caching with cache hit/miss demo |
| `langchain_chat_history.py` | Chat message history with multi-session and TTL |
| `langchain_rag_chatbot.py` | End-to-end RAG chatbot (vectorstore + chat history) |

**LangGraph:**
| Sample | Integration |
|--------|------------|
| `langgraph_checkpointer.py` | Sync checkpointer — multi-turn memory, `get_state()`, `get_state_history()` |
| `langgraph_checkpointer_async.py` | Async checkpointer with `from_conn_info` context manager |
| `langgraph_cache.py` | Sync graph caching |
| `langgraph_cache_async.py` | Async graph caching |
| `langgraph_store.py` | Sync long-term memory with namespace organization and semantic search |
| `langgraph_store_async.py` | Async long-term memory |

### Package README (`libs/azure-cosmosdb/README.md`)

Updated with:
- Integrations table listing all 6 integrations with sync/async class names
- Usage examples for every integration with Sync/Async headers
- Authentication section (access key vs AAD/Managed Identity)
- 1.0.0 changelog entry
- Link to samples directory