### PR TITLE
Add Azure AI Content Understanding to azure-ai README

### DIFF
--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -37,6 +37,7 @@ This package includes:
 * [Microsoft Foundry Content Safety](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/agents/middleware)
 * [Microsoft Foundry Agent Service](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/agents)
 * [Azure AI Search](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
+* [Azure AI Content Understanding](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/document_loaders)
 * [Azure AI Services tools](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/tools)
 * [Cosmos DB](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
 
@@ -159,6 +160,97 @@ enable_auto_tracing(
 
 For a complete end-to-end example, see [`samples/enable_auto_tracing_appinsights.py`](../../samples/enable_auto_tracing_appinsights.py).
 
+### Azure AI Content Understanding
+
+Load and extract content from documents, images, audio, and video using [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). For a comprehensive walkthrough with all modalities, output modes, and RAG pipeline examples, see the [demo notebook](./docs/content_understanding_loader_demo.ipynb).
+
+#### Document Loader
+
+```python
+from azure.identity import DefaultAzureCredential
+from langchain_azure_ai.document_loaders import AzureAIContentUnderstandingLoader
+
+loader = AzureAIContentUnderstandingLoader(
+    endpoint="https://{your-resource-name}.services.ai.azure.com",
+    credential=DefaultAzureCredential(),
+    url="https://example.com/report.pdf",
+)
+
+docs = loader.load()
+print(docs[0].page_content[:200])  # markdown content
+print(docs[0].metadata["source"])  # source file info
+```
+
+Use `output_mode` to control how results are split:
+
+```python
+# One document per page — each carries metadata["page"] for source attribution
+loader = AzureAIContentUnderstandingLoader(
+    endpoint="https://{your-resource-name}.services.ai.azure.com",
+    credential=DefaultAzureCredential(),
+    file_path="report.pdf",
+    output_mode="page",
+)
+docs = loader.load()
+for doc in docs[:3]:
+    print(f"Page {doc.metadata['page']}: {doc.page_content[:80]}...")
+```
+
+Extract structured fields with a prebuilt analyzer:
+
+```python
+loader = AzureAIContentUnderstandingLoader(
+    endpoint="https://{your-resource-name}.services.ai.azure.com",
+    credential=DefaultAzureCredential(),
+    file_path="invoice.pdf",
+    analyzer_id="prebuilt-invoice",
+    model_deployments={"gpt-4.1": "gpt-4.1"},  # map model name -> your deployment name
+)
+
+docs = loader.load()
+fields = docs[0].metadata["fields"]
+print(f"Amount due: {fields['AmountDue']['value']}")      # field value
+print(f"Confidence: {fields['AmountDue']['confidence']}")  # confidence score
+print(f"Vendor: {fields['VendorName']['value']}")
+```
+
+Load audio and video — CU supports all modalities through a single loader:
+
+```python
+# Transcribe an audio file
+loader = AzureAIContentUnderstandingLoader(
+    endpoint="https://{your-resource-name}.services.ai.azure.com",
+    credential=DefaultAzureCredential(),
+    url="https://example.com/support-call.mp3",
+)
+docs = loader.load()
+print(docs[0].page_content[:200])           # transcript as markdown
+print(docs[0].metadata["start_time_ms"])    # 0
+print(docs[0].metadata["end_time_ms"])      # total duration in ms
+```
+
+#### Agent Tool
+
+Use `AzureAIContentUnderstandingTool` to give LLM agents the ability to analyze documents, images, audio, and video:
+
+```python
+from azure.identity import DefaultAzureCredential
+from langchain_azure_ai.tools import AzureAIContentUnderstandingTool
+
+tool = AzureAIContentUnderstandingTool(
+    endpoint="https://{your-resource-name}.services.ai.azure.com",
+    credential=DefaultAzureCredential(),
+)
+
+# Analyze a document from a URL
+result = tool.invoke({"source": "https://example.com/invoice.pdf", "source_type": "url"})
+print(result)
+
+# Analyze a local file
+result = tool.invoke({"source": "/path/to/report.pdf", "source_type": "path"})
+print(result)
+```
+
 
 ## Changelog
 
@@ -171,6 +263,8 @@ For a complete end-to-end example, see [`samples/enable_auto_tracing_appinsights
 
 - **1.2.2**:
 
+  - **[NEW]** We introduced `AzureAIContentUnderstandingLoader` document loader for extracting content from documents, images, audio, and video using Azure AI Content Understanding. [#423](https://github.com/langchain-ai/langchain-azure/pull/423)
+  - **[NEW]** We introduced `AzureAIContentUnderstandingTool` for using Content Understanding as an agent tool, also available via `AIServicesToolkit`. [#446](https://github.com/langchain-ai/langchain-azure/pull/446)
   - We introduced `context_extractor` support across content safety middleware classes, so you can control how content is extracted from agent state before safety checks run. [#419](https://github.com/langchain-ai/langchain-azure/pull/419)
   - We introduced `context_extractor` support for `AzureGroundednessMiddleware` and added a notebook example for easier adoption. [#410](https://github.com/langchain-ai/langchain-azure/pull/410)
   - We changed the default implementation of `init_chat_model("azure_ai:<your-model>")` to use the OpenAI Responses API path for improved compatibility with modern LangChain chat model initialization. [#409](https://github.com/langchain-ai/langchain-azure/pull/409)

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -163,7 +163,7 @@ For a complete end-to-end example, see [`samples/enable_auto_tracing_appinsights
 
 Use tools from Azure AI services as LangChain tools via `AzureAIServicesToolkit`. Available tools include Azure AI Content Understanding, Document Intelligence, Image Analysis, Text Analytics for Health, and more.
 
-Azure AI Content Understanding is also available as a document loader via `AzureAIContentUnderstandingLoader`.
+Azure AI Content Understanding is also available as a document loader via `AzureAIContentUnderstandingLoader`. See the [Content Understanding loader notebook](./docs/content_understanding_loader_demo.ipynb) for a full walkthrough.
 
 
 ## Changelog

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -162,7 +162,7 @@ For a complete end-to-end example, see [`samples/enable_auto_tracing_appinsights
 
 ### Azure AI Content Understanding
 
-Load and extract content from documents, images, audio, and video using [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). CU delivers high-quality markdown with accurate table structure (including empty cells), chart/figure understanding, and multi-modal support through a single loader interface. Also available as an agent tool via `AzureAIContentUnderstandingTool`.
+Use `AzureAIContentUnderstandingLoader` to extract content from documents, images, audio, and video via [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). Returns high-quality markdown with accurate table structure, chart/figure understanding, and multi-modal support. Also available as an agent tool via `AzureAIContentUnderstandingTool`.
 
 For a comprehensive walkthrough, see the [demo notebook](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-ai/docs/content_understanding_loader_demo.ipynb).
 

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -164,6 +164,12 @@ For a complete end-to-end example, see [`samples/enable_auto_tracing_appinsights
 
 Load and extract content from documents, images, audio, and video using [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). For a comprehensive walkthrough with all modalities, output modes, and RAG pipeline examples, see the [demo notebook](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-ai/docs/content_understanding_loader_demo.ipynb).
 
+**Why use Content Understanding over traditional PDF loaders?**
+
+- **Accurate table extraction** — CU produces correct markdown tables even when cells are empty. Most PDF text extractors (e.g., PyPDFLoader, PyMuPDFLoader) lose column alignment and output a flat list of values, making it impossible to reconstruct which value belongs to which column. See this [sample PDF](https://github.com/Azure-Samples/azure-ai-content-understanding-assets/blob/153612d0dc17afe58166515c79b5a724da56f3bf/document/financial_table_and_chart.pdf) for an example that breaks standard loaders.
+- **Chart and figure understanding** — The `prebuilt-documentSearch` analyzer extracts semantic content from charts and figures (e.g., bar chart values, trend descriptions), not just scattered axis labels.
+- **Multi-modal in one loader** — Documents, images, audio, and video all go through the same `AzureAIContentUnderstandingLoader` interface, returning clean markdown content ready for RAG pipelines.
+
 #### Document Loader
 
 ```python
@@ -173,7 +179,7 @@ from langchain_azure_ai.document_loaders import AzureAIContentUnderstandingLoade
 loader = AzureAIContentUnderstandingLoader(
     endpoint="https://{your-resource-name}.services.ai.azure.com",
     credential=DefaultAzureCredential(),
-    url="https://example.com/report.pdf",
+    url="https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/financial_table_and_chart.pdf",
 )
 
 # Returns LangChain Document objects ready for use in chains and RAG pipelines

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -162,21 +162,9 @@ For a complete end-to-end example, see [`samples/enable_auto_tracing_appinsights
 
 ### Azure AI Content Understanding
 
-Load and extract content from documents, images, audio, and video using [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). CU delivers high-quality markdown with accurate table structure (including empty cells), chart/figure understanding, and multi-modal support through a single loader interface.
+Load and extract content from documents, images, audio, and video using [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). CU delivers high-quality markdown with accurate table structure (including empty cells), chart/figure understanding, and multi-modal support through a single loader interface. Also available as an agent tool via `AzureAIContentUnderstandingTool`.
 
-```python
-from azure.identity import DefaultAzureCredential
-from langchain_azure_ai.document_loaders import AzureAIContentUnderstandingLoader
-
-loader = AzureAIContentUnderstandingLoader(
-    endpoint="https://{your-resource-name}.services.ai.azure.com",
-    credential=DefaultAzureCredential(),
-    url="https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/financial_table_and_chart.pdf",
-)
-docs = loader.load()
-```
-
-Also available as an agent tool via `AzureAIContentUnderstandingTool`. For a comprehensive walkthrough, see the [demo notebook](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-ai/docs/content_understanding_loader_demo.ipynb).
+For a comprehensive walkthrough, see the [demo notebook](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-ai/docs/content_understanding_loader_demo.ipynb).
 
 
 ## Changelog

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -162,7 +162,7 @@ For a complete end-to-end example, see [`samples/enable_auto_tracing_appinsights
 
 ### Azure AI Content Understanding
 
-Load and extract content from documents, images, audio, and video using [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). For a comprehensive walkthrough with all modalities, output modes, and RAG pipeline examples, see the [demo notebook](./docs/content_understanding_loader_demo.ipynb).
+Load and extract content from documents, images, audio, and video using [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). For a comprehensive walkthrough with all modalities, output modes, and RAG pipeline examples, see the [demo notebook](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-ai/docs/content_understanding_loader_demo.ipynb).
 
 #### Document Loader
 
@@ -176,24 +176,10 @@ loader = AzureAIContentUnderstandingLoader(
     url="https://example.com/report.pdf",
 )
 
+# Returns LangChain Document objects ready for use in chains and RAG pipelines
 docs = loader.load()
 print(docs[0].page_content[:200])  # markdown content
 print(docs[0].metadata["source"])  # source file info
-```
-
-Use `output_mode` to control how results are split:
-
-```python
-# One document per page — each carries metadata["page"] for source attribution
-loader = AzureAIContentUnderstandingLoader(
-    endpoint="https://{your-resource-name}.services.ai.azure.com",
-    credential=DefaultAzureCredential(),
-    file_path="report.pdf",
-    output_mode="page",
-)
-docs = loader.load()
-for doc in docs[:3]:
-    print(f"Page {doc.metadata['page']}: {doc.page_content[:80]}...")
 ```
 
 Extract structured fields with a prebuilt analyzer:
@@ -204,7 +190,6 @@ loader = AzureAIContentUnderstandingLoader(
     credential=DefaultAzureCredential(),
     file_path="invoice.pdf",
     analyzer_id="prebuilt-invoice",
-    model_deployments={"gpt-4.1": "gpt-4.1"},  # map model name -> your deployment name
 )
 
 docs = loader.load()
@@ -221,7 +206,7 @@ Load audio and video — CU supports all modalities through a single loader:
 loader = AzureAIContentUnderstandingLoader(
     endpoint="https://{your-resource-name}.services.ai.azure.com",
     credential=DefaultAzureCredential(),
-    url="https://example.com/support-call.mp3",
+    url="https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/audio/callCenterRecording.mp3",
 )
 docs = loader.load()
 print(docs[0].page_content[:200])           # transcript as markdown

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -37,8 +37,7 @@ This package includes:
 * [Microsoft Foundry Content Safety](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/agents/middleware)
 * [Microsoft Foundry Agent Service](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/agents)
 * [Azure AI Search](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
-* [Azure AI Content Understanding](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/document_loaders)
-* [Azure AI Services tools](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/tools)
+* [Microsoft Foundry Tools](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/tools) (including Azure AI Content Understanding, Document Intelligence, and more)
 * [Cosmos DB](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
 
 Here's a quick start example to show you how to get started with the Chat Completions model. For more details and tutorials see [Get started with LangChain and LangGraph with Foundry](https://aka.ms/azureai/langchain).
@@ -160,11 +159,11 @@ enable_auto_tracing(
 
 For a complete end-to-end example, see [`samples/enable_auto_tracing_appinsights.py`](../../samples/enable_auto_tracing_appinsights.py).
 
-### Azure AI Content Understanding
+### Microsoft Foundry Tools
 
-Use `AzureAIContentUnderstandingLoader` to extract content from documents, images, audio, and video via [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). Returns high-quality markdown with accurate table structure, chart/figure understanding, and multi-modal support. Also available as an agent tool via `AzureAIContentUnderstandingTool`.
+Use tools from Azure AI services as LangChain tools via `AzureAIServicesToolkit`. Available tools include Azure AI Content Understanding, Document Intelligence, Image Analysis, Text Analytics for Health, and more.
 
-For a comprehensive walkthrough, see the [demo notebook](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-ai/docs/content_understanding_loader_demo.ipynb).
+Azure AI Content Understanding is also available as a document loader via `AzureAIContentUnderstandingLoader`.
 
 
 ## Changelog
@@ -179,7 +178,7 @@ For a comprehensive walkthrough, see the [demo notebook](https://github.com/lang
 - **1.2.2**:
 
   - **[NEW]** We introduced `AzureAIContentUnderstandingLoader` document loader for extracting content from documents, images, audio, and video using Azure AI Content Understanding. [#423](https://github.com/langchain-ai/langchain-azure/pull/423)
-  - **[NEW]** We introduced `AzureAIContentUnderstandingTool` for using Content Understanding as an agent tool, also available via `AIServicesToolkit`. [#446](https://github.com/langchain-ai/langchain-azure/pull/446)
+  - **[NEW]** We introduced `AzureAIContentUnderstandingTool` for using Content Understanding as an agent tool, also available via `AzureAIServicesToolkit`. [#446](https://github.com/langchain-ai/langchain-azure/pull/446)
   - We introduced `context_extractor` support across content safety middleware classes, so you can control how content is extracted from agent state before safety checks run. [#419](https://github.com/langchain-ai/langchain-azure/pull/419)
   - We introduced `context_extractor` support for `AzureGroundednessMiddleware` and added a notebook example for easier adoption. [#410](https://github.com/langchain-ai/langchain-azure/pull/410)
   - We changed the default implementation of `init_chat_model("azure_ai:<your-model>")` to use the OpenAI Responses API path for improved compatibility with modern LangChain chat model initialization. [#409](https://github.com/langchain-ai/langchain-azure/pull/409)

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -32,14 +32,14 @@ The `langchain-azure-ai` package uses the Microsoft Foundry family of SDKs and c
 
 This package includes:
 
-* [Microsoft Foundry Models inference](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/chat_models)
-* [Microsoft Foundry Tools](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/tools)
-* [Microsoft Foundry Content Safety](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/agents/middleware)
-* [Microsoft Foundry Agent Service](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/agents)
-* [Azure AI Search](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
-* [Azure AI Content Understanding](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/document_loaders)
-* [Azure AI Services tools](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/tools)
-* [Cosmos DB](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
+* [Microsoft Foundry Models inference](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/chat_models)
+* [Microsoft Foundry Tools](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/tools)
+* [Microsoft Foundry Content Safety](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/agents/middleware)
+* [Microsoft Foundry Agent Service](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/agents)
+* [Azure AI Search](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/vectorstores)
+* [Azure AI Content Understanding](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/document_loaders)
+* [Azure AI Services tools](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/tools)
+* [Cosmos DB](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/vectorstores)
 
 Here's a quick start example to show you how to get started with the Chat Completions model. For more details and tutorials see [Get started with LangChain and LangGraph with Foundry](https://aka.ms/azureai/langchain).
 

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -32,14 +32,14 @@ The `langchain-azure-ai` package uses the Microsoft Foundry family of SDKs and c
 
 This package includes:
 
-* [Microsoft Foundry Models inference](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/chat_models)
-* [Microsoft Foundry Tools](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/tools)
-* [Microsoft Foundry Content Safety](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/agents/middleware)
-* [Microsoft Foundry Agent Service](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/agents)
-* [Azure AI Search](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/vectorstores)
+* [Microsoft Foundry Models inference](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/chat_models)
+* [Microsoft Foundry Tools](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/tools)
+* [Microsoft Foundry Content Safety](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/agents/middleware)
+* [Microsoft Foundry Agent Service](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/agents)
+* [Azure AI Search](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
 * [Azure AI Content Understanding](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/document_loaders)
-* [Azure AI Services tools](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/tools)
-* [Cosmos DB](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/vectorstores)
+* [Azure AI Services tools](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/tools)
+* [Cosmos DB](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
 
 Here's a quick start example to show you how to get started with the Chat Completions model. For more details and tutorials see [Get started with LangChain and LangGraph with Foundry](https://aka.ms/azureai/langchain).
 

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -38,7 +38,6 @@ This package includes:
 * [Microsoft Foundry Agent Service](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/agents)
 * [Azure AI Search](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
 * [Microsoft Foundry Tools](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/tools) (including Azure AI Content Understanding, Document Intelligence, and more)
-* [Cosmos DB](https://github.com/langchain-ai/langchain-azure/libs/azure-ai/langchain_azure_ai/vectorstores)
 
 Here's a quick start example to show you how to get started with the Chat Completions model. For more details and tutorials see [Get started with LangChain and LangGraph with Foundry](https://aka.ms/azureai/langchain).
 

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -162,15 +162,7 @@ For a complete end-to-end example, see [`samples/enable_auto_tracing_appinsights
 
 ### Azure AI Content Understanding
 
-Load and extract content from documents, images, audio, and video using [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). For a comprehensive walkthrough with all modalities, output modes, and RAG pipeline examples, see the [demo notebook](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-ai/docs/content_understanding_loader_demo.ipynb).
-
-**Why use Content Understanding over traditional PDF loaders?**
-
-- **Accurate table extraction** — CU produces correct markdown tables even when cells are empty. Most PDF text extractors lose column alignment and output a flat list of values, making it impossible to reconstruct which value belongs to which column. See this [sample PDF](https://github.com/Azure-Samples/azure-ai-content-understanding-assets/blob/153612d0dc17afe58166515c79b5a724da56f3bf/document/financial_table_and_chart.pdf) for an example that breaks standard loaders.
-- **Chart and figure understanding** — The `prebuilt-documentSearch` analyzer extracts semantic content from charts and figures (e.g., bar chart values, trend descriptions), not just scattered axis labels.
-- **Multi-modal in one loader** — Documents, images, audio, and video all go through the same `AzureAIContentUnderstandingLoader` interface, returning clean markdown content ready for RAG pipelines.
-
-#### Document Loader
+Load and extract content from documents, images, audio, and video using [Azure AI Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/). CU delivers high-quality markdown with accurate table structure (including empty cells), chart/figure understanding, and multi-modal support through a single loader interface.
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -181,66 +173,10 @@ loader = AzureAIContentUnderstandingLoader(
     credential=DefaultAzureCredential(),
     url="https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/financial_table_and_chart.pdf",
 )
-
-# Returns LangChain Document objects ready for use in chains and RAG pipelines
 docs = loader.load()
-print(docs[0].page_content[:200])  # markdown content
-print(docs[0].metadata["source"])  # source file info
 ```
 
-Extract structured fields with a prebuilt analyzer:
-
-```python
-loader = AzureAIContentUnderstandingLoader(
-    endpoint="https://{your-resource-name}.services.ai.azure.com",
-    credential=DefaultAzureCredential(),
-    file_path="invoice.pdf",
-    analyzer_id="prebuilt-invoice",
-)
-
-docs = loader.load()
-fields = docs[0].metadata["fields"]
-print(f"Amount due: {fields['AmountDue']['value']}")      # field value
-print(f"Confidence: {fields['AmountDue']['confidence']}")  # confidence score
-print(f"Vendor: {fields['VendorName']['value']}")
-```
-
-Load audio and video — CU supports all modalities through a single loader:
-
-```python
-# Transcribe an audio file
-loader = AzureAIContentUnderstandingLoader(
-    endpoint="https://{your-resource-name}.services.ai.azure.com",
-    credential=DefaultAzureCredential(),
-    url="https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/audio/callCenterRecording.mp3",
-)
-docs = loader.load()
-print(docs[0].page_content[:200])           # transcript as markdown
-print(docs[0].metadata["start_time_ms"])    # 0
-print(docs[0].metadata["end_time_ms"])      # total duration in ms
-```
-
-#### Agent Tool
-
-Use `AzureAIContentUnderstandingTool` to give LLM agents the ability to analyze documents, images, audio, and video:
-
-```python
-from azure.identity import DefaultAzureCredential
-from langchain_azure_ai.tools import AzureAIContentUnderstandingTool
-
-tool = AzureAIContentUnderstandingTool(
-    endpoint="https://{your-resource-name}.services.ai.azure.com",
-    credential=DefaultAzureCredential(),
-)
-
-# Analyze a document from a URL
-result = tool.invoke({"source": "https://example.com/invoice.pdf", "source_type": "url"})
-print(result)
-
-# Analyze a local file
-result = tool.invoke({"source": "/path/to/report.pdf", "source_type": "path"})
-print(result)
-```
+Also available as an agent tool via `AzureAIContentUnderstandingTool`. For a comprehensive walkthrough, see the [demo notebook](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-ai/docs/content_understanding_loader_demo.ipynb).
 
 
 ## Changelog

--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -166,7 +166,7 @@ Load and extract content from documents, images, audio, and video using [Azure A
 
 **Why use Content Understanding over traditional PDF loaders?**
 
-- **Accurate table extraction** — CU produces correct markdown tables even when cells are empty. Most PDF text extractors (e.g., PyPDFLoader, PyMuPDFLoader) lose column alignment and output a flat list of values, making it impossible to reconstruct which value belongs to which column. See this [sample PDF](https://github.com/Azure-Samples/azure-ai-content-understanding-assets/blob/153612d0dc17afe58166515c79b5a724da56f3bf/document/financial_table_and_chart.pdf) for an example that breaks standard loaders.
+- **Accurate table extraction** — CU produces correct markdown tables even when cells are empty. Most PDF text extractors lose column alignment and output a flat list of values, making it impossible to reconstruct which value belongs to which column. See this [sample PDF](https://github.com/Azure-Samples/azure-ai-content-understanding-assets/blob/153612d0dc17afe58166515c79b5a724da56f3bf/document/financial_table_and_chart.pdf) for an example that breaks standard loaders.
 - **Chart and figure understanding** — The `prebuilt-documentSearch` analyzer extracts semantic content from charts and figures (e.g., bar chart values, trend descriptions), not just scattered axis labels.
 - **Multi-modal in one loader** — Documents, images, audio, and video all go through the same `AzureAIContentUnderstandingLoader` interface, returning clean markdown content ready for RAG pipelines.
 


### PR DESCRIPTION
## Summary

Updates the `langchain-azure-ai` README to document Microsoft Foundry Tools and add missing changelog entries for Content Understanding.

## Changes

1. **Feature list**: Renamed "Azure AI Services tools" → "Microsoft Foundry Tools" with parenthetical noting Content Understanding, Document Intelligence, and more (also fixed the source link to use `/tree/main/` for correct GitHub rendering)

2. **New section — Microsoft Foundry Tools**: Added a quick-reference section mentioning `AzureAIServicesToolkit` and `AzureAIContentUnderstandingLoader`, with a link to the [demo notebook](./libs/azure-ai/docs/content_understanding_loader_demo.ipynb)

3. **Changelog (1.2.2)**: Added two `[NEW]` entries that were missing:
   - `AzureAIContentUnderstandingLoader` document loader ([#423](https://github.com/langchain-ai/langchain-azure/pull/423))
   - `AzureAIContentUnderstandingTool` agent tool, also available via `AzureAIServicesToolkit` ([#446](https://github.com/langchain-ai/langchain-azure/pull/446))

## Why

Content Understanding components shipped in 1.2.2 but were not mentioned in the README feature list, had no Quick Start section, and had no changelog entries. This makes CU discoverable on PyPI. Detailed usage docs live in the [demo notebook](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-ai/docs/content_understanding_loader_demo.ipynb) and [Microsoft Learn](https://learn.microsoft.com/azure/ai-services/content-understanding/).

## Related PRs

- [#423](https://github.com/langchain-ai/langchain-azure/pull/423) — `AzureAIContentUnderstandingLoader` (merged)
- [#446](https://github.com/langchain-ai/langchain-azure/pull/446) — `AzureAIContentUnderstandingTool` (merged)