### PR TITLE
fix: remove deprecated model client

### DIFF
--- a/samples/hosting/langgraph-hosted-agents/invocations/01_basic/README.md
+++ b/samples/hosting/langgraph-hosted-agents/invocations/01_basic/README.md
@@ -17,8 +17,9 @@ so history survives restarts.
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential`. The graph is a stock
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`. The graph is a stock
 `create_agent(model, tools=[], checkpointer=MemorySaver())`, so every
 turn is just one chat-completion call against persisted history.
 

--- a/samples/hosting/langgraph-hosted-agents/invocations/01_basic/main.py
+++ b/samples/hosting/langgraph-hosted-agents/invocations/01_basic/main.py
@@ -33,10 +33,12 @@ from __future__ import annotations
 
 import os
 
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langgraph.checkpoint.memory import MemorySaver
 from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -45,18 +47,25 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from langchain_azure_ai.agents.hosting import InvocationsHostServer
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
 load_dotenv()
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 

--- a/samples/hosting/langgraph-hosted-agents/invocations/02_tools/README.md
+++ b/samples/hosting/langgraph-hosted-agents/invocations/02_tools/README.md
@@ -17,8 +17,9 @@ the Responses protocol instead (see
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential`. The graph is
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`. The graph is
 `create_agent(model, tools=[get_weather], checkpointer=MemorySaver())`,
 so every turn runs the standard LangChain ReAct loop with a
 `MemorySaver` keeping per-session history.

--- a/samples/hosting/langgraph-hosted-agents/invocations/02_tools/main.py
+++ b/samples/hosting/langgraph-hosted-agents/invocations/02_tools/main.py
@@ -36,11 +36,13 @@ import os
 from random import randint
 from typing import Annotated
 
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
 from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -49,7 +51,6 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from langchain_azure_ai.agents.hosting import InvocationsHostServer
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
 load_dotenv()
 
@@ -66,13 +67,21 @@ def get_weather(
     )
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 

--- a/samples/hosting/langgraph-hosted-agents/responses/01_basic/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/01_basic/README.md
@@ -9,8 +9,9 @@ host wrapping a LangChain chat model.
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential` (`az login`
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient` (`az login`
 is enough for local dev). The
 underlying graph is a stock `create_agent(model, tools=[])`, so every
 turn is just one chat-completion call.

--- a/samples/hosting/langgraph-hosted-agents/responses/01_basic/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/01_basic/main.py
@@ -23,9 +23,11 @@ from __future__ import annotations
 
 import os
 
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -34,18 +36,25 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from langchain_azure_ai.agents.hosting import ResponsesHostServer
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
 load_dotenv()
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 

--- a/samples/hosting/langgraph-hosted-agents/responses/02_tools/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/02_tools/README.md
@@ -11,8 +11,9 @@ the Responses host surfaces every tool round-trip to the client as
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential`. The graph is built by
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`. The graph is built by
 `langchain.agents.create_agent(model, tools=[get_weather])`, which gives
 the LLM access to one local tool.
 

--- a/samples/hosting/langgraph-hosted-agents/responses/02_tools/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/02_tools/main.py
@@ -43,9 +43,11 @@ import os
 from random import randint
 from typing import Annotated
 
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 from langchain_core.tools import tool
 
 from opentelemetry import trace
@@ -55,7 +57,6 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from langchain_azure_ai.agents.hosting import ResponsesHostServer
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
 load_dotenv()
 
@@ -72,13 +73,21 @@ def get_weather(
     )
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 

--- a/samples/hosting/langgraph-hosted-agents/responses/03_mcp/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/03_mcp/README.md
@@ -12,8 +12,9 @@ any HTTP-transport MCP endpoint.
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential`.
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`.
 
 See [main.py](main.py) for the full implementation.
 

--- a/samples/hosting/langgraph-hosted-agents/responses/03_mcp/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/03_mcp/main.py
@@ -44,9 +44,11 @@ import asyncio
 import os
 from typing import List
 
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
@@ -57,20 +59,27 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from langchain_azure_ai.agents.hosting import ResponsesHostServer
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
 load_dotenv()
 
 _DEFAULT_MCP_URL = "https://api.githubcopilot.com/mcp/"
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 

--- a/samples/hosting/langgraph-hosted-agents/responses/04_foundry_toolbox/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/04_foundry_toolbox/README.md
@@ -11,8 +11,9 @@ the **Responses protocol**.
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential`.
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`.
 
 See [main.py](main.py) for the full implementation.
 

--- a/samples/hosting/langgraph-hosted-agents/responses/04_foundry_toolbox/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/04_foundry_toolbox/main.py
@@ -50,10 +50,12 @@ import asyncio
 import os
 from typing import List
 
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langchain_core.tools import BaseTool
 from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -62,19 +64,26 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from langchain_azure_ai.agents.hosting import ResponsesHostServer
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 from langchain_azure_ai.tools import AzureAIProjectToolbox
 
 load_dotenv()
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 

--- a/samples/hosting/langgraph-hosted-agents/responses/05_workflows/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/05_workflows/README.md
@@ -16,8 +16,9 @@ choose which protocol(s) to expose it under.
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential`.
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`.
 
 See [main.py](main.py) for the full implementation.
 

--- a/samples/hosting/langgraph-hosted-agents/responses/05_workflows/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/05_workflows/main.py
@@ -55,8 +55,10 @@ from typing import Annotated
 
 from azure.ai.agentserver.invocations import InvocationAgentServerHost
 from azure.ai.agentserver.responses import ResponsesAgentServerHost
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
 from langchain_core.messages import BaseMessage, SystemMessage
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
@@ -75,7 +77,6 @@ from langchain_azure_ai.agents.hosting import (
     ResponsesHostServer,
 )
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
 load_dotenv()
 
@@ -114,13 +115,21 @@ class State(TypedDict):
     messages: Annotated[list[BaseMessage], add_messages]
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 

--- a/samples/hosting/langgraph-hosted-agents/responses/06_files/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/06_files/README.md
@@ -29,8 +29,9 @@ can read files at runtime"; the wiring is different.
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential`.
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`.
 
 See [main.py](main.py) for the full implementation.
 

--- a/samples/hosting/langgraph-hosted-agents/responses/06_files/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/06_files/main.py
@@ -38,9 +38,11 @@ import os
 from pathlib import Path
 from typing import Annotated
 
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 from langchain_core.tools import tool
 
 from opentelemetry import trace
@@ -50,7 +52,6 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from langchain_azure_ai.agents.hosting import ResponsesHostServer
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
 load_dotenv()
 
@@ -115,13 +116,21 @@ def read_text_file(
         return data.decode("utf-8", errors="replace")
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 

--- a/samples/hosting/langgraph-hosted-agents/responses/07_observability/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/07_observability/README.md
@@ -15,8 +15,9 @@ makes it discoverable as a standalone, deployable scenario.
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential`.
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`.
 
 ### Tracing wiring
 

--- a/samples/hosting/langgraph-hosted-agents/responses/07_observability/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/07_observability/main.py
@@ -49,9 +49,11 @@ from __future__ import annotations
 
 import os
 
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -60,18 +62,25 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from langchain_azure_ai.agents.hosting import ResponsesHostServer
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
 load_dotenv()
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 

--- a/samples/hosting/langgraph-hosted-agents/responses/08_hitl/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/08_hitl/README.md
@@ -17,8 +17,9 @@ as an alternative.
 
 ### Model Integration
 
-The agent uses `langchain_azure_ai.chat_models.AzureAIOpenAIApiChatModel`
-with the Foundry project endpoint and `DefaultAzureCredential`.
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`.
 
 See [main.py](main.py) for the full implementation.
 

--- a/samples/hosting/langgraph-hosted-agents/responses/08_hitl/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/08_hitl/main.py
@@ -68,8 +68,10 @@ from __future__ import annotations
 import os
 from typing import Annotated, Any
 
-from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import InMemorySaver
@@ -82,7 +84,6 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from langchain_azure_ai.agents.hosting import ResponsesHostServer
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
-from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
 load_dotenv()
 
@@ -108,13 +109,21 @@ _TOOLS_BY_NAME = {"get_weather": get_weather}
 # ---------------------------------------------------------------------------
 
 
-def _build_chat_model() -> AzureAIOpenAIApiChatModel:
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
     project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
     deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
-    return AzureAIOpenAIApiChatModel(
-        project_endpoint=project_endpoint,
-        credential=DefaultAzureCredential(),
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
         model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
     )
 
 


### PR DESCRIPTION
Information from Arun: AzureAIOpenAIApiChatModel is going to be deprecated so we shouldn't depend on it. Use ChatOpenAI instead.