### PR TITLE
Add AzureAIAnthropicChatModel for Anthropic Messages API on Azure AI Foundry

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/_resources.py
+++ b/libs/azure-ai/langchain_azure_ai/_resources.py
@@ -23,9 +23,15 @@ from langchain_azure_ai.utils.utils import get_service_endpoint_from_project
 
 logger = logging.getLogger(__name__)
 
+# Default OAuth 2.0 token scope used when acquiring bearer tokens for
+# Azure AI Foundry services.  Centralised here so that all callers
+# (chat models, embedding models, tool integrations, …) use exactly the
+# same scope string without having to hard-code it individually.
+_DEFAULT_FOUNDRY_SCOPE = "https://ai.azure.com/.default"
+
 
 def _make_token_provider(
-    credential: TokenCredential, scopes: str = "https://ai.azure.com/.default"
+    credential: TokenCredential, scopes: str = _DEFAULT_FOUNDRY_SCOPE
 ) -> Callable[[], str]:
     """Return a bearer-token provider callable for the given credential."""
     try:
@@ -40,7 +46,7 @@ def _make_token_provider(
 
 def _make_async_token_provider(
     credential: Union[TokenCredential, AsyncTokenCredential],
-    scopes: str = "https://ai.azure.com/.default",
+    scopes: str = _DEFAULT_FOUNDRY_SCOPE,
 ) -> Callable[[], Awaitable[str]]:
     """Return an async bearer-token provider for ``AsyncOpenAI``.
 

--- a/libs/azure-ai/langchain_azure_ai/_resources.py
+++ b/libs/azure-ai/langchain_azure_ai/_resources.py
@@ -24,7 +24,7 @@ from langchain_azure_ai.utils.utils import get_service_endpoint_from_project
 logger = logging.getLogger(__name__)
 
 # Default OAuth 2.0 token scope used when acquiring bearer tokens for
-# Azure AI Foundry services.  Centralised here so that all callers
+# Azure AI Foundry services.  Centralized here so that all callers
 # (chat models, embedding models, tool integrations, …) use exactly the
 # same scope string without having to hard-code it individually.
 _DEFAULT_FOUNDRY_SCOPE = "https://ai.azure.com/.default"

--- a/libs/azure-ai/langchain_azure_ai/chat_models/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/__init__.py
@@ -1,15 +1,18 @@
 """Chat completions model for Azure AI."""
 
+import importlib
 from typing import TYPE_CHECKING, Any
 
 from langchain_azure_ai.chat_models.openai import AzureAIOpenAIApiChatModel
 
 if TYPE_CHECKING:
+    from langchain_azure_ai.chat_models.anthropic import AzureAIAnthropicChatModel
     from langchain_azure_ai.chat_models.inference import AzureAIChatCompletionsModel
 
 __all__ = [
-    "AzureAIOpenAIApiChatModel",
+    "AzureAIAnthropicChatModel",
     "AzureAIChatCompletionsModel",
+    "AzureAIOpenAIApiChatModel",
 ]
 
 
@@ -22,4 +25,10 @@ def __getattr__(name: str) -> Any:
     # never called for that lookup, making the shim automatically inert.
     if name == "AzureAIChatCompletionsModel":
         return AzureAIOpenAIApiChatModel
+    if name == "AzureAIAnthropicChatModel":
+        # Imported lazily so that users who do not need Anthropic support
+        # are not required to install the optional `langchain-anthropic`
+        # and `anthropic` dependencies.
+        module = importlib.import_module("langchain_azure_ai.chat_models.anthropic")
+        return module.AzureAIAnthropicChatModel
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
@@ -244,9 +244,11 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
         # AnthropicFoundry falls back to the ANTHROPIC_FOUNDRY_RESOURCE
         # environment variable natively (resource and base_url are mutually
         # exclusive in AnthropicFoundry).
-        effective_endpoint = self.endpoint
-        if effective_endpoint is None and self.project_endpoint is not None:
-            effective_endpoint = _get_base_url_from_endpoint(self.project_endpoint)
+        effective_endpoint = (
+            _get_base_url_from_endpoint(self.project_endpoint)
+            if self.project_endpoint is not None
+            else self.endpoint
+        )
 
         if effective_endpoint is not None:
             params["base_url"] = _resolve_anthropic_endpoint(effective_endpoint)

--- a/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
@@ -12,6 +12,8 @@ from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCreden
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 
 from langchain_azure_ai._resources import (
+    _DEFAULT_FOUNDRY_SCOPE,
+    _get_base_url_from_endpoint,
     _make_async_token_provider,
     _make_token_provider,
 )
@@ -27,10 +29,6 @@ except ImportError as exc:  # pragma: no cover - exercised via lazy import
     ) from exc
 
 logger = logging.getLogger(__name__)
-
-# Token scope used to acquire bearer tokens for the Azure AI Foundry
-# Anthropic Messages API.
-_ANTHROPIC_FOUNDRY_SCOPE = "https://ai.azure.com/.default"
 
 # Environment variable holding the Azure AI Foundry resource name or full URL.
 # When only a resource name is provided (no ``://``), the endpoint is
@@ -105,6 +103,21 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
     ``/anthropic`` path is appended automatically.  You may also pass a URL
     that already ends in ``/anthropic`` – the result is the same.
 
+    Alternatively, supply a Foundry *project* endpoint and the resource
+    root is derived automatically:
+
+    ```python
+    model = AzureAIAnthropicChatModel(
+        project_endpoint=(
+            "https://<resource>.services.ai.azure.com/api/projects/my-project"
+        ),
+        credential=DefaultAzureCredential(),
+        model="claude-sonnet-4-20250514",
+    )
+    ```
+
+    ``project_endpoint`` and ``endpoint`` are mutually exclusive.
+
     **API-key authentication:**
 
     ```python
@@ -136,12 +149,18 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
         validate_by_name=True,
     )
 
+    project_endpoint: Optional[str] = Field(default=None)
+    """Azure AI Foundry project endpoint, e.g.
+    ``https://<resource>.services.ai.azure.com/api/projects/<project>``.
+    The resource root is extracted automatically and ``/anthropic`` is
+    appended.  Mutually exclusive with ``endpoint``."""
+
     endpoint: Optional[str] = Field(default=None)
     """Azure AI Foundry resource endpoint, e.g.
     ``https://<resource>.services.ai.azure.com``.  ``/anthropic`` is
     appended automatically.  When omitted, falls back to the
     ``ANTHROPIC_FOUNDRY_RESOURCE`` environment variable (resource name or
-    full URL)."""
+    full URL).  Mutually exclusive with ``project_endpoint``."""
 
     credential: Optional[
         Union[str, AzureKeyCredential, TokenCredential, AsyncTokenCredential]
@@ -178,14 +197,33 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
 
         credential = values.get("credential")
         endpoint = values.get("endpoint")
+        project_endpoint = values.get("project_endpoint")
+
+        # Validate mutual exclusivity.
+        if project_endpoint and endpoint:
+            raise ValueError(
+                "Both `project_endpoint` and `endpoint` were provided.  "
+                "Use only one: `project_endpoint` for Azure AI Foundry "
+                "projects, or `endpoint` for direct resource endpoints."
+            )
+
+        # When a project endpoint is given, derive the resource base URL
+        # from it so that ``_resolve_anthropic_endpoint`` can append the
+        # ``/anthropic`` path correctly.
+        endpoint_for_resolution = endpoint
+        if project_endpoint:
+            endpoint_for_resolution = _get_base_url_from_endpoint(project_endpoint)
 
         # Pre-populate ``base_url`` on the underlying ChatAnthropic instance
         # so introspection (e.g. ``self.anthropic_api_url``) reflects the
         # resolved Foundry endpoint.  The actual HTTP base URL used by the
-        # overridden clients is computed from ``self.endpoint`` directly.
+        # overridden clients is computed from ``self.endpoint`` /
+        # ``self.project_endpoint`` directly.
         resource_env = os.environ.get(_ANTHROPIC_FOUNDRY_RESOURCE_ENV_VAR, "").strip()
-        if endpoint or resource_env:
-            values.setdefault("base_url", _resolve_anthropic_endpoint(endpoint))
+        if endpoint_for_resolution or resource_env:
+            values.setdefault(
+                "base_url", _resolve_anthropic_endpoint(endpoint_for_resolution)
+            )
 
         if "api_key" not in values and "anthropic_api_key" not in values:
             if isinstance(credential, (str, AzureKeyCredential)):
@@ -201,12 +239,17 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
             "max_retries": self.max_retries,
             "default_headers": self._client_params.get("default_headers", {}),
         }
-        if self.endpoint is not None:
-            # Explicit endpoint provided – pass it as base_url.
-            # When endpoint is None, AnthropicFoundry reads
-            # ANTHROPIC_FOUNDRY_RESOURCE natively (resource and base_url are
-            # mutually exclusive in AnthropicFoundry).
-            params["base_url"] = _resolve_anthropic_endpoint(self.endpoint)
+        # Determine the effective resource endpoint.  ``project_endpoint``
+        # takes priority over ``endpoint``; when both are None,
+        # AnthropicFoundry falls back to the ANTHROPIC_FOUNDRY_RESOURCE
+        # environment variable natively (resource and base_url are mutually
+        # exclusive in AnthropicFoundry).
+        effective_endpoint = self.endpoint
+        if effective_endpoint is None and self.project_endpoint is not None:
+            effective_endpoint = _get_base_url_from_endpoint(self.project_endpoint)
+
+        if effective_endpoint is not None:
+            params["base_url"] = _resolve_anthropic_endpoint(effective_endpoint)
         if self.default_request_timeout is None or self.default_request_timeout > 0:
             params["timeout"] = self.default_request_timeout
         return params
@@ -233,7 +276,7 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
         if isinstance(credential, TokenCredential):
             return AnthropicFoundry(
                 azure_ad_token_provider=_make_token_provider(
-                    credential, _ANTHROPIC_FOUNDRY_SCOPE
+                    credential, _DEFAULT_FOUNDRY_SCOPE
                 ),
                 **params,
             )
@@ -255,7 +298,7 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
         if isinstance(credential, (TokenCredential, AsyncTokenCredential)):
             return AsyncAnthropicFoundry(
                 azure_ad_token_provider=_make_async_token_provider(
-                    credential, _ANTHROPIC_FOUNDRY_SCOPE
+                    credential, _DEFAULT_FOUNDRY_SCOPE
                 ),
                 **params,
             )

--- a/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
@@ -140,7 +140,7 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
     * ``ANTHROPIC_FOUNDRY_RESOURCE`` – resolved as ``endpoint`` when neither
       ``endpoint`` nor ``project_endpoint`` is set (directly or via env var).
       May be a bare resource name (e.g. ``my-resource``) or a full URL.  When
-      a bare name is provided the endpoint is synthesised as
+      a bare name is provided the endpoint is synthesized as
       ``https://<ANTHROPIC_FOUNDRY_RESOURCE>.services.ai.azure.com``.
       This is the same variable used by **Claude Code** when connected to
       Azure AI Foundry, so models configured that way will work here without

--- a/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
@@ -17,6 +17,7 @@ from langchain_azure_ai._resources import (
     _make_async_token_provider,
     _make_token_provider,
 )
+from langchain_azure_ai.utils.env import get_project_endpoint
 
 try:
     from anthropic import AnthropicFoundry, AsyncAnthropicFoundry
@@ -130,11 +131,27 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
 
     **Environment variables:**
 
-    * ``ANTHROPIC_FOUNDRY_RESOURCE`` – used as the ``endpoint`` when the
-      constructor parameter is omitted.  May be a bare resource name (e.g.
-      ``my-resource``) or a full URL.  When a bare name is provided the
-      endpoint is synthesized as
+    The following environment variables are checked when the corresponding
+    constructor parameters are not provided:
+
+    * ``AZURE_AI_PROJECT_ENDPOINT`` or ``FOUNDRY_PROJECT_ENDPOINT`` – resolved
+      as ``project_endpoint``.  ``AZURE_AI_PROJECT_ENDPOINT`` takes precedence
+      when both are set.
+    * ``ANTHROPIC_FOUNDRY_RESOURCE`` – resolved as ``endpoint`` when neither
+      ``endpoint`` nor ``project_endpoint`` is set (directly or via env var).
+      May be a bare resource name (e.g. ``my-resource``) or a full URL.  When
+      a bare name is provided the endpoint is synthesised as
       ``https://<ANTHROPIC_FOUNDRY_RESOURCE>.services.ai.azure.com``.
+      This is the same variable used by **Claude Code** when connected to
+      Azure AI Foundry, so models configured that way will work here without
+      any additional configuration.
+
+    **Resolution priority** (highest to lowest):
+
+    1. Constructor parameters (``project_endpoint``, ``endpoint``).
+    2. ``AZURE_AI_PROJECT_ENDPOINT`` environment variable (or
+       ``FOUNDRY_PROJECT_ENDPOINT`` if the former is not set).
+    3. ``ANTHROPIC_FOUNDRY_RESOURCE`` environment variable.
 
     All other keyword arguments accepted by
     :class:`langchain_anthropic.ChatAnthropic` are forwarded as-is.
@@ -153,7 +170,10 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
     """Azure AI Foundry project endpoint, e.g.
     ``https://<resource>.services.ai.azure.com/api/projects/<project>``.
     The resource root is extracted automatically and ``/anthropic`` is
-    appended.  Mutually exclusive with ``endpoint``."""
+    appended.  Mutually exclusive with ``endpoint``.
+
+    When omitted, falls back to the ``AZURE_AI_PROJECT_ENDPOINT`` environment
+    variable (or ``FOUNDRY_PROJECT_ENDPOINT`` as a secondary alias)."""
 
     endpoint: Optional[str] = Field(default=None)
     """Azure AI Foundry resource endpoint, e.g.
@@ -206,6 +226,14 @@ class AzureAIAnthropicChatModel(ChatAnthropic):
                 "Use only one: `project_endpoint` for Azure AI Foundry "
                 "projects, or `endpoint` for direct resource endpoints."
             )
+
+        # Fall back to AZURE_AI_PROJECT_ENDPOINT / FOUNDRY_PROJECT_ENDPOINT
+        # environment variables when no constructor parameter was provided —
+        # the same resolution logic used by all other Azure AI models.
+        if not project_endpoint and not endpoint:
+            project_endpoint = get_project_endpoint(values, nullable=True)
+            if project_endpoint:
+                values["project_endpoint"] = project_endpoint
 
         # When a project endpoint is given, derive the resource base URL
         # from it so that ``_resolve_anthropic_endpoint`` can append the

--- a/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
+++ b/libs/azure-ai/langchain_azure_ai/chat_models/anthropic.py
@@ -1,0 +1,263 @@
+"""Azure AI chat model using the Anthropic Messages API via Azure AI Foundry."""
+
+import logging
+import os
+from functools import cached_property
+from typing import Any, Optional, Union
+
+from azure.core.credentials import AzureKeyCredential, TokenCredential
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.identity import DefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCredential
+from pydantic import ConfigDict, Field, SecretStr, model_validator
+
+from langchain_azure_ai._resources import (
+    _make_async_token_provider,
+    _make_token_provider,
+)
+
+try:
+    from anthropic import AnthropicFoundry, AsyncAnthropicFoundry
+    from langchain_anthropic import ChatAnthropic
+except ImportError as exc:  # pragma: no cover - exercised via lazy import
+    raise ImportError(
+        "`AzureAIAnthropicChatModel` requires the optional "
+        "`langchain-anthropic` and `anthropic` packages. "
+        "Install them with `pip install anthropic langchain-anthropic`."
+    ) from exc
+
+logger = logging.getLogger(__name__)
+
+# Token scope used to acquire bearer tokens for the Azure AI Foundry
+# Anthropic Messages API.
+_ANTHROPIC_FOUNDRY_SCOPE = "https://ai.azure.com/.default"
+
+# Environment variable holding the Azure AI Foundry resource name or full URL.
+# When only a resource name is provided (no ``://``), the endpoint is
+# synthesized as ``https://<resource>.services.ai.azure.com``.
+_ANTHROPIC_FOUNDRY_RESOURCE_ENV_VAR = "ANTHROPIC_FOUNDRY_RESOURCE"
+
+
+def _resolve_anthropic_endpoint(endpoint: Optional[str]) -> str:
+    """Resolve the Anthropic Foundry ``base_url`` from an endpoint value.
+
+    Accepts the Foundry resource root (e.g.
+    ``https://<resource>.services.ai.azure.com``) or a URL that already
+    includes the ``/anthropic`` path; in both cases the returned value ends
+    with ``/anthropic/``.
+
+    When *endpoint* is ``None``, falls back to the
+    ``ANTHROPIC_FOUNDRY_RESOURCE`` environment variable, which holds a bare
+    Foundry resource name (e.g. ``my-resource``).  The endpoint is then
+    synthesized as
+    ``https://<ANTHROPIC_FOUNDRY_RESOURCE>.services.ai.azure.com/anthropic/``.
+    """
+    if not endpoint:
+        resource = os.environ.get(_ANTHROPIC_FOUNDRY_RESOURCE_ENV_VAR, "").strip()
+        if not resource:
+            raise ValueError(
+                "An `endpoint` must be provided, or the "
+                f"`{_ANTHROPIC_FOUNDRY_RESOURCE_ENV_VAR}` environment variable "
+                "must be set to the Foundry resource name."
+            )
+        endpoint = f"https://{resource}.services.ai.azure.com"
+
+    stripped = endpoint.rstrip("/")
+    if stripped.endswith("/anthropic"):
+        return stripped + "/"
+    return stripped + "/anthropic/"
+
+
+def _extract_api_key(credential: Union[str, AzureKeyCredential]) -> str:
+    """Return the raw API key from a string or :class:`AzureKeyCredential`."""
+    if isinstance(credential, str):
+        return credential
+    return credential.key
+
+
+class AzureAIAnthropicChatModel(ChatAnthropic):
+    """Azure AI chat model using the Anthropic Messages API.
+
+    Wraps :class:`langchain_anthropic.ChatAnthropic` so that Anthropic
+    Claude models hosted by Azure AI Foundry can be accessed through the
+    ``/anthropic`` endpoint with native Microsoft Entra ID authentication.
+
+    Authentication uses :class:`anthropic.AnthropicFoundry` (and
+    :class:`anthropic.AsyncAnthropicFoundry`) under the hood, which accepts
+    an ``azure_ad_token_provider`` callable that is invoked on every
+    request – so bearer tokens are refreshed automatically and the model
+    can be used in long-running services without manual token rotation.
+
+    **Microsoft Entra ID authentication (recommended):**
+
+    ```python
+    from langchain_azure_ai.chat_models import AzureAIAnthropicChatModel
+    from azure.identity import DefaultAzureCredential
+
+    model = AzureAIAnthropicChatModel(
+        endpoint="https://<resource>.services.ai.azure.com",
+        credential=DefaultAzureCredential(),
+        model="claude-sonnet-4-20250514",
+    )
+    ```
+
+    The ``endpoint`` is the Azure AI Foundry resource root; the
+    ``/anthropic`` path is appended automatically.  You may also pass a URL
+    that already ends in ``/anthropic`` – the result is the same.
+
+    **API-key authentication:**
+
+    ```python
+    model = AzureAIAnthropicChatModel(
+        endpoint="https://<resource>.services.ai.azure.com",
+        credential="your-api-key",
+        model="claude-sonnet-4-20250514",
+    )
+    ```
+
+    **Environment variables:**
+
+    * ``ANTHROPIC_FOUNDRY_RESOURCE`` – used as the ``endpoint`` when the
+      constructor parameter is omitted.  May be a bare resource name (e.g.
+      ``my-resource``) or a full URL.  When a bare name is provided the
+      endpoint is synthesized as
+      ``https://<ANTHROPIC_FOUNDRY_RESOURCE>.services.ai.azure.com``.
+
+    All other keyword arguments accepted by
+    :class:`langchain_anthropic.ChatAnthropic` are forwarded as-is.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra="ignore",
+        protected_namespaces=(),
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+    )
+
+    endpoint: Optional[str] = Field(default=None)
+    """Azure AI Foundry resource endpoint, e.g.
+    ``https://<resource>.services.ai.azure.com``.  ``/anthropic`` is
+    appended automatically.  When omitted, falls back to the
+    ``ANTHROPIC_FOUNDRY_RESOURCE`` environment variable (resource name or
+    full URL)."""
+
+    credential: Optional[
+        Union[str, AzureKeyCredential, TokenCredential, AsyncTokenCredential]
+    ] = Field(default=None)
+    """Credential for authentication.
+
+    * A plain ``str`` or :class:`~azure.core.credentials.AzureKeyCredential`
+      is treated as an Anthropic API key.
+    * A :class:`~azure.core.credentials.TokenCredential` (e.g.
+      :class:`~azure.identity.DefaultAzureCredential`) or
+      :class:`~azure.core.credentials_async.AsyncTokenCredential` (e.g.
+      :class:`~azure.identity.aio.DefaultAzureCredential`) is used as a
+      callable bearer-token provider so that tokens are refreshed
+      automatically.
+    * ``None`` (default) falls back to
+      :class:`~azure.identity.DefaultAzureCredential`.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _configure_foundry(cls, values: Any) -> Any:
+        """Resolve endpoint, credential and inject a placeholder API key.
+
+        :class:`~langchain_anthropic.ChatAnthropic` requires a non-empty
+        ``api_key`` field (it reads from ``ANTHROPIC_API_KEY`` when not
+        provided).  When the user passes an Azure ``TokenCredential`` there
+        is no API key, so a placeholder value is injected to satisfy
+        validation; the actual ``_client`` and ``_async_client`` are
+        overridden below to use :class:`anthropic.AnthropicFoundry`, which
+        handles bearer-token authentication itself.
+        """
+        if not isinstance(values, dict):
+            return values
+
+        credential = values.get("credential")
+        endpoint = values.get("endpoint")
+
+        # Pre-populate ``base_url`` on the underlying ChatAnthropic instance
+        # so introspection (e.g. ``self.anthropic_api_url``) reflects the
+        # resolved Foundry endpoint.  The actual HTTP base URL used by the
+        # overridden clients is computed from ``self.endpoint`` directly.
+        resource_env = os.environ.get(_ANTHROPIC_FOUNDRY_RESOURCE_ENV_VAR, "").strip()
+        if endpoint or resource_env:
+            values.setdefault("base_url", _resolve_anthropic_endpoint(endpoint))
+
+        if "api_key" not in values and "anthropic_api_key" not in values:
+            if isinstance(credential, (str, AzureKeyCredential)):
+                values["api_key"] = _extract_api_key(credential)
+            else:
+                values["api_key"] = SecretStr("placeholder-managed-by-azure")
+
+        return values
+
+    def _foundry_client_params(self) -> dict:
+        """Build keyword arguments shared by sync and async Foundry clients."""
+        params: dict = {
+            "max_retries": self.max_retries,
+            "default_headers": self._client_params.get("default_headers", {}),
+        }
+        if self.endpoint is not None:
+            # Explicit endpoint provided – pass it as base_url.
+            # When endpoint is None, AnthropicFoundry reads
+            # ANTHROPIC_FOUNDRY_RESOURCE natively (resource and base_url are
+            # mutually exclusive in AnthropicFoundry).
+            params["base_url"] = _resolve_anthropic_endpoint(self.endpoint)
+        if self.default_request_timeout is None or self.default_request_timeout > 0:
+            params["timeout"] = self.default_request_timeout
+        return params
+
+    @cached_property
+    def _client(self) -> Any:  # type: ignore[override]
+        """Return an :class:`anthropic.AnthropicFoundry` client."""
+        credential = self.credential
+        if credential is None:
+            logger.info("No credential provided, using DefaultAzureCredential().")
+            credential = DefaultAzureCredential()
+
+        params = self._foundry_client_params()
+
+        if isinstance(credential, (str, AzureKeyCredential)):
+            return AnthropicFoundry(api_key=_extract_api_key(credential), **params)
+        if isinstance(credential, AsyncTokenCredential):
+            raise ValueError(
+                "An `AsyncTokenCredential` was provided but the synchronous "
+                "client was requested.  Provide a `TokenCredential` "
+                "(e.g. `DefaultAzureCredential()`) instead, or call the "
+                "async API."
+            )
+        if isinstance(credential, TokenCredential):
+            return AnthropicFoundry(
+                azure_ad_token_provider=_make_token_provider(
+                    credential, _ANTHROPIC_FOUNDRY_SCOPE
+                ),
+                **params,
+            )
+
+        raise ValueError(f"Unsupported credential type: {type(credential).__name__}.")
+
+    @cached_property
+    def _async_client(self) -> Any:  # type: ignore[override]
+        """Return an :class:`anthropic.AsyncAnthropicFoundry` client."""
+        credential = self.credential
+        if credential is None:
+            logger.info("No credential provided, using AsyncDefaultAzureCredential().")
+            credential = AsyncDefaultAzureCredential()
+
+        params = self._foundry_client_params()
+
+        if isinstance(credential, (str, AzureKeyCredential)):
+            return AsyncAnthropicFoundry(api_key=_extract_api_key(credential), **params)
+        if isinstance(credential, (TokenCredential, AsyncTokenCredential)):
+            return AsyncAnthropicFoundry(
+                azure_ad_token_provider=_make_async_token_provider(
+                    credential, _ANTHROPIC_FOUNDRY_SCOPE
+                ),
+                **params,
+            )
+
+        raise ValueError(f"Unsupported credential type: {type(credential).__name__}.")

--- a/libs/azure-ai/langchain_azure_ai/utils/env.py
+++ b/libs/azure-ai/langchain_azure_ai/utils/env.py
@@ -45,12 +45,24 @@ def get_project_endpoint(
         ValueError: When the endpoint cannot be resolved and *nullable* is
             ``False``.
     """
-    return get_from_dict_or_env(
+    endpoint = get_from_dict_or_env(
         data or {},
         "project_endpoint",
         PROJECT_ENDPOINT_ENV_VARS,
-        nullable=nullable,
+        nullable=True,
     )
+    if endpoint:
+        return endpoint
+
+    if nullable:
+        return None
+
+    msg = (
+        "Did not find project_endpoint, please add an environment variable"
+        f" `{PROJECT_ENDPOINT_ENV_VARS[0]}` which contains it, or pass"
+        " `project_endpoint` as a named parameter."
+    )
+    raise ValueError(msg)
 
 
 def get_from_dict_or_env(

--- a/libs/azure-ai/pyproject.toml
+++ b/libs/azure-ai/pyproject.toml
@@ -106,6 +106,10 @@ module = [
   "deepagents.*",
   "azure.cognitiveservices",
   "azure.cognitiveservices.*",
+  "anthropic",
+  "anthropic.*",
+  "langchain_anthropic",
+  "langchain_anthropic.*",
 ]
 ignore_missing_imports = true
 follow_imports = "skip"
@@ -167,6 +171,7 @@ test = [
   "pytest-recording~=0.13.4",
   "vcrpy>=8.2.1",
   "anthropic (>=0.111.0,<1.0)",
+  "langchain-anthropic (>=1.3.0,<2.0)",
 ]
 test_integration = ["pytest>=9.0.3,<10", "python-dotenv~=1.0", "pytest-recording~=0.13.4", "vcrpy>=8.2.1"]
 typing = ["mypy>=1.10,<3.0", "types-requests~=2.28"]

--- a/libs/azure-ai/tests/unit_tests/test_chat_models_anthropic.py
+++ b/libs/azure-ai/tests/unit_tests/test_chat_models_anthropic.py
@@ -234,3 +234,44 @@ class TestAzureAIAnthropicChatModel:
                 credential="sk-ant-test",
                 model="claude-sonnet-4-20250514",
             )
+
+    def test_azure_ai_project_endpoint_env_var_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "AZURE_AI_PROJECT_ENDPOINT",
+            "https://env-resource.services.ai.azure.com/api/projects/env-project",
+        )
+        monkeypatch.delenv("ANTHROPIC_FOUNDRY_RESOURCE", raising=False)
+        model = AzureAIAnthropicChatModel(
+            credential="sk-ant-test",
+            model="claude-sonnet-4-20250514",
+        )
+        assert model.project_endpoint == (
+            "https://env-resource.services.ai.azure.com/api/projects/env-project"
+        )
+        assert (
+            str(model._client.base_url)
+            == "https://env-resource.services.ai.azure.com/anthropic/"
+        )
+
+    def test_foundry_project_endpoint_env_var_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "FOUNDRY_PROJECT_ENDPOINT",
+            "https://env2-resource.services.ai.azure.com/api/projects/env-project",
+        )
+        monkeypatch.delenv("AZURE_AI_PROJECT_ENDPOINT", raising=False)
+        monkeypatch.delenv("ANTHROPIC_FOUNDRY_RESOURCE", raising=False)
+        model = AzureAIAnthropicChatModel(
+            credential="sk-ant-test",
+            model="claude-sonnet-4-20250514",
+        )
+        assert model.project_endpoint == (
+            "https://env2-resource.services.ai.azure.com/api/projects/env-project"
+        )
+        assert (
+            str(model._client.base_url)
+            == "https://env2-resource.services.ai.azure.com/anthropic/"
+        )

--- a/libs/azure-ai/tests/unit_tests/test_chat_models_anthropic.py
+++ b/libs/azure-ai/tests/unit_tests/test_chat_models_anthropic.py
@@ -190,3 +190,47 @@ class TestAzureAIAnthropicChatModel:
             str(model._client.base_url)
             == "https://env-resource.services.ai.azure.com/anthropic/"
         )
+
+    def test_project_endpoint_derives_resource_url(self) -> None:
+        model = AzureAIAnthropicChatModel(
+            project_endpoint=(
+                "https://test.services.ai.azure.com/api/projects/my-project"
+            ),
+            credential="sk-ant-test",
+            model="claude-sonnet-4-20250514",
+        )
+        assert (
+            str(model._client.base_url)
+            == "https://test.services.ai.azure.com/anthropic/"
+        )
+        assert model.project_endpoint == (
+            "https://test.services.ai.azure.com/api/projects/my-project"
+        )
+        assert model.endpoint is None
+
+    def test_project_endpoint_with_token_credential(self) -> None:
+        cred = _FakeTokenCredential()
+        model = AzureAIAnthropicChatModel(
+            project_endpoint=(
+                "https://test.services.ai.azure.com/api/projects/my-project"
+            ),
+            credential=cred,
+            model="claude-sonnet-4-20250514",
+        )
+        client = model._client
+        assert type(client).__name__ == "AnthropicFoundry"
+        assert str(client.base_url) == "https://test.services.ai.azure.com/anthropic/"
+        provider = client._azure_ad_token_provider
+        assert callable(provider)
+        assert provider() == "fake-sync-token"
+
+    def test_project_endpoint_and_endpoint_are_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError, match="Both.*project_endpoint.*endpoint"):
+            AzureAIAnthropicChatModel(
+                project_endpoint=(
+                    "https://test.services.ai.azure.com/api/projects/my-project"
+                ),
+                endpoint="https://test.services.ai.azure.com",
+                credential="sk-ant-test",
+                model="claude-sonnet-4-20250514",
+            )

--- a/libs/azure-ai/tests/unit_tests/test_chat_models_anthropic.py
+++ b/libs/azure-ai/tests/unit_tests/test_chat_models_anthropic.py
@@ -1,0 +1,192 @@
+"""Unit tests for AzureAIAnthropicChatModel."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from azure.core.credentials import AccessToken, AzureKeyCredential, TokenCredential
+from azure.core.credentials_async import AsyncTokenCredential
+
+from langchain_azure_ai.chat_models import AzureAIAnthropicChatModel
+from langchain_azure_ai.chat_models.anthropic import _resolve_anthropic_endpoint
+
+
+class _FakeTokenCredential(TokenCredential):
+    """Sync TokenCredential that returns a static token."""
+
+    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+        return AccessToken("fake-sync-token", 9999999999)
+
+
+class _FakeAsyncTokenCredential(AsyncTokenCredential):
+    """Async TokenCredential that returns a static token."""
+
+    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+        return AccessToken("fake-async-token", 9999999999)
+
+    async def close(self) -> None:
+        return None
+
+    async def __aenter__(self) -> "_FakeAsyncTokenCredential":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+
+class TestResolveAnthropicEndpoint:
+    """Tests for the endpoint resolution helper."""
+
+    def test_appends_anthropic_path(self) -> None:
+        assert (
+            _resolve_anthropic_endpoint("https://r.services.ai.azure.com")
+            == "https://r.services.ai.azure.com/anthropic/"
+        )
+
+    def test_trailing_slash_is_normalised(self) -> None:
+        assert (
+            _resolve_anthropic_endpoint("https://r.services.ai.azure.com/")
+            == "https://r.services.ai.azure.com/anthropic/"
+        )
+
+    def test_preserves_explicit_anthropic_path(self) -> None:
+        assert (
+            _resolve_anthropic_endpoint("https://r.services.ai.azure.com/anthropic")
+            == "https://r.services.ai.azure.com/anthropic/"
+        )
+
+    def test_env_fallback_resource_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_RESOURCE", "my-resource")
+        assert (
+            _resolve_anthropic_endpoint(None)
+            == "https://my-resource.services.ai.azure.com/anthropic/"
+        )
+
+    def test_missing_endpoint_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_FOUNDRY_RESOURCE", raising=False)
+        with pytest.raises(ValueError, match="ANTHROPIC_FOUNDRY_RESOURCE"):
+            _resolve_anthropic_endpoint(None)
+
+
+class TestAzureAIAnthropicChatModel:
+    """Tests for AzureAIAnthropicChatModel construction and client wiring."""
+
+    def test_api_key_string_credential(self) -> None:
+        model = AzureAIAnthropicChatModel(
+            endpoint="https://test.services.ai.azure.com",
+            credential="sk-ant-test",
+            model="claude-sonnet-4-20250514",
+        )
+
+        assert (
+            model.anthropic_api_url == "https://test.services.ai.azure.com/anthropic/"
+        )
+        client = model._client
+        async_client = model._async_client
+
+        assert type(client).__name__ == "AnthropicFoundry"
+        assert type(async_client).__name__ == "AsyncAnthropicFoundry"
+        assert str(client.base_url) == "https://test.services.ai.azure.com/anthropic/"
+        assert client.api_key == "sk-ant-test"
+        assert async_client.api_key == "sk-ant-test"
+
+    def test_azure_key_credential(self) -> None:
+        model = AzureAIAnthropicChatModel(
+            endpoint="https://test.services.ai.azure.com",
+            credential=AzureKeyCredential("my-key"),
+            model="claude-sonnet-4-20250514",
+        )
+
+        assert model._client.api_key == "my-key"
+        assert model._async_client.api_key == "my-key"
+
+    def test_token_credential_uses_azure_ad_token_provider(self) -> None:
+        cred = _FakeTokenCredential()
+        model = AzureAIAnthropicChatModel(
+            endpoint="https://test.services.ai.azure.com",
+            credential=cred,
+            model="claude-sonnet-4-20250514",
+        )
+
+        client = model._client
+        # AnthropicFoundry stores the provider on a private attribute.
+        provider = client._azure_ad_token_provider
+        assert callable(provider)
+        assert provider() == "fake-sync-token"
+        # API key was injected as a placeholder so validation passes; the
+        # actual auth happens via the token provider.
+        assert client.api_key != "sk-ant-test"
+
+    def test_async_token_credential_uses_async_provider(self) -> None:
+        cred = _FakeAsyncTokenCredential()
+        model = AzureAIAnthropicChatModel(
+            endpoint="https://test.services.ai.azure.com",
+            credential=cred,
+            model="claude-sonnet-4-20250514",
+        )
+
+        async_client = model._async_client
+        assert type(async_client).__name__ == "AsyncAnthropicFoundry"
+        provider = async_client._azure_ad_token_provider
+        assert callable(provider)
+
+    def test_async_token_credential_rejected_for_sync_client(self) -> None:
+        cred = _FakeAsyncTokenCredential()
+        model = AzureAIAnthropicChatModel(
+            endpoint="https://test.services.ai.azure.com",
+            credential=cred,
+            model="claude-sonnet-4-20250514",
+        )
+
+        with pytest.raises(ValueError, match="AsyncTokenCredential"):
+            _ = model._client
+
+    def test_default_credential_used_when_none(self) -> None:
+        with patch(
+            "langchain_azure_ai.chat_models.anthropic.DefaultAzureCredential"
+        ) as default_cred_cls:
+            default_cred_cls.return_value = _FakeTokenCredential()
+            model = AzureAIAnthropicChatModel(
+                endpoint="https://test.services.ai.azure.com",
+                model="claude-sonnet-4-20250514",
+            )
+            _ = model._client
+
+        default_cred_cls.assert_called_once()
+
+    def test_async_default_credential_used_when_none(self) -> None:
+        with patch(
+            "langchain_azure_ai.chat_models.anthropic.AsyncDefaultAzureCredential"
+        ) as async_default_cred_cls:
+            async_default_cred_cls.return_value = _FakeAsyncTokenCredential()
+            model = AzureAIAnthropicChatModel(
+                endpoint="https://test.services.ai.azure.com",
+                model="claude-sonnet-4-20250514",
+            )
+            _ = model._async_client
+
+        async_default_cred_cls.assert_called_once()
+
+    def test_endpoint_already_has_anthropic_suffix(self) -> None:
+        model = AzureAIAnthropicChatModel(
+            endpoint="https://test.services.ai.azure.com/anthropic",
+            credential="sk-ant-test",
+            model="claude-sonnet-4-20250514",
+        )
+        assert (
+            str(model._client.base_url)
+            == "https://test.services.ai.azure.com/anthropic/"
+        )
+
+    def test_env_var_resource_name_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_RESOURCE", "env-resource")
+        model = AzureAIAnthropicChatModel(
+            credential="sk-ant-test",
+            model="claude-sonnet-4-20250514",
+        )
+        assert (
+            str(model._client.base_url)
+            == "https://env-resource.services.ai.azure.com/anthropic/"
+        )

--- a/libs/azure-ai/uv.lock
+++ b/libs/azure-ai/uv.lock
@@ -987,7 +987,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1295,17 +1295,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -1323,18 +1323,18 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -1346,7 +1346,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1543,6 +1543,20 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-anthropic"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/e3/d2f9dec95602524b1cfb4be2747ba5bc38d32501b2a56cb4bcb76e80bb45/langchain_anthropic-1.4.3.tar.gz", hash = "sha256:f8a2442463c0629b1b3110eaeaa56fdbdc87df2a802f8c7f5ecf611eb4874ec8", size = 685219, upload-time = "2026-05-03T17:33:27.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/55/482a1968c95275e8be6d8c1e53b54f0f7be0b8b155ce1608c947a95cf543/langchain_anthropic-1.4.3-py3-none-any.whl", hash = "sha256:65466e0f2f95909a009708f2958e917dfdbfab79c612b4484a30866a85e1f291", size = 50389, upload-time = "2026-05-03T17:33:25.671Z" },
+]
+
+[[package]]
 name = "langchain-azure-ai"
 version = "1.2.8"
 source = { editable = "." }
@@ -1611,6 +1625,7 @@ lint = [
 test = [
     { name = "anthropic" },
     { name = "azure-monitor-opentelemetry" },
+    { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
@@ -1694,6 +1709,7 @@ lint = [
 test = [
     { name = "anthropic", specifier = ">=0.111.0,<1.0" },
     { name = "azure-monitor-opentelemetry", specifier = "~=1.6" },
+    { name = "langchain-anthropic", specifier = ">=1.3.0,<2.0" },
     { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore" },
     { name = "opentelemetry-api", specifier = ">=1.37" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.58b0" },
@@ -4061,8 +4077,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [


### PR DESCRIPTION
Picks up the work from #773 (closed).

Adds `AzureAIAnthropicChatModel`, a new chat model class that wraps `langchain_anthropic.ChatAnthropic` to enable Anthropic Claude models hosted on Azure AI Foundry to be accessed through the `/anthropic` endpoint with native Microsoft Entra ID authentication.

### Changes

- **`langchain_azure_ai/chat_models/anthropic.py`**: New `AzureAIAnthropicChatModel` class supporting API-key and Entra ID (`TokenCredential` / `AsyncTokenCredential`) authentication. Supports both `endpoint` (direct resource URL) and `project_endpoint` (Azure AI Foundry project URL) — these are mutually exclusive. Uses `anthropic.AnthropicFoundry` and `anthropic.AsyncAnthropicFoundry` as the underlying HTTP clients so bearer tokens are refreshed automatically. When neither `endpoint` nor `project_endpoint` is provided, falls back to the `ANTHROPIC_FOUNDRY_RESOURCE` environment variable (a bare Foundry resource name).
- **`langchain_azure_ai/_resources.py`**: Extracted `_DEFAULT_FOUNDRY_SCOPE = "https://ai.azure.com/.default"` as a named constant, centralising the OAuth scope used by `_make_token_provider` and `_make_async_token_provider` (previously a repeated string literal).
- **`langchain_azure_ai/chat_models/__init__.py`**: `AzureAIAnthropicChatModel` is exposed via a lazy import so users who don't need Anthropic support are not forced to install optional packages. Attempting to import without the packages raises a clear `ImportError` with instructions to run `pip install anthropic langchain-anthropic`.
- **`langchain_azure_ai/utils/env.py`**: `get_project_endpoint` now resolves nullable separately and raises a clearer `ValueError` when the endpoint cannot be resolved.
- **`pyproject.toml` / `uv.lock`**: add `langchain-anthropic` to the `test` group and ignore missing imports for `anthropic` / `langchain_anthropic` in mypy config.
- **Tests**: added `tests/unit_tests/test_chat_models_anthropic.py` covering endpoint resolution, all credential types, client wiring, and `project_endpoint` usage.

### Example

**Microsoft Entra ID authentication via project endpoint (recommended for Azure AI Foundry):**

```python
from langchain_azure_ai.chat_models import AzureAIAnthropicChatModel
from azure.identity import DefaultAzureCredential

model = AzureAIAnthropicChatModel(
    project_endpoint="https://<resource>.services.ai.azure.com/api/projects/my-project",
    credential=DefaultAzureCredential(),
    model="claude-sonnet-4-20250514",
)
```

**Microsoft Entra ID authentication via direct resource endpoint:**

```python
from langchain_azure_ai.chat_models import AzureAIAnthropicChatModel
from azure.identity import DefaultAzureCredential

model = AzureAIAnthropicChatModel(
    endpoint="https://<resource>.services.ai.azure.com",
    credential=DefaultAzureCredential(),
    model="claude-sonnet-4-20250514",
)
```

**API-key authentication:**

```python
model = AzureAIAnthropicChatModel(
    endpoint="https://<resource>.services.ai.azure.com",
    credential="your-api-key",
    model="claude-sonnet-4-20250514",
)
```

### Dependencies

`anthropic` and `langchain-anthropic` are **not** declared as runtime dependencies. Install them separately before using this class:

```bash
pip install anthropic langchain-anthropic
```

### Validation

- `pytest tests/unit_tests` → 1013 passed, 3 skipped
- `ruff check`, `ruff format`, and `mypy` all pass on the changed files