### PR TITLE
fix(azure-ai/hosting): stamp hosting User-Agent on OpenAI SDK clients

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -114,6 +114,81 @@ add_user_agent_prefix(HOSTING_USER_AGENT)
 # ``setdefault`` so a caller-supplied value wins.
 os.environ.setdefault("AZURE_HTTP_USER_AGENT", HOSTING_USER_AGENT)
 
+# Third leg of UA propagation: wrap the ``openai`` SDK client classes'
+# ``__init__`` so any ``OpenAI`` / ``AsyncOpenAI`` / ``AzureOpenAI`` /
+# ``AsyncAzureOpenAI`` instance constructed inside a process that imports
+# this hosting layer automatically carries the hosting-SDK UA in its
+# ``default_headers``. This is the only path that picks up ``ChatOpenAI``
+# / ``AzureChatOpenAI`` (which build their own ``openai`` client and do
+# not read ``AZURE_HTTP_USER_AGENT``), as well as ``init_chat_model``,
+# raw ``openai`` SDK usage, eval libraries, etc.
+#
+# Patching at the ``openai`` SDK layer rather than the ``httpx`` layer
+# scopes the mutation to OpenAI-bound traffic only — no URL filter, no
+# surprise stamping of unrelated HTTP requests in the same process.
+#
+# ``openai`` is an optional runtime dependency of this package: it is
+# resolved lazily and the patch is silently skipped if the package is
+# not installed in the environment.
+_OPENAI_INIT_PATCHED = False
+
+
+def _install_openai_user_agent_stamp() -> None:
+    global _OPENAI_INIT_PATCHED
+    if _OPENAI_INIT_PATCHED:
+        return
+
+    try:
+        openai = importlib.import_module("openai")
+    except ImportError:
+        return
+
+    _OPENAI_INIT_PATCHED = True
+
+    def _wrap(cls: type) -> None:
+        orig_init = cls.__init__
+
+        def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+            orig_init(self, *args, **kwargs)
+            prefix = get_user_agent()
+            if not prefix:
+                return
+            # ``BaseClient.default_headers`` is the merge of platform +
+            # auth + ``self.user_agent`` + ``self._custom_headers``;
+            # ``_custom_headers`` wins. Combine our prefix with whatever
+            # UA is currently effective so the SDK's own
+            # ``AsyncOpenAI/Python <ver>`` (or a caller-supplied
+            # override) is preserved as the suffix.
+            try:
+                custom = getattr(self, "_custom_headers", None)
+                if custom is None:
+                    custom = {}
+                existing = custom.get("User-Agent") or getattr(
+                    self, "user_agent", ""
+                )
+                if prefix in (existing or ""):
+                    return
+                custom["User-Agent"] = f"{prefix} {existing}".strip()
+                self._custom_headers = custom
+            except Exception:
+                # Never let UA stamping break client construction.
+                pass
+
+        cls.__init__ = _patched_init  # type: ignore[method-assign]
+
+    for cls_name in (
+        "OpenAI",
+        "AsyncOpenAI",
+        "AzureOpenAI",
+        "AsyncAzureOpenAI",
+    ):
+        cls = getattr(openai, cls_name, None)
+        if cls is not None:
+            _wrap(cls)
+
+
+_install_openai_user_agent_stamp()
+
 if TYPE_CHECKING:
     from azure.ai.agentserver.invocations import InvocationAgentServerHost
     from azure.ai.agentserver.responses import (

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -234,3 +234,128 @@ class TestHostedEnvDetection:
                 _user_agent._detect_hosted_environment()
                 find_spec.assert_not_called()
             assert _user_agent._hosted_env_detected is True
+
+
+# ---------------------------------------------------------------------------
+# Hosting subpackage: AZURE_HTTP_USER_AGENT env var
+# ---------------------------------------------------------------------------
+
+
+class TestHostingAzureHttpUserAgent:
+    def test_env_var_is_set_on_import(self) -> None:
+        import langchain_azure_ai.agents.hosting as hosting
+
+        # The hosting subpackage runs ``os.environ.setdefault`` at import
+        # time; by the time any test executes the module has already been
+        # imported (and cached in ``sys.modules``), so the env var must
+        # reflect the hosting prefix.
+        assert os.environ.get("AZURE_HTTP_USER_AGENT") is not None
+        assert hosting.HOSTING_USER_AGENT in os.environ["AZURE_HTTP_USER_AGENT"]
+
+    def test_caller_value_wins(self) -> None:
+        """``setdefault`` semantics: a pre-existing value is preserved."""
+        with patch.dict(
+            os.environ, {"AZURE_HTTP_USER_AGENT": "caller/1.0"}, clear=False
+        ):
+            # Re-run the env-var registration logic on a fresh hosting
+            # module (simulate "user already exported the env var before
+            # importing us").
+            os.environ.setdefault(
+                "AZURE_HTTP_USER_AGENT", "should-not-override/9.9"
+            )
+            assert os.environ["AZURE_HTTP_USER_AGENT"] == "caller/1.0"
+
+
+# ---------------------------------------------------------------------------
+# Hosting subpackage: openai SDK UA stamping
+# ---------------------------------------------------------------------------
+
+
+class TestHostingOpenAIUserAgentStamp:
+    """End-to-end behavior of the ``openai``-SDK ``__init__`` monkey-patch.
+
+    The hosting subpackage installs the patch at import time; the
+    autouse fixture clears the prefix registry per test, so we re-add
+    the hosting prefix in each case before constructing a client.
+    """
+
+    def _hosting_prefix(self) -> str:
+        import langchain_azure_ai.agents.hosting as hosting
+
+        _user_agent.add_user_agent_prefix(hosting.HOSTING_USER_AGENT)
+        return hosting.HOSTING_USER_AGENT
+
+    def test_async_openai_client_carries_hosting_prefix(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        prefix = self._hosting_prefix()
+        client = openai.AsyncOpenAI(api_key="test-key")
+        ua = client._custom_headers["User-Agent"]
+        assert ua.startswith(prefix + " ")
+        # SDK's own UA token preserved as suffix.
+        assert "AsyncOpenAI/Python" in ua
+
+    def test_sync_openai_client_carries_hosting_prefix(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        prefix = self._hosting_prefix()
+        client = openai.OpenAI(api_key="test-key")
+        ua = client._custom_headers["User-Agent"]
+        assert ua.startswith(prefix + " ")
+        assert "OpenAI/Python" in ua
+
+    def test_caller_default_headers_user_agent_preserved(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        prefix = self._hosting_prefix()
+        client = openai.AsyncOpenAI(
+            api_key="test-key",
+            default_headers={"User-Agent": "my-app/1.0"},
+        )
+        ua = client._custom_headers["User-Agent"]
+        assert ua.startswith(prefix + " ")
+        assert "my-app/1.0" in ua
+
+    def test_idempotent_no_double_stamp(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        prefix = self._hosting_prefix()
+        # Re-running the installer must be a no-op.
+        import langchain_azure_ai.agents.hosting as hosting
+
+        hosting._install_openai_user_agent_stamp()
+        hosting._install_openai_user_agent_stamp()
+
+        client = openai.AsyncOpenAI(api_key="test-key")
+        ua = client._custom_headers["User-Agent"]
+        assert ua.count(prefix) == 1
+
+    def test_opt_out_skips_stamping(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        self._hosting_prefix()
+        with patch.dict(
+            os.environ,
+            {_user_agent.USER_AGENT_TELEMETRY_DISABLED_ENV_VAR: "1"},
+        ):
+            client = openai.AsyncOpenAI(api_key="test-key")
+            ua = client._custom_headers.get("User-Agent", "")
+            # Hosting prefix must not be injected when telemetry is off.
+            assert "langchain_azure_ai.agents.hosting/" not in ua
+
+    def test_install_is_noop_when_openai_missing(self) -> None:
+        """When ``openai`` is not installed, the installer returns cleanly."""
+        import langchain_azure_ai.agents.hosting as hosting
+
+        original_flag = hosting._OPENAI_INIT_PATCHED
+        try:
+            hosting._OPENAI_INIT_PATCHED = False
+            with patch(
+                "importlib.import_module", side_effect=ImportError("no openai")
+            ):
+                # Must not raise.
+                hosting._install_openai_user_agent_stamp()
+            # Flag stayed False since we never patched anything.
+            assert hosting._OPENAI_INIT_PATCHED is False
+        finally:
+            hosting._OPENAI_INIT_PATCHED = original_flag


### PR DESCRIPTION
ChatOpenAI / AzureChatOpenAI (used by LangChain/LangGraph apps) build their HTTP client via the openai SDK, which does not read AZURE_HTTP_USER_AGENT and ignores the langchain-azure-ai user-agent registry. As a result, requests from hosted apps went out with a raw `AsyncOpenAI/Python <ver>` User-Agent and the hosting prefix was dropped on the wire.

Fix it in the hosting layer by monkey-patching the four openai client classes (OpenAI, AsyncOpenAI, AzureOpenAI, AsyncAzureOpenAI) at import time. The wrapper runs the original `__init__` first, then merges the hosting prefix into `self._custom_headers["User-Agent"]` while preserving:

* any caller-supplied `default_headers["User-Agent"]` override
* the SDK's own `self.user_agent` suffix (`AsyncOpenAI/Python <ver>` etc.)

Other properties:

* `openai` stays an optional dependency — the installer lazy-imports it via `importlib` and is a no-op if openai is not installed.
* Idempotent: a module-level flag prevents double-patching when `hosting` is reimported.
* Honors the existing telemetry opt-out (`LANGCHAIN_AZURE_AI_USER_AGENT_TELEMETRY_DISABLED`); when opted out the hosting prefix is empty and nothing is stamped.
* Wrapped in try/except so a patch failure can never break client construction.
* Also sets `AZURE_HTTP_USER_AGENT` via `os.environ.setdefault` so azure-core SDKs (which do honor it) get the same hosting prefix without overriding a caller-supplied value.

Tests
-----
8 new unit tests in `tests/unit_tests/test_user_agent.py`:

* `TestHostingAzureHttpUserAgent` (2): env var is set on import; caller value wins.
* `TestHostingOpenAIUserAgentStamp` (6): hosting prefix lands on `_custom_headers["User-Agent"]` for sync + async clients; caller-supplied User-Agent is preserved; installer is idempotent; opt-out path is honored; missing-openai is a no-op.

Full suite: 32 passed.