### PR TITLE
fix: hosting detection should be optional

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/_user_agent.py
+++ b/libs/azure-ai/langchain_azure_ai/_user_agent.py
@@ -98,7 +98,11 @@ def _detect_hosted_environment() -> None:
         _hosted_env_detected = True
         return
 
-    if importlib.util.find_spec("azure.ai.agentserver.core") is None:
+    try:
+        if importlib.util.find_spec("azure.ai.agentserver.core") is None:
+            return
+    except Exception:
+        logger.debug("Skipping Foundry hosting detection.", exc_info=True)
         return
 
     with contextlib.suppress(ImportError, AttributeError):

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -217,6 +217,13 @@ class TestHostedEnvDetection:
                 _user_agent._detect_hosted_environment()
                 assert _user_agent._hosted_env_detected is False
 
+    def test_agentserver_spec_probe_failure_leaves_flag_unset(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FOUNDRY_HOSTING_ENVIRONMENT", None)
+            with patch("importlib.util.find_spec", side_effect=ValueError("boom")):
+                _user_agent._detect_hosted_environment()
+                assert _user_agent._hosted_env_detected is False
+
     def test_detection_is_cached(self) -> None:
         with patch.dict(os.environ, {"FOUNDRY_HOSTING_ENVIRONMENT": "1"}):
             _user_agent._detect_hosted_environment()


### PR DESCRIPTION
When not using the langchain_azure_ai[hosting] extra, we shouldn't hard depend on azure-ai-agentserver.core package