### PR TITLE
fix(azure-ai/hosting): stamp hosting User-Agent on OpenAI and Anthropic SDK clients

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -114,6 +114,81 @@ add_user_agent_prefix(HOSTING_USER_AGENT)
 # ``setdefault`` so a caller-supplied value wins.
 os.environ.setdefault("AZURE_HTTP_USER_AGENT", HOSTING_USER_AGENT)
 
+# Third leg of UA propagation: wrap the ``openai`` SDK client classes'
+# ``__init__`` so any ``OpenAI`` / ``AsyncOpenAI`` / ``AzureOpenAI`` /
+# ``AsyncAzureOpenAI`` instance constructed inside a process that imports
+# this hosting layer automatically carries the hosting-SDK UA in its
+# ``default_headers``. This is the only path that picks up ``ChatOpenAI``
+# / ``AzureChatOpenAI`` (which build their own ``openai`` client and do
+# not read ``AZURE_HTTP_USER_AGENT``), as well as ``init_chat_model``,
+# raw ``openai`` SDK usage, eval libraries, etc.
+#
+# Patching at the ``openai`` SDK layer rather than the ``httpx`` layer
+# scopes the mutation to OpenAI-bound traffic only — no URL filter, no
+# surprise stamping of unrelated HTTP requests in the same process.
+#
+# ``openai`` is an optional runtime dependency of this package: it is
+# resolved lazily and the patch is silently skipped if the package is
+# not installed in the environment.
+_OPENAI_INIT_PATCHED = False
+
+
+def _install_openai_user_agent_stamp() -> None:
+    global _OPENAI_INIT_PATCHED
+    if _OPENAI_INIT_PATCHED:
+        return
+
+    try:
+        openai = importlib.import_module("openai")
+    except ImportError:
+        return
+
+    _OPENAI_INIT_PATCHED = True
+
+    def _wrap(cls: type) -> None:
+        orig_init = cls.__init__
+
+        def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+            orig_init(self, *args, **kwargs)
+            prefix = get_user_agent()
+            if not prefix:
+                return
+            # ``BaseClient.default_headers`` is the merge of platform +
+            # auth + ``self.user_agent`` + ``self._custom_headers``;
+            # ``_custom_headers`` wins. Combine our prefix with whatever
+            # UA is currently effective so the SDK's own
+            # ``AsyncOpenAI/Python <ver>`` (or a caller-supplied
+            # override) is preserved as the suffix.
+            try:
+                custom = getattr(self, "_custom_headers", None)
+                if custom is None:
+                    custom = {}
+                existing = custom.get("User-Agent") or getattr(
+                    self, "user_agent", ""
+                )
+                if prefix in (existing or ""):
+                    return
+                custom["User-Agent"] = f"{prefix} {existing}".strip()
+                self._custom_headers = custom
+            except Exception:
+                # Never let UA stamping break client construction.
+                pass
+
+        cls.__init__ = _patched_init  # type: ignore[method-assign]
+
+    for cls_name in (
+        "OpenAI",
+        "AsyncOpenAI",
+        "AzureOpenAI",
+        "AsyncAzureOpenAI",
+    ):
+        cls = getattr(openai, cls_name, None)
+        if cls is not None:
+            _wrap(cls)
+
+
+_install_openai_user_agent_stamp()
+
 if TYPE_CHECKING:
     from azure.ai.agentserver.invocations import InvocationAgentServerHost
     from azure.ai.agentserver.responses import (

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -114,90 +114,131 @@ add_user_agent_prefix(HOSTING_USER_AGENT)
 # ``setdefault`` so a caller-supplied value wins.
 os.environ.setdefault("AZURE_HTTP_USER_AGENT", HOSTING_USER_AGENT)
 
-# Third leg of UA propagation: wrap the ``openai`` SDK client classes'
-# ``__init__`` so any ``OpenAI`` / ``AsyncOpenAI`` / ``AzureOpenAI`` /
-# ``AsyncAzureOpenAI`` instance constructed inside a process that imports
-# this hosting layer automatically carries the hosting-SDK UA. The patch
+# Third leg of UA propagation: wrap LLM SDK client classes' ``__init__``
+# so any client instance constructed inside a process that imports this
+# hosting layer automatically carries the hosting-SDK UA. The patch
 # writes the merged value into ``self._custom_headers["User-Agent"]``,
 # which takes precedence in the SDK's ``BaseClient.default_headers``
-# merge over the built-in ``AsyncOpenAI/Python <ver>`` token and over
+# merge over the built-in ``<ClientName>/Python <ver>`` token and over
 # ``self.user_agent``, so the prefix lands on every outbound request.
-# This is the only path that picks up ``ChatOpenAI`` / ``AzureChatOpenAI``
-# (which build their own ``openai`` client and do not read
-# ``AZURE_HTTP_USER_AGENT``), as well as ``init_chat_model``, raw
-# ``openai`` SDK usage, eval libraries, etc.
 #
-# Patching at the ``openai`` SDK layer rather than the ``httpx`` layer
-# scopes the mutation to OpenAI-bound traffic only — no URL filter, no
-# surprise stamping of unrelated HTTP requests in the same process.
+# Two providers are stamped:
 #
-# ``openai`` is an optional runtime dependency of this package: it is
-# resolved lazily and the patch is silently skipped if the package is
+# * ``openai`` covers ``ChatOpenAI`` / ``AzureChatOpenAI`` (which build
+#   their own ``openai`` client and do not read
+#   ``AZURE_HTTP_USER_AGENT``), as well as ``init_chat_model``, raw
+#   ``openai`` SDK usage, eval libraries, and any Foundry model exposed
+#   via the OpenAI-compatible route (e.g. Mistral, Llama, Phi, DeepSeek).
+# * ``anthropic`` covers Foundry's native Anthropic surface
+#   (``https://<resource>.services.ai.azure.com/anthropic``), used by
+#   ``langchain-anthropic``'s ``ChatAnthropic`` when pointed at Foundry,
+#   and by direct ``anthropic`` SDK usage.
+#
+# Patching at the SDK layer rather than the ``httpx`` layer scopes the
+# mutation to provider-bound traffic only — no URL filter, no surprise
+# stamping of unrelated HTTP requests in the same process.
+#
+# Both SDKs are optional runtime dependencies of this package: they are
+# resolved lazily and each patch is silently skipped if the package is
 # not installed in the environment.
+
+
+def _wrap_init_with_user_agent(cls: type) -> None:
+    """Patch ``cls.__init__`` to merge the hosting UA prefix into outbound headers.
+
+    Targets SDK client classes that follow the shared ``BaseClient`` shape
+    used by both ``openai`` and ``anthropic``: an ``_custom_headers`` dict
+    plus a ``user_agent`` attribute, with ``_custom_headers["User-Agent"]``
+    winning in the outbound header merge. The per-instance
+    ``if prefix in existing`` guard makes the patch idempotent across
+    repeat installs and re-imports.
+    """
+    orig_init = cls.__init__  # type: ignore[misc]
+
+    def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        orig_init(self, *args, **kwargs)
+        prefix = get_user_agent()
+        if not prefix:
+            return
+        # ``BaseClient.default_headers`` is the merge of platform + auth
+        # + ``self.user_agent`` + ``self._custom_headers``;
+        # ``_custom_headers`` wins. Combine our prefix with whatever UA
+        # is currently effective so the SDK's own
+        # ``<ClientName>/Python <ver>`` (or a caller-supplied override)
+        # is preserved as the suffix.
+        try:
+            custom = getattr(self, "_custom_headers", None)
+            if custom is None:
+                custom = {}
+            existing = custom.get("User-Agent") or getattr(self, "user_agent", "")
+            if prefix in (existing or ""):
+                return
+            custom["User-Agent"] = f"{prefix} {existing}".strip()
+            self._custom_headers = custom
+        except Exception:
+            # Never let UA stamping break client construction.
+            pass
+
+    cls.__init__ = _patched_init  # type: ignore[method-assign,misc]
+
+
+def _install_sdk_user_agent_stamp(
+    module_name: str, class_names: tuple[str, ...]
+) -> bool:
+    """Wrap the named classes from ``module_name`` if the SDK is importable.
+
+    Returns ``True`` if the SDK was found and at least one class was
+    patched, ``False`` if the SDK is not installed. Per-class failures
+    are swallowed so a future SDK that makes ``__init__`` non-writable
+    on one class cannot prevent the others from being patched and never
+    breaks import of the hosting package.
+    """
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        return False
+
+    for cls_name in class_names:
+        try:
+            cls = getattr(module, cls_name, None)
+            if cls is not None:
+                _wrap_init_with_user_agent(cls)
+        except Exception:
+            pass
+    return True
+
+
 _OPENAI_INIT_PATCHED = False
+_ANTHROPIC_INIT_PATCHED = False
 
 
 def _install_openai_user_agent_stamp() -> None:
     global _OPENAI_INIT_PATCHED
     if _OPENAI_INIT_PATCHED:
         return
-
-    try:
-        openai = importlib.import_module("openai")
-    except ImportError:
-        return
-
-    _OPENAI_INIT_PATCHED = True
-
-    def _wrap(cls: type) -> None:
-        orig_init = cls.__init__  # type: ignore[misc]
-
-        def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
-            orig_init(self, *args, **kwargs)
-            prefix = get_user_agent()
-            if not prefix:
-                return
-            # ``BaseClient.default_headers`` is the merge of platform +
-            # auth + ``self.user_agent`` + ``self._custom_headers``;
-            # ``_custom_headers`` wins. Combine our prefix with whatever
-            # UA is currently effective so the SDK's own
-            # ``AsyncOpenAI/Python <ver>`` (or a caller-supplied
-            # override) is preserved as the suffix.
-            try:
-                custom = getattr(self, "_custom_headers", None)
-                if custom is None:
-                    custom = {}
-                existing = custom.get("User-Agent") or getattr(self, "user_agent", "")
-                if prefix in (existing or ""):
-                    return
-                custom["User-Agent"] = f"{prefix} {existing}".strip()
-                self._custom_headers = custom
-            except Exception:
-                # Never let UA stamping break client construction.
-                pass
-
-        cls.__init__ = _patched_init  # type: ignore[method-assign,misc]
-
-    for cls_name in (
-        "OpenAI",
-        "AsyncOpenAI",
-        "AzureOpenAI",
-        "AsyncAzureOpenAI",
+    if _install_sdk_user_agent_stamp(
+        "openai",
+        ("OpenAI", "AsyncOpenAI", "AzureOpenAI", "AsyncAzureOpenAI"),
     ):
-        try:
-            cls = getattr(openai, cls_name, None)
-            if cls is not None:
-                _wrap(cls)
-        except Exception:
-            # Per-class isolation: a failure on one client class (e.g. a
-            # future SDK that makes ``__init__`` non-writable, or a lazy
-            # module ``__getattr__`` raising) must not prevent the other
-            # classes from being patched and must never break import of
-            # the hosting package.
-            pass
+        _OPENAI_INIT_PATCHED = True
+
+
+def _install_anthropic_user_agent_stamp() -> None:
+    global _ANTHROPIC_INIT_PATCHED
+    if _ANTHROPIC_INIT_PATCHED:
+        return
+    # ``AnthropicBedrock`` / ``AnthropicVertex`` are intentionally omitted:
+    # those clients do not reach Foundry and stamping them would attribute
+    # off-platform traffic to the hosting layer.
+    if _install_sdk_user_agent_stamp(
+        "anthropic",
+        ("Anthropic", "AsyncAnthropic"),
+    ):
+        _ANTHROPIC_INIT_PATCHED = True
 
 
 _install_openai_user_agent_stamp()
+_install_anthropic_user_agent_stamp()
 
 if TYPE_CHECKING:
     from azure.ai.agentserver.invocations import InvocationAgentServerHost

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -188,24 +188,27 @@ def _install_sdk_user_agent_stamp(
     """Wrap the named classes from ``module_name`` if the SDK is importable.
 
     Returns ``True`` if the SDK was found and at least one class was
-    patched, ``False`` if the SDK is not installed. Per-class failures
-    are swallowed so a future SDK that makes ``__init__`` non-writable
-    on one class cannot prevent the others from being patched and never
-    breaks import of the hosting package.
+    patched, ``False`` if the SDK is not installed or no target class
+    could be patched. Per-class failures are swallowed so a future SDK
+    that makes ``__init__`` non-writable on one class cannot prevent
+    the others from being patched and never breaks import of the
+    hosting package.
     """
     try:
         module = importlib.import_module(module_name)
     except ImportError:
         return False
 
+    patched = 0
     for cls_name in class_names:
         try:
             cls = getattr(module, cls_name, None)
             if cls is not None:
                 _wrap_init_with_user_agent(cls)
+                patched += 1
         except Exception:
             pass
-    return True
+    return patched > 0
 
 
 _OPENAI_INIT_PATCHED = False

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -150,7 +150,7 @@ def _install_openai_user_agent_stamp() -> None:
     _OPENAI_INIT_PATCHED = True
 
     def _wrap(cls: type) -> None:
-        orig_init = cls.__init__
+        orig_init = cls.__init__  # type: ignore[misc]
 
         def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
             orig_init(self, *args, **kwargs)
@@ -176,7 +176,7 @@ def _install_openai_user_agent_stamp() -> None:
                 # Never let UA stamping break client construction.
                 pass
 
-        cls.__init__ = _patched_init  # type: ignore[method-assign]
+        cls.__init__ = _patched_init  # type: ignore[method-assign,misc]
 
     for cls_name in (
         "OpenAI",

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -117,11 +117,15 @@ os.environ.setdefault("AZURE_HTTP_USER_AGENT", HOSTING_USER_AGENT)
 # Third leg of UA propagation: wrap the ``openai`` SDK client classes'
 # ``__init__`` so any ``OpenAI`` / ``AsyncOpenAI`` / ``AzureOpenAI`` /
 # ``AsyncAzureOpenAI`` instance constructed inside a process that imports
-# this hosting layer automatically carries the hosting-SDK UA in its
-# ``default_headers``. This is the only path that picks up ``ChatOpenAI``
-# / ``AzureChatOpenAI`` (which build their own ``openai`` client and do
-# not read ``AZURE_HTTP_USER_AGENT``), as well as ``init_chat_model``,
-# raw ``openai`` SDK usage, eval libraries, etc.
+# this hosting layer automatically carries the hosting-SDK UA. The patch
+# writes the merged value into ``self._custom_headers["User-Agent"]``,
+# which takes precedence in the SDK's ``BaseClient.default_headers``
+# merge over the built-in ``AsyncOpenAI/Python <ver>`` token and over
+# ``self.user_agent``, so the prefix lands on every outbound request.
+# This is the only path that picks up ``ChatOpenAI`` / ``AzureChatOpenAI``
+# (which build their own ``openai`` client and do not read
+# ``AZURE_HTTP_USER_AGENT``), as well as ``init_chat_model``, raw
+# ``openai`` SDK usage, eval libraries, etc.
 #
 # Patching at the ``openai`` SDK layer rather than the ``httpx`` layer
 # scopes the mutation to OpenAI-bound traffic only — no URL filter, no
@@ -163,9 +167,7 @@ def _install_openai_user_agent_stamp() -> None:
                 custom = getattr(self, "_custom_headers", None)
                 if custom is None:
                     custom = {}
-                existing = custom.get("User-Agent") or getattr(
-                    self, "user_agent", ""
-                )
+                existing = custom.get("User-Agent") or getattr(self, "user_agent", "")
                 if prefix in (existing or ""):
                     return
                 custom["User-Agent"] = f"{prefix} {existing}".strip()
@@ -182,9 +184,17 @@ def _install_openai_user_agent_stamp() -> None:
         "AzureOpenAI",
         "AsyncAzureOpenAI",
     ):
-        cls = getattr(openai, cls_name, None)
-        if cls is not None:
-            _wrap(cls)
+        try:
+            cls = getattr(openai, cls_name, None)
+            if cls is not None:
+                _wrap(cls)
+        except Exception:
+            # Per-class isolation: a failure on one client class (e.g. a
+            # future SDK that makes ``__init__`` non-writable, or a lazy
+            # module ``__getattr__`` raising) must not prevent the other
+            # classes from being patched and must never break import of
+            # the hosting package.
+            pass
 
 
 _install_openai_user_agent_stamp()

--- a/libs/azure-ai/poetry.lock
+++ b/libs/azure-ai/poetry.lock
@@ -184,6 +184,36 @@ files = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.109.1"
+description = "The official Python library for the anthropic API"
+optional = false
+python-versions = ">=3.9"
+groups = ["test"]
+files = [
+    {file = "anthropic-0.109.1-py3-none-any.whl", hash = "sha256:ce7d94a7657f2aa29338cca448945eac621b4f62c1794cf461cb32847223e9b8"},
+    {file = "anthropic-0.109.1.tar.gz", hash = "sha256:83e06b3d9d40ff5898f588020e0cc4e42187de954549a3b5fbe6e2685a09c785"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+docstring-parser = ">=0.15,<1"
+httpx = ">=0.25.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+typing-extensions = ">=4.14,<5"
+
+[package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
+aws = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
+bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
+mcp = ["mcp (>=1.0) ; python_version >= \"3.10\""]
+vertex = ["google-auth[requests] (>=2,<3)"]
+webhooks = ["standardwebhooks (>=1.0.1,<2)"]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
@@ -641,7 +671,7 @@ files = [
     {file = "azure_monitor_opentelemetry_exporter-1.0.0b52-py2.py3-none-any.whl", hash = "sha256:a38c503e5e2cc0ec8a4bf336b23cce23488719f5361a45cdd01a514080f0e7fc"},
     {file = "azure_monitor_opentelemetry_exporter-1.0.0b52.tar.gz", hash = "sha256:7eac679fca32dee9e426df65f2a538161db4514fc322fc66107f7826567d86e1"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\""}
 
 [package.dependencies]
 azure-core = ">=1.28.0,<2.0.0"
@@ -1129,7 +1159,7 @@ version = "1.9.0"
 description = "Distro - an OS platform information API"
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
     {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
@@ -1155,6 +1185,23 @@ doq = ["aioquic (>=1.2.0)"]
 idna = ["idna (>=3.10)"]
 trio = ["trio (>=0.30)"]
 wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+description = "Parse Python docstrings in reST, Google and Numpydoc format"
+optional = false
+python-versions = ">=3.8"
+groups = ["test"]
+files = [
+    {file = "docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b"},
+    {file = "docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015"},
+]
+
+[package.extras]
+dev = ["pre-commit (>=2.16.0) ; python_version >= \"3.9\"", "pydoctor (>=25.4.0)", "pytest"]
+docs = ["pydoctor (>=25.4.0)"]
+test = ["pytest"]
 
 [[package]]
 name = "exceptiongroup"
@@ -1597,7 +1644,7 @@ files = [
     {file = "importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"},
     {file = "importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\""}
 
 [package.dependencies]
 zipp = ">=3.20"
@@ -1734,7 +1781,7 @@ version = "0.13.0"
 description = "Fast iterable JSON parser."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "jiter-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2ffc63785fd6c7977defe49b9824ae6ce2b2e2b77ce539bdaf006c26da06342e"},
     {file = "jiter-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4a638816427006c1e3f0013eb66d391d7a3acda99a7b0cf091eff4497ccea33a"},
@@ -2261,7 +2308,7 @@ files = [
     {file = "msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32"},
     {file = "msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\" or extra == \"tools\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\" or extra == \"tools\""}
 
 [package.dependencies]
 azure-core = ">=1.24.0"
@@ -2604,7 +2651,7 @@ files = [
     {file = "oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"},
     {file = "oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\" or extra == \"tools\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\" or extra == \"tools\""}
 
 [package.extras]
 rsa = ["cryptography (>=3.0.0)"]
@@ -2650,7 +2697,7 @@ files = [
     {file = "opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9"},
     {file = "opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\""}
 
 [package.dependencies]
 importlib-metadata = ">=6.0,<8.8.0"
@@ -3015,7 +3062,7 @@ files = [
     {file = "opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1"},
     {file = "opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\""}
 
 [package.dependencies]
 opentelemetry-api = "1.40.0"
@@ -3033,7 +3080,7 @@ files = [
     {file = "opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2"},
     {file = "opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\""}
 
 [package.dependencies]
 opentelemetry-api = "1.40.0"
@@ -3514,7 +3561,7 @@ files = [
     {file = "psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee"},
     {file = "psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\""}
 
 [package.extras]
 dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
@@ -3559,7 +3606,7 @@ files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", dev = "implementation_name == \"pypy\"", test = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
+markers = {main = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\"", dev = "implementation_name == \"pypy\"", test = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -4354,7 +4401,7 @@ files = [
     {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
     {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\" or extra == \"tools\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\" or extra == \"tools\""}
 
 [package.dependencies]
 oauthlib = ">=3.0.0"
@@ -4512,7 +4559,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -5387,7 +5434,7 @@ files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
 ]
-markers = {main = "extra == \"hosting\" or extra == \"opentelemetry\""}
+markers = {main = "extra == \"opentelemetry\" or extra == \"hosting\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
@@ -5518,4 +5565,4 @@ v1 = ["azure-ai-agents", "azure-ai-inference"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<4.0"
-content-hash = "992fd3b982d6971c14bd357d2a883046e4171f3d06e0f642db988da092cd1c6f"
+content-hash = "271f66fc5af3625af56c86f6b7704fb6a82102bd9b742f21eed3a1860391050e"

--- a/libs/azure-ai/pyproject.toml
+++ b/libs/azure-ai/pyproject.toml
@@ -137,6 +137,7 @@ simsimd = "~=6.0"
 optional = true
 
 [tool.poetry.group.test.dependencies]
+anthropic = ">=0.40,<1.0"
 azure-monitor-opentelemetry = "~=1.8"
 opentelemetry-api = ">=1.37"
 opentelemetry-instrumentation = ">=0.58b0"

--- a/libs/azure-ai/pyproject.toml
+++ b/libs/azure-ai/pyproject.toml
@@ -137,7 +137,6 @@ simsimd = "~=6.0"
 optional = true
 
 [tool.poetry.group.test.dependencies]
-anthropic = ">=0.40,<1.0"
 azure-monitor-opentelemetry = "~=1.8"
 opentelemetry-api = ">=1.37"
 opentelemetry-instrumentation = ">=0.58b0"
@@ -222,6 +221,7 @@ test = [
   "syrupy>=5.0,<6",
   "pytest-recording~=0.13.4",
   "vcrpy>=7.0",
+  "anthropic (>=0.40,<1.0)",
 ]
 test_integration = ["pytest>=9.0.3,<10", "python-dotenv~=1.0", "pytest-recording~=0.13.4", "vcrpy>=7.0"]
 typing = ["mypy~=1.10", "types-requests~=2.28"]

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -303,6 +303,12 @@ class TestHostingAzureHttpUserAgent:
                 os.environ["AZURE_HTTP_USER_AGENT"] = saved_env
             for cls, init in saved_inits.items():
                 cls.__init__ = init  # type: ignore[method-assign,misc]
+            # Keep test runs hermetic under partial selection: if hosting
+            # wasn't imported coming in, don't leave it in ``sys.modules``
+            # with its patch flags set while we've just restored the SDK
+            # class ``__init__``s to their pre-patch state.
+            if not was_imported:
+                sys.modules.pop("langchain_azure_ai.agents.hosting", None)
 
     def test_env_var_is_set_on_import(self) -> None:
         """With no pre-existing env var, hosting injects its prefix."""

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -296,9 +296,7 @@ class TestHostingAzureHttpUserAgent:
                     sys.modules["langchain_azure_ai.agents.hosting"]
                 )
             else:
-                hosting = importlib.import_module(
-                    "langchain_azure_ai.agents.hosting"
-                )
+                hosting = importlib.import_module("langchain_azure_ai.agents.hosting")
             yield hosting
         finally:
             if saved_env is None:
@@ -311,10 +309,7 @@ class TestHostingAzureHttpUserAgent:
     def test_env_var_is_set_on_import(self) -> None:
         """With no pre-existing env var, hosting injects its prefix."""
         with self._reload_hosting_with_env(None) as hosting:
-            assert (
-                os.environ.get("AZURE_HTTP_USER_AGENT")
-                == hosting.HOSTING_USER_AGENT
-            )
+            assert os.environ.get("AZURE_HTTP_USER_AGENT") == hosting.HOSTING_USER_AGENT
 
     def test_caller_value_wins(self) -> None:
         """Hosting's ``setdefault`` preserves a caller-supplied value."""
@@ -410,9 +405,7 @@ class TestHostingOpenAIUserAgentStamp:
         original_flag = hosting._OPENAI_INIT_PATCHED
         try:
             hosting._OPENAI_INIT_PATCHED = False
-            with patch(
-                "importlib.import_module", side_effect=ImportError("no openai")
-            ):
+            with patch("importlib.import_module", side_effect=ImportError("no openai")):
                 # Must not raise.
                 hosting._install_openai_user_agent_stamp()
             # Flag stayed False since we never patched anything.

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -234,3 +234,128 @@ class TestHostedEnvDetection:
                 _user_agent._detect_hosted_environment()
                 find_spec.assert_not_called()
             assert _user_agent._hosted_env_detected is True
+
+
+# ---------------------------------------------------------------------------
+# Hosting subpackage: AZURE_HTTP_USER_AGENT env var
+# ---------------------------------------------------------------------------
+
+
+class TestHostingAzureHttpUserAgent:
+    def test_env_var_is_set_on_import(self) -> None:
+        import langchain_azure_ai.agents.hosting as hosting
+
+        # The hosting subpackage runs ``os.environ.setdefault`` at import
+        # time; by the time any test executes the module has already been
+        # imported (and cached in ``sys.modules``), so the env var must
+        # reflect the hosting prefix.
+        assert os.environ.get("AZURE_HTTP_USER_AGENT") is not None
+        assert hosting.HOSTING_USER_AGENT in os.environ["AZURE_HTTP_USER_AGENT"]
+
+    def test_caller_value_wins(self) -> None:
+        """``setdefault`` semantics: a pre-existing value is preserved."""
+        with patch.dict(
+            os.environ, {"AZURE_HTTP_USER_AGENT": "caller/1.0"}, clear=False
+        ):
+            # Re-run the env-var registration logic on a fresh hosting
+            # module (simulate "user already exported the env var before
+            # importing us").
+            os.environ.setdefault(
+                "AZURE_HTTP_USER_AGENT", "should-not-override/9.9"
+            )
+            assert os.environ["AZURE_HTTP_USER_AGENT"] == "caller/1.0"
+
+
+# ---------------------------------------------------------------------------
+# Hosting subpackage: openai SDK UA stamping
+# ---------------------------------------------------------------------------
+
+
+class TestHostingOpenAIUserAgentStamp:
+    """End-to-end behavior of the ``openai``-SDK ``__init__`` monkey-patch.
+
+    The hosting subpackage installs the patch at import time; the
+    autouse fixture clears the prefix registry per test, so we re-add
+    the hosting prefix in each case before constructing a client.
+    """
+
+    def _hosting_prefix(self) -> str:
+        import langchain_azure_ai.agents.hosting as hosting
+
+        _user_agent.add_user_agent_prefix(hosting.HOSTING_USER_AGENT)
+        return hosting.HOSTING_USER_AGENT
+
+    def test_async_openai_client_carries_hosting_prefix(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        prefix = self._hosting_prefix()
+        client = openai.AsyncOpenAI(api_key="test-key")
+        ua = client._custom_headers["User-Agent"]
+        assert ua.startswith(prefix + " ")
+        # SDK's own UA token preserved as suffix.
+        assert "AsyncOpenAI/Python" in ua
+
+    def test_sync_openai_client_carries_hosting_prefix(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        prefix = self._hosting_prefix()
+        client = openai.OpenAI(api_key="test-key")
+        ua = client._custom_headers["User-Agent"]
+        assert ua.startswith(prefix + " ")
+        assert "OpenAI/Python" in ua
+
+    def test_caller_default_headers_user_agent_preserved(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        prefix = self._hosting_prefix()
+        client = openai.AsyncOpenAI(
+            api_key="test-key",
+            default_headers={"User-Agent": "my-app/1.0"},
+        )
+        ua = client._custom_headers["User-Agent"]
+        assert ua.startswith(prefix + " ")
+        assert "my-app/1.0" in ua
+
+    def test_idempotent_no_double_stamp(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        prefix = self._hosting_prefix()
+        # Re-running the installer must be a no-op.
+        import langchain_azure_ai.agents.hosting as hosting
+
+        hosting._install_openai_user_agent_stamp()
+        hosting._install_openai_user_agent_stamp()
+
+        client = openai.AsyncOpenAI(api_key="test-key")
+        ua = client._custom_headers["User-Agent"]
+        assert ua.count(prefix) == 1
+
+    def test_opt_out_skips_stamping(self) -> None:
+        openai = pytest.importorskip("openai")
+
+        self._hosting_prefix()
+        with patch.dict(
+            os.environ,
+            {_user_agent.USER_AGENT_TELEMETRY_DISABLED_ENV_VAR: "1"},
+        ):
+            client = openai.AsyncOpenAI(api_key="test-key")
+            ua = client._custom_headers.get("User-Agent", "")
+            # Hosting prefix must not be injected when telemetry is off.
+            assert "langchain_azure_ai.agents.hosting/" not in ua
+
+    def test_install_is_noop_when_openai_missing(self) -> None:
+        """When ``openai`` is not installed, the installer returns cleanly."""
+        import langchain_azure_ai.agents.hosting as hosting
+
+        original_flag = hosting._OPENAI_INIT_PATCHED
+        try:
+            hosting._OPENAI_INIT_PATCHED = False
+            with patch(
+                "importlib.import_module", side_effect=ImportError("no openai")
+            ):
+                # Must not raise.
+                hosting._install_openai_user_agent_stamp()
+            # Flag stayed False since we never patched anything.
+            assert hosting._OPENAI_INIT_PATCHED is False
+        finally:
+            hosting._OPENAI_INIT_PATCHED = original_flag

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import importlib
 import os
-from typing import Iterator
+from contextlib import contextmanager
+from typing import Any, Iterator
 from unittest.mock import patch
 
 import pytest
@@ -242,28 +243,68 @@ class TestHostedEnvDetection:
 
 
 class TestHostingAzureHttpUserAgent:
-    def test_env_var_is_set_on_import(self) -> None:
+    @staticmethod
+    @contextmanager
+    def _reload_hosting_with_env(
+        env_value: str | None,
+    ) -> Iterator[Any]:
+        """Reload the hosting module under a controlled ``os.environ``.
+
+        Snapshots and restores both ``AZURE_HTTP_USER_AGENT`` and the
+        four ``openai`` SDK client class ``__init__``s, since reloading
+        the hosting module also re-runs the openai SDK monkey-patch
+        installer.
+        """
         import langchain_azure_ai.agents.hosting as hosting
 
-        # The hosting subpackage runs ``os.environ.setdefault`` at import
-        # time; by the time any test executes the module has already been
-        # imported (and cached in ``sys.modules``), so the env var must
-        # reflect the hosting prefix.
-        assert os.environ.get("AZURE_HTTP_USER_AGENT") is not None
-        assert hosting.HOSTING_USER_AGENT in os.environ["AZURE_HTTP_USER_AGENT"]
+        saved_inits: dict[type, Any] = {}
+        try:
+            openai_mod = importlib.import_module("openai")
+        except ImportError:
+            openai_mod = None
+        if openai_mod is not None:
+            for cls_name in (
+                "OpenAI",
+                "AsyncOpenAI",
+                "AzureOpenAI",
+                "AsyncAzureOpenAI",
+            ):
+                cls = getattr(openai_mod, cls_name, None)
+                if cls is not None:
+                    saved_inits[cls] = cls.__init__
+
+        saved_env = os.environ.get("AZURE_HTTP_USER_AGENT")
+        try:
+            if env_value is None:
+                os.environ.pop("AZURE_HTTP_USER_AGENT", None)
+            else:
+                os.environ["AZURE_HTTP_USER_AGENT"] = env_value
+            importlib.reload(hosting)
+            yield hosting
+        finally:
+            if saved_env is None:
+                os.environ.pop("AZURE_HTTP_USER_AGENT", None)
+            else:
+                os.environ["AZURE_HTTP_USER_AGENT"] = saved_env
+            for cls, init in saved_inits.items():
+                cls.__init__ = init  # type: ignore[method-assign]
+
+    def test_env_var_is_set_on_import(self) -> None:
+        """With no pre-existing env var, hosting injects its prefix."""
+        with self._reload_hosting_with_env(None) as hosting:
+            assert (
+                os.environ.get("AZURE_HTTP_USER_AGENT")
+                == hosting.HOSTING_USER_AGENT
+            )
 
     def test_caller_value_wins(self) -> None:
-        """``setdefault`` semantics: a pre-existing value is preserved."""
-        with patch.dict(
-            os.environ, {"AZURE_HTTP_USER_AGENT": "caller/1.0"}, clear=False
-        ):
-            # Re-run the env-var registration logic on a fresh hosting
-            # module (simulate "user already exported the env var before
-            # importing us").
-            os.environ.setdefault(
-                "AZURE_HTTP_USER_AGENT", "should-not-override/9.9"
-            )
+        """Hosting's ``setdefault`` preserves a caller-supplied value."""
+        with self._reload_hosting_with_env("caller/1.0") as hosting:
             assert os.environ["AZURE_HTTP_USER_AGENT"] == "caller/1.0"
+            # Sanity: the hosting prefix exists but was not used here.
+            assert hosting.HOSTING_USER_AGENT.startswith(
+                "langchain_azure_ai.agents.hosting/"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -358,4 +399,41 @@ class TestHostingOpenAIUserAgentStamp:
             # Flag stayed False since we never patched anything.
             assert hosting._OPENAI_INIT_PATCHED is False
         finally:
+            hosting._OPENAI_INIT_PATCHED = original_flag
+
+    def test_install_isolates_per_class_failure(self) -> None:
+        """A failure on one client class must not break the others or import."""
+        openai = pytest.importorskip("openai")
+        import langchain_azure_ai.agents.hosting as hosting
+
+        # Simulate a future SDK where one of the four client classes
+        # raises while being patched (e.g. ``__init__`` non-writable,
+        # module ``__getattr__`` raising, etc.). The installer must
+        # swallow the per-class failure and continue patching the rest.
+        class _BadMeta(type):
+            def __setattr__(cls, name: str, value: Any) -> None:
+                if name == "__init__":
+                    raise TypeError("simulated immutable __init__")
+                super().__setattr__(name, value)
+
+        class _BadOpenAI(metaclass=_BadMeta):
+            pass
+
+        original_flag = hosting._OPENAI_INIT_PATCHED
+        original_async_init = openai.AsyncOpenAI.__init__
+        try:
+            hosting._OPENAI_INIT_PATCHED = False
+
+            with patch.object(openai, "OpenAI", _BadOpenAI):
+                # Must not raise even though _BadOpenAI patching fails.
+                hosting._install_openai_user_agent_stamp()
+
+            prefix = self._hosting_prefix()
+            # The other (real) classes were still patched successfully.
+            client = openai.AsyncOpenAI(api_key="test-key")
+            ua = client._custom_headers["User-Agent"]
+            assert ua.startswith(prefix + " ")
+        finally:
+            # Restore real __init__ on the class we wrapped.
+            openai.AsyncOpenAI.__init__ = original_async_init  # type: ignore[method-assign]
             hosting._OPENAI_INIT_PATCHED = original_flag

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -251,35 +251,33 @@ class TestHostingAzureHttpUserAgent:
     ) -> Iterator[Any]:
         """Reload the hosting module under a controlled ``os.environ``.
 
-        Snapshots and restores both ``AZURE_HTTP_USER_AGENT`` and the
-        four ``openai`` SDK client class ``__init__``s, since (re)loading
-        the hosting module also re-runs the openai SDK monkey-patch
-        installer.
+        Snapshots and restores ``AZURE_HTTP_USER_AGENT`` plus the
+        ``__init__`` of every SDK client class hosting monkey-patches
+        (``openai`` and ``anthropic``), since (re)loading the hosting
+        module re-runs each SDK installer.
 
         Snapshots are taken *before* the hosting module is imported or
         reloaded: hosting's import-time side effects (``setdefault`` on
-        ``AZURE_HTTP_USER_AGENT`` and the openai ``__init__`` patch)
+        ``AZURE_HTTP_USER_AGENT`` and the per-SDK ``__init__`` patches)
         would otherwise pollute the snapshot on a cold first import and
         leak past the helper's restore step.
         """
         # Snapshot env BEFORE any hosting import so we capture pre-test state.
         saved_env = os.environ.get("AZURE_HTTP_USER_AGENT")
 
-        # Snapshot openai class __init__s BEFORE any hosting import for
-        # the same reason.
+        # Snapshot SDK client class __init__s BEFORE any hosting import
+        # for the same reason.
         saved_inits: dict[type, Any] = {}
-        try:
-            openai_mod = importlib.import_module("openai")
-        except ImportError:
-            openai_mod = None
-        if openai_mod is not None:
-            for cls_name in (
-                "OpenAI",
-                "AsyncOpenAI",
-                "AzureOpenAI",
-                "AsyncAzureOpenAI",
-            ):
-                cls = getattr(openai_mod, cls_name, None)
+        for sdk_name, class_names in (
+            ("openai", ("OpenAI", "AsyncOpenAI", "AzureOpenAI", "AsyncAzureOpenAI")),
+            ("anthropic", ("Anthropic", "AsyncAnthropic")),
+        ):
+            try:
+                sdk_mod = importlib.import_module(sdk_name)
+            except ImportError:
+                continue
+            for cls_name in class_names:
+                cls = getattr(sdk_mod, cls_name, None)
                 if cls is not None:
                     saved_inits[cls] = cls.__init__
 
@@ -449,3 +447,105 @@ class TestHostingOpenAIUserAgentStamp:
             # Restore real __init__ on the class we wrapped.
             openai.AsyncOpenAI.__init__ = original_async_init  # type: ignore[method-assign,misc]
             hosting._OPENAI_INIT_PATCHED = original_flag
+
+
+# ---------------------------------------------------------------------------
+# Hosting subpackage: anthropic SDK UA stamping
+# ---------------------------------------------------------------------------
+
+
+class TestHostingAnthropicUserAgentStamp:
+    """End-to-end behavior of the ``anthropic``-SDK ``__init__`` monkey-patch.
+
+    Mirrors :class:`TestHostingOpenAIUserAgentStamp`. The hosting
+    subpackage installs the patch at import time; the autouse fixture
+    clears the prefix registry per test, so we re-add the hosting prefix
+    in each case before constructing a client.
+
+    Foundry exposes Anthropic models on its own ``/anthropic/v1/messages``
+    surface; ``ChatAnthropic`` and direct ``anthropic`` SDK usage that
+    points at a Foundry endpoint both flow through these client classes,
+    so UA stamping at this layer is what attributes Claude traffic to the
+    hosting layer in App Insights.
+    """
+
+    def _hosting_prefix(self) -> str:
+        import langchain_azure_ai.agents.hosting as hosting
+
+        _user_agent.add_user_agent_prefix(hosting.HOSTING_USER_AGENT)
+        return hosting.HOSTING_USER_AGENT
+
+    def test_async_anthropic_client_carries_hosting_prefix(self) -> None:
+        anthropic = pytest.importorskip("anthropic")
+
+        prefix = self._hosting_prefix()
+        client = anthropic.AsyncAnthropic(api_key="test-key")
+        ua = client._custom_headers["User-Agent"]
+        assert ua.startswith(prefix + " ")
+        # SDK's own UA token preserved as suffix.
+        assert "AsyncAnthropic/Python" in ua
+
+    def test_sync_anthropic_client_carries_hosting_prefix(self) -> None:
+        anthropic = pytest.importorskip("anthropic")
+
+        prefix = self._hosting_prefix()
+        client = anthropic.Anthropic(api_key="test-key")
+        ua = client._custom_headers["User-Agent"]
+        assert ua.startswith(prefix + " ")
+        assert "Anthropic/Python" in ua
+
+    def test_caller_default_headers_user_agent_preserved(self) -> None:
+        anthropic = pytest.importorskip("anthropic")
+
+        prefix = self._hosting_prefix()
+        client = anthropic.AsyncAnthropic(
+            api_key="test-key",
+            default_headers={"User-Agent": "my-app/1.0"},
+        )
+        ua = client._custom_headers["User-Agent"]
+        assert ua.startswith(prefix + " ")
+        assert "my-app/1.0" in ua
+
+    def test_idempotent_no_double_stamp(self) -> None:
+        anthropic = pytest.importorskip("anthropic")
+
+        prefix = self._hosting_prefix()
+        # Re-running the installer must be a no-op.
+        import langchain_azure_ai.agents.hosting as hosting
+
+        hosting._install_anthropic_user_agent_stamp()
+        hosting._install_anthropic_user_agent_stamp()
+
+        client = anthropic.AsyncAnthropic(api_key="test-key")
+        ua = client._custom_headers["User-Agent"]
+        assert ua.count(prefix) == 1
+
+    def test_opt_out_skips_stamping(self) -> None:
+        anthropic = pytest.importorskip("anthropic")
+
+        self._hosting_prefix()
+        with patch.dict(
+            os.environ,
+            {_user_agent.USER_AGENT_TELEMETRY_DISABLED_ENV_VAR: "1"},
+        ):
+            client = anthropic.AsyncAnthropic(api_key="test-key")
+            ua = client._custom_headers.get("User-Agent", "")
+            # Hosting prefix must not be injected when telemetry is off.
+            assert "langchain_azure_ai.agents.hosting/" not in ua
+
+    def test_install_is_noop_when_anthropic_missing(self) -> None:
+        """When ``anthropic`` is not installed, the installer returns cleanly."""
+        import langchain_azure_ai.agents.hosting as hosting
+
+        original_flag = hosting._ANTHROPIC_INIT_PATCHED
+        try:
+            hosting._ANTHROPIC_INIT_PATCHED = False
+            with patch(
+                "importlib.import_module", side_effect=ImportError("no anthropic")
+            ):
+                # Must not raise.
+                hosting._install_anthropic_user_agent_stamp()
+            # Flag stayed False since we never patched anything.
+            assert hosting._ANTHROPIC_INIT_PATCHED is False
+        finally:
+            hosting._ANTHROPIC_INIT_PATCHED = original_flag

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import sys
 from contextlib import contextmanager
 from typing import Any, Iterator
 from unittest.mock import patch
@@ -251,12 +252,21 @@ class TestHostingAzureHttpUserAgent:
         """Reload the hosting module under a controlled ``os.environ``.
 
         Snapshots and restores both ``AZURE_HTTP_USER_AGENT`` and the
-        four ``openai`` SDK client class ``__init__``s, since reloading
+        four ``openai`` SDK client class ``__init__``s, since (re)loading
         the hosting module also re-runs the openai SDK monkey-patch
         installer.
-        """
-        import langchain_azure_ai.agents.hosting as hosting
 
+        Snapshots are taken *before* the hosting module is imported or
+        reloaded: hosting's import-time side effects (``setdefault`` on
+        ``AZURE_HTTP_USER_AGENT`` and the openai ``__init__`` patch)
+        would otherwise pollute the snapshot on a cold first import and
+        leak past the helper's restore step.
+        """
+        # Snapshot env BEFORE any hosting import so we capture pre-test state.
+        saved_env = os.environ.get("AZURE_HTTP_USER_AGENT")
+
+        # Snapshot openai class __init__s BEFORE any hosting import for
+        # the same reason.
         saved_inits: dict[type, Any] = {}
         try:
             openai_mod = importlib.import_module("openai")
@@ -273,13 +283,22 @@ class TestHostingAzureHttpUserAgent:
                 if cls is not None:
                     saved_inits[cls] = cls.__init__
 
-        saved_env = os.environ.get("AZURE_HTTP_USER_AGENT")
+        was_imported = "langchain_azure_ai.agents.hosting" in sys.modules
+
         try:
             if env_value is None:
                 os.environ.pop("AZURE_HTTP_USER_AGENT", None)
             else:
                 os.environ["AZURE_HTTP_USER_AGENT"] = env_value
-            importlib.reload(hosting)
+
+            if was_imported:
+                hosting = importlib.reload(
+                    sys.modules["langchain_azure_ai.agents.hosting"]
+                )
+            else:
+                hosting = importlib.import_module(
+                    "langchain_azure_ai.agents.hosting"
+                )
             yield hosting
         finally:
             if saved_env is None:
@@ -287,7 +306,7 @@ class TestHostingAzureHttpUserAgent:
             else:
                 os.environ["AZURE_HTTP_USER_AGENT"] = saved_env
             for cls, init in saved_inits.items():
-                cls.__init__ = init  # type: ignore[method-assign]
+                cls.__init__ = init  # type: ignore[method-assign,misc]
 
     def test_env_var_is_set_on_import(self) -> None:
         """With no pre-existing env var, hosting injects its prefix."""
@@ -435,5 +454,5 @@ class TestHostingOpenAIUserAgentStamp:
             assert ua.startswith(prefix + " ")
         finally:
             # Restore real __init__ on the class we wrapped.
-            openai.AsyncOpenAI.__init__ = original_async_init  # type: ignore[method-assign]
+            openai.AsyncOpenAI.__init__ = original_async_init  # type: ignore[method-assign,misc]
             hosting._OPENAI_INIT_PATCHED = original_flag


### PR DESCRIPTION
ChatOpenAI / AzureChatOpenAI (used by LangChain/LangGraph apps) build their HTTP client via the `openai` SDK, and ChatAnthropic similarly builds its client via the `anthropic` SDK. Neither SDK reads `AZURE_HTTP_USER_AGENT` and neither consults the `langchain-azure-ai` user-agent registry, so requests from hosted apps went out with raw `AsyncOpenAI/Python <ver>` or `AsyncAnthropic/Python <ver>` User-Agents and the hosting prefix was dropped on the wire.

Fix it in the hosting layer by monkey-patching the model SDK client classes at import time:

- `openai`: `OpenAI`, `AsyncOpenAI`, `AzureOpenAI`, `AsyncAzureOpenAI` — covers the Azure OpenAI surface (`/openai/v1`) **and the OpenAI-compatible alias surface** that Foundry exposes for non-OpenAI models (Cohere, Mistral, Meta Llama, DeepSeek, Phi, etc.). Those models publish an OpenAI-shaped `/chat/completions` endpoint, so LangChain's `ChatOpenAI` / `init_chat_model("openai:…")` and the GA OpenAI Python SDK are the standard client path — patching the SDK class once stamps every one of them.
- `anthropic`: `Anthropic`, `AsyncAnthropic` — covers Foundry's native Anthropic Messages surface (`/anthropic/v1/messages`). `AnthropicBedrock` / `AnthropicVertex` are intentionally omitted since they don't reach Foundry.

The wrapper runs the original `__init__` first, then merges the hosting prefix into `self._custom_headers["User-Agent"]` while preserving:

- any caller-supplied `default_headers["User-Agent"]` override
- the SDK's own `self.user_agent` suffix (`AsyncOpenAI/Python <ver>`, `AsyncAnthropic/Python <ver>`, etc.)

Implementation is shared between SDKs via two small helpers — `_wrap_init_with_user_agent(cls)` and `_install_sdk_user_agent_stamp(module, classes)` — so adding more SDKs in the future is one line.

Other properties:

- `openai` and `anthropic` both stay non-runtime dependencies — the installers lazy-import via `importlib` and are no-ops if the SDK isn't installed. End users do **not** get `anthropic` transitively; it's pinned only in the Poetry test group so CI can exercise the stamper.
- Idempotent: per-SDK module-level flags (`_OPENAI_INIT_PATCHED`, `_ANTHROPIC_INIT_PATCHED`) prevent double-patching when `hosting` is reimported.
- Honors the existing telemetry opt-out (`LANGCHAIN_AZURE_AI_USER_AGENT_TELEMETRY_DISABLED`); when opted out the hosting prefix is empty and nothing is stamped.
- Wrapped in try/except so a patch failure can never break client construction.
- Also sets `AZURE_HTTP_USER_AGENT` via `os.environ.setdefault` so azure-core SDKs (which *do* honor it) get the same hosting prefix without overriding a caller-supplied value.

## Tests

14 new unit tests in `tests/unit_tests/test_user_agent.py`:

- `TestHostingAzureHttpUserAgent` (2): env var is set on import; caller value wins.
- `TestHostingOpenAIUserAgentStamp` (7): hosting prefix lands on `_custom_headers["User-Agent"]` for sync + async clients; caller-supplied User-Agent is preserved; installer is idempotent; opt-out path is honored; missing-`openai` is a no-op; per-class failure isolation.
- `TestHostingAnthropicUserAgentStamp` (6): mirrors the OpenAI suite for `anthropic` — async + sync client stamping, caller `default_headers` preservation, idempotency, opt-out, missing-SDK no-op. All tests use `pytest.importorskip("anthropic")`.

Full suite: 39 passed.