### PR TITLE
Expand Dependabot coverage: add uv entries for /samples and azure-cosmosdb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,6 +104,58 @@ updates:
         update-types:
           - "major"
 
+  - package-ecosystem: "uv"
+    directory: "/libs/azure-cosmosdb"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langchain-core"
+      - dependency-name: "langchain"
+      - dependency-name: "langchain-classic"
+      - dependency-name: "langchain-text-splitters"
+      - dependency-name: "langchain-tests"
+      - dependency-name: "langchain-model-profiles"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  - package-ecosystem: "uv"
+    directory: "/samples"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langchain-core"
+      - dependency-name: "langchain"
+      - dependency-name: "langchain-classic"
+      - dependency-name: "langchain-text-splitters"
+      - dependency-name: "langchain-tests"
+      - dependency-name: "langchain-model-profiles"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
   - package-ecosystem: "pip"
     directory: "/libs/azure-ai"
     schedule:


### PR DESCRIPTION
## What this does

Adds two `uv` `package-ecosystem` entries to `.github/dependabot.yml`:

- **`/samples`** — covers `samples/uv.lock`, which had **~29 open Dependabot alerts** and no matching config entry, so Dependabot never opened update PRs for it.
- **`/libs/azure-cosmosdb`** — this directory was absent from `dependabot.yml` entirely.

Both mirror the existing uv blocks (weekly schedule, `versioning-strategy: increase`, `langchain-*` ignores, minor-and-patch + major groups). Purely additive, non-breaking.

## Correction from the first revision

An earlier version of this PR also **deleted the `libs/*/poetry.lock` files**, on the assumption they were stale leftovers from a uv migration. **That was wrong and broke CI** — these libs are actively built with Poetry (`poetry run pytest`, `make test`), so `poetry.lock` is the live lockfile. Those deletions have been reverted; this PR now changes only `dependabot.yml`.

## The real root cause (needs a maintainer decision — not fixed here)

Most of the ~145 open Dependabot alerts sit in `libs/*/poetry.lock`:

| Manifest | Open alerts |
|---|---|
| `libs/azure-postgresql/poetry.lock` | 49 |
| `libs/azure-storage/poetry.lock` | 21 |
| `libs/azure-dynamic-sessions/poetry.lock` | 15 |
| `libs/sqlserver/poetry.lock` | 11 |
| `libs/azure-ai/poetry.lock` | 7 |
| `libs/azure-cosmosdb/poetry.lock` | 2 |

The libs are **dual-locked**: both `poetry.lock` and `uv.lock` are committed. CI uses Poetry, but `dependabot.yml` configures the **`uv`** ecosystem for these dirs — so Dependabot updates `uv.lock` while the alerts (and the lockfile CI actually installs from) live in `poetry.lock`, which it never touches.

Resolving those alerts requires picking a direction, e.g.:
- **Consolidate on uv** — migrate CI off Poetry and remove `poetry.lock`, or
- **Have Dependabot manage Poetry** — add `pip` ecosystem entries for these dirs (Dependabot's `pip` ecosystem reads `[tool.poetry]` + `poetry.lock`), in addition to or instead of the `uv` entries.

Flagging for maintainers rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)