### PR TITLE
`AzureAIProjectToolbox.get_tools_requiring_approval` method

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/tools/_toolbox.py
+++ b/libs/azure-ai/langchain_azure_ai/tools/_toolbox.py
@@ -54,6 +54,36 @@ def _build_toolbox_mcp_url(
     return f"{base}/toolboxes/{toolbox_name}/mcp?api-version={api_version}"
 
 
+async def _fetch_require_approval_tools(
+    endpoint: str,
+    auth: Any,
+    extra_headers: dict[str, str],
+) -> dict[str, str]:
+    """Fetch tool approval configuration from the toolbox MCP endpoint.
+
+    Returns a mapping of tool name to the ``require_approval`` value for
+    tools where that field is present.
+    """
+    try:
+        import httpx
+    except ImportError as ex:
+        raise ImportError(
+            "AzureAIProjectToolbox requires 'httpx'. "
+            "Install it with:\n  pip install httpx"
+        ) from ex
+
+    async with httpx.AsyncClient(auth=auth, headers=extra_headers, timeout=30.0) as hc:
+        payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+        resp = await hc.post(endpoint, json=payload)
+        resp.raise_for_status()
+
+    return {
+        t["name"]: t["_meta"]["tool_configuration"]["require_approval"]
+        for t in resp.json().get("result", {}).get("tools", [])
+        if t.get("_meta", {}).get("tool_configuration", {}).get("require_approval")
+    }
+
+
 # ── OAuth consent-error helpers ────────────────────────────────────────────────
 
 
@@ -249,13 +279,35 @@ class AzureAIProjectToolbox(BaseModel):
     def _build_mcp_client(self) -> Any:
         """Construct and return a ``MultiServerMCPClient`` for the toolbox endpoint."""
         try:
-            import httpx
             from langchain_mcp_adapters.client import MultiServerMCPClient
         except ImportError as ex:
             raise ImportError(
                 "AzureAIProjectToolbox requires 'langchain-mcp-adapters' and 'httpx'. "
                 "Install them with:\n"
                 "  pip install langchain-mcp-adapters httpx"
+            ) from ex
+
+        auth, extra_headers = self._build_auth_and_headers()
+
+        return MultiServerMCPClient(
+            {
+                "toolbox": {
+                    "url": self.toolbox_endpoint,
+                    "transport": "streamable_http",
+                    "headers": extra_headers,
+                    "auth": auth,
+                }
+            }
+        )
+
+    def _build_auth_and_headers(self) -> tuple[Any, dict[str, str]]:
+        """Build request auth and headers used for toolbox MCP calls."""
+        try:
+            import httpx
+        except ImportError as ex:
+            raise ImportError(
+                "AzureAIProjectToolbox requires 'httpx'. "
+                "Install it with:\n  pip install httpx"
             ) from ex
 
         # Start with user-provided extra headers and merge in
@@ -304,16 +356,20 @@ class AzureAIProjectToolbox(BaseModel):
 
             auth = _TokenBearerAuth(token_provider)
 
-        return MultiServerMCPClient(
-            {
-                "toolbox": {
-                    "url": self.toolbox_endpoint,
-                    "transport": "streamable_http",
-                    "headers": extra_headers,
-                    "auth": auth,
-                }
-            }
-        )
+        return auth, extra_headers
+
+    def _validate_required_fields(self) -> None:
+        """Validate required toolbox configuration fields."""
+        if not self.project_endpoint:
+            raise ValueError(
+                "project_endpoint is required. Pass it as a constructor argument "
+                "or set the AZURE_AI_PROJECT_ENDPOINT environment variable."
+            )
+        if not self.toolbox_name:
+            raise ValueError(
+                "toolbox_name is required. Pass it as a constructor argument "
+                "or set the FOUNDRY_AGENT_TOOLBOX_NAME environment variable."
+            )
 
     # ``async with`` is accepted for ergonomic compatibility but is a no-op:
     # MultiServerMCPClient.get_tools() manages its own session per call, so
@@ -345,18 +401,31 @@ class AzureAIProjectToolbox(BaseModel):
         Raises:
             ValueError: If ``project_endpoint`` or ``toolbox_name`` is not set.
         """
-        if not self.project_endpoint:
-            raise ValueError(
-                "project_endpoint is required. Pass it as a constructor argument "
-                "or set the AZURE_AI_PROJECT_ENDPOINT environment variable."
-            )
-        if not self.toolbox_name:
-            raise ValueError(
-                "toolbox_name is required. Pass it as a constructor argument "
-                "or set the FOUNDRY_AGENT_TOOLBOX_NAME environment variable."
-            )
+        self._validate_required_fields()
         client = self._build_mcp_client()
         return await self._fetch_tools(client)
+
+    async def get_tools_requiring_approval(self) -> List[str]:
+        """Return names of toolbox tools that require runtime approval.
+
+        This inspects the toolbox ``tools/list`` metadata and returns tool names
+        whose ``_meta.tool_configuration.require_approval`` value is ``"always"``.
+        This capability is independent from OAuth consent handling.
+
+        Returns:
+            List of tool names that require approval before execution.
+
+        Raises:
+            ValueError: If ``project_endpoint`` or ``toolbox_name`` is not set.
+        """
+        self._validate_required_fields()
+        auth, extra_headers = self._build_auth_and_headers()
+        approval_map = await _fetch_require_approval_tools(
+            self.toolbox_endpoint,
+            auth,
+            extra_headers,
+        )
+        return [name for name, val in approval_map.items() if val == "always"]
 
     async def aget_tools(self) -> List[BaseTool]:
         """Async alias for ``get_tools()``.

--- a/libs/azure-ai/tests/unit_tests/test_toolbox.py
+++ b/libs/azure-ai/tests/unit_tests/test_toolbox.py
@@ -1,0 +1,190 @@
+"""Unit tests for AzureAIProjectToolbox."""
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from langchain_azure_ai.tools._toolbox import (
+    _DEFAULT_FEATURES,
+    _FEATURES_HEADER,
+    AzureAIProjectToolbox,
+    _fetch_require_approval_tools,
+)
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore::langchain_azure_ai._api.base.ExperimentalWarning"
+)
+
+
+class TestFetchRequireApprovalTools:
+    async def test_filters_tools_with_require_approval(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        observed: dict[str, Any] = {}
+
+        class FakeResponse:
+            def __init__(self, payload: dict[str, Any]) -> None:
+                self._payload = payload
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, Any]:
+                return self._payload
+
+        class FakeAsyncClient:
+            def __init__(
+                self,
+                *,
+                auth: Any,
+                headers: dict[str, str],
+                timeout: float,
+            ) -> None:
+                observed["auth"] = auth
+                observed["headers"] = headers
+                observed["timeout"] = timeout
+
+            async def __aenter__(self) -> "FakeAsyncClient":
+                return self
+
+            async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+                return None
+
+            async def post(self, endpoint: str, json: dict[str, Any]) -> FakeResponse:
+                observed["endpoint"] = endpoint
+                observed["payload"] = json
+                return FakeResponse(
+                    {
+                        "result": {
+                            "tools": [
+                                {
+                                    "name": "send_email",
+                                    "_meta": {
+                                        "tool_configuration": {
+                                            "require_approval": "always"
+                                        }
+                                    },
+                                },
+                                {
+                                    "name": "read_calendar",
+                                    "_meta": {
+                                        "tool_configuration": {
+                                            "require_approval": "never"
+                                        }
+                                    },
+                                },
+                                {
+                                    "name": "echo",
+                                },
+                            ]
+                        }
+                    }
+                )
+
+        fake_httpx = ModuleType("httpx")
+        fake_httpx.AsyncClient = FakeAsyncClient  # type: ignore[attr-defined]
+        monkeypatch.setitem(__import__("sys").modules, "httpx", fake_httpx)
+
+        result = await _fetch_require_approval_tools(
+            endpoint="https://example.test/mcp",
+            auth="AUTH",
+            extra_headers={"X-Test": "1"},
+        )
+
+        assert result == {"send_email": "always", "read_calendar": "never"}
+        assert observed["endpoint"] == "https://example.test/mcp"
+        assert observed["payload"] == {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {},
+        }
+        assert observed["auth"] == "AUTH"
+        assert observed["headers"] == {"X-Test": "1"}
+        assert observed["timeout"] == 30.0
+
+
+class TestAzureAIProjectToolboxApproval:
+    async def test_get_tools_requiring_approval_returns_always_only(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        toolbox = AzureAIProjectToolbox(
+            project_endpoint="https://resource.services.ai.azure.com/api/projects/p",
+            toolbox_name="tb",
+            credential="token",
+        )
+
+        monkeypatch.setattr(
+            toolbox,
+            "_build_auth_and_headers",
+            lambda: ("AUTH", {"X-Test": "1"}),
+        )
+
+        async def fake_fetch(
+            endpoint: str,
+            auth: Any,
+            extra_headers: dict[str, str],
+        ) -> dict[str, str]:
+            assert endpoint == toolbox.toolbox_endpoint
+            assert auth == "AUTH"
+            assert extra_headers == {"X-Test": "1"}
+            return {
+                "send_email": "always",
+                "list_files": "never",
+                "delete_item": "always",
+            }
+
+        monkeypatch.setattr(
+            "langchain_azure_ai.tools._toolbox._fetch_require_approval_tools",
+            fake_fetch,
+        )
+
+        names = await toolbox.get_tools_requiring_approval()
+
+        assert names == ["send_email", "delete_item"]
+
+    async def test_get_tools_requiring_approval_requires_project_endpoint(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("AZURE_AI_PROJECT_ENDPOINT", raising=False)
+        monkeypatch.delenv("FOUNDRY_PROJECT_ENDPOINT", raising=False)
+        toolbox = AzureAIProjectToolbox(project_endpoint="", toolbox_name="tb")
+
+        with pytest.raises(ValueError, match="project_endpoint is required"):
+            await toolbox.get_tools_requiring_approval()
+
+
+class TestAzureAIProjectToolboxAuthHeaders:
+    def test_build_auth_and_headers_with_static_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class FakeAuth:
+            pass
+
+        fake_httpx = ModuleType("httpx")
+        fake_httpx.Auth = FakeAuth  # type: ignore[attr-defined]
+        monkeypatch.setitem(__import__("sys").modules, "httpx", fake_httpx)
+
+        toolbox = AzureAIProjectToolbox(
+            project_endpoint="https://resource.services.ai.azure.com/api/projects/p",
+            toolbox_name="tb",
+            credential="abc123",
+            extra_headers={"X-Test": "1"},
+        )
+
+        auth, headers = toolbox._build_auth_and_headers()
+        request = SimpleNamespace(headers={})
+
+        flow = auth.auth_flow(request)
+        next(flow)
+
+        assert request.headers["Authorization"] == "Bearer abc123"
+        assert headers["X-Test"] == "1"
+        assert headers[_FEATURES_HEADER] == _DEFAULT_FEATURES


### PR DESCRIPTION
This pull request adds the ability to detect which toolbox tools require runtime approval in the `AzureAIProjectToolbox` and refactors related authentication and validation logic. It also introduces comprehensive unit tests for these new features and internal helpers.

### New toolbox approval detection

* Added the async method `get_tools_requiring_approval` to `AzureAIProjectToolbox`, which returns the names of tools that require runtime approval (where `require_approval` is `"always"`). This uses a new internal helper, `_fetch_require_approval_tools`, to fetch and filter the approval status from the toolbox MCP endpoint. [[1]](diffhunk://#diff-96c3d3845dc34fe95f533297528f16dee325f311a8a9030223861a9fb208fca2R57-R86) [[2]](diffhunk://#diff-96c3d3845dc34fe95f533297528f16dee325f311a8a9030223861a9fb208fca2L348-R429)

### Refactoring and internal improvements

* Refactored authentication and header construction into a new `_build_auth_and_headers` method, which is now reused across toolbox MCP calls.
* Moved required field validation into a dedicated `_validate_required_fields` method, improving code clarity and error handling. [[1]](diffhunk://#diff-96c3d3845dc34fe95f533297528f16dee325f311a8a9030223861a9fb208fca2L307-R371) [[2]](diffhunk://#diff-96c3d3845dc34fe95f533297528f16dee325f311a8a9030223861a9fb208fca2L348-R429)

### Testing

* Added a new test module `test_toolbox.py` with unit tests for `_fetch_require_approval_tools`, `get_tools_requiring_approval`, and `_build_auth_and_headers`, covering both positive and error cases.