### PR TITLE
fix(ci): resolve release deps from PyPI, not just TestPyPI

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -120,23 +120,36 @@ jobs:
           PKG_NAME: ${{ needs.build.outputs.pkg-name }}
           VERSION: ${{ needs.build.outputs.version }}
         # Here we use:
-        # - The default regular PyPI index as the *primary* index, meaning
-        #   that it takes priority (https://pypi.org/simple)
-        # - The test PyPI index as an extra index, so that any dependencies that
-        #   are not found on test PyPI can be resolved and installed anyway.
-        #   (https://test.pypi.org/simple). This will include the PKG_NAME==VERSION
-        #   package because VERSION will not have been uploaded to regular PyPI yet.
+        # - The regular PyPI index (https://pypi.org/simple) for resolving
+        #   dependencies.
+        # - The test PyPI index as an extra index (https://test.pypi.org/simple),
+        #   which is where the freshly built PKG_NAME==VERSION lives because
+        #   VERSION will not have been uploaded to regular PyPI yet.
+        # - `--index-strategy unsafe-best-match` so uv considers *all* indexes
+        #   for every package and picks the best compatible version. Without it,
+        #   uv's default `first-index` strategy pins each package to the first
+        #   index that contains it. Since `--extra-index-url` is higher priority,
+        #   a dependency that happens to exist on test PyPI at an incompatible
+        #   version (e.g. an old aiohttp) would shadow the good version on PyPI
+        #   and break resolution.
+        # - `--prerelease=allow` to silence the misleading pre-release hint that
+        #   uv emits for compatible-release specifiers (e.g. `aiohttp~=3.14`,
+        #   which uv normalizes to `>=3.14,<4.dev0`).
         # - attempt install again after 5 seconds if it fails because there is
         #   sometimes a delay in availability on test pypi
         run: |
           uv venv
           uv pip install \
             --extra-index-url https://test.pypi.org/simple/ \
+            --index-strategy unsafe-best-match \
+            --prerelease=allow \
             "$PKG_NAME==$VERSION" || \
           ( \
             sleep 5 && \
             uv pip install \
               --extra-index-url https://test.pypi.org/simple/ \
+              --index-strategy unsafe-best-match \
+              --prerelease=allow \
               "$PKG_NAME==$VERSION" \
           )
 
@@ -160,6 +173,8 @@ jobs:
         run: |
           uv pip install \
             --extra-index-url https://test.pypi.org/simple/ \
+            --index-strategy unsafe-best-match \
+            --prerelease=allow \
             "$PKG_NAME==$VERSION"
 
       - name: Run unit tests

--- a/libs/azure-cosmosdb/uv.lock
+++ b/libs/azure-cosmosdb/uv.lock
@@ -666,7 +666,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -998,7 +998,7 @@ wheels = [
 
 [[package]]
 name = "langchain-azure-ai"
-version = "1.2.7"
+version = "1.2.8"
 source = { editable = "../azure-ai" }
 dependencies = [
     { name = "aiohttp" },
@@ -1021,9 +1021,9 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = "~=3.14" },
     { name = "azure-ai-agents", marker = "extra == 'v1'", specifier = "==1.2.0b6" },
-    { name = "azure-ai-agentserver-core", marker = "extra == 'hosting'", specifier = ">=2.0.0b6,<3.0" },
-    { name = "azure-ai-agentserver-invocations", marker = "extra == 'hosting'", specifier = ">=1.0.0b5,<2.0" },
-    { name = "azure-ai-agentserver-responses", marker = "extra == 'hosting'", specifier = ">=1.0.0b7,<2.0" },
+    { name = "azure-ai-agentserver-core", marker = "extra == 'hosting'", specifier = ">=2.0.0b7,<3.0" },
+    { name = "azure-ai-agentserver-invocations", marker = "extra == 'hosting'", specifier = ">=1.0.0b6,<2.0" },
+    { name = "azure-ai-agentserver-responses", marker = "extra == 'hosting'", specifier = ">=1.0.0b8,<2.0" },
     { name = "azure-ai-contentsafety", specifier = ">=1.0.0,<2.0.0" },
     { name = "azure-ai-contentunderstanding", specifier = ">=1.2.0b2,<2.0.0" },
     { name = "azure-ai-documentintelligence", marker = "extra == 'tools'", specifier = ">=1.0.2,<2.0.0" },


### PR DESCRIPTION
## Problem

The `pre-release-checks` job in `_release.yml` installs the freshly built package to smoke-test it before publishing:

```yaml
uv pip install \
  --extra-index-url https://test.pypi.org/simple/ \
  "$PKG_NAME==$VERSION"
```

The comment claimed PyPI is the primary index and TestPyPI is only a fallback. That assumption is **wrong for uv**:

- uv gives `--extra-index-url` indexes **higher** priority than the default index, and
- uv's default `--index-strategy` is **`first-index`**, which pins each package to the first index that contains it and never looks further.

So for a dependency like `aiohttp`, uv checks TestPyPI first, finds only an old version there (e.g. `aiohttp==3.8.1` from the shared TestPyPI namespace), pins to that index, and never falls back to PyPI's `3.14.x`. Resolution fails with:

```
No solution found ... only aiohttp==3.8.1 is available and
langchain-azure-ai==1.2.8 depends on aiohttp>=3.14,<4.dev0
```

This is inherently fragile — any dependency that happens to exist on TestPyPI at an incompatible version breaks the release.

## Fix

Add two flags to the three `uv pip install` invocations that use TestPyPI:

- **`--index-strategy unsafe-best-match`** — the real fix. uv considers *all* indexes for every package and picks the best compatible version, so deps come from PyPI while the just-uploaded `PKG==VERSION` comes from TestPyPI. This is the pattern uv documents for combining PyPI + TestPyPI.
- **`--prerelease=allow`** — silences the misleading pre-release hint uv emits for compatible-release specifiers (`aiohttp~=3.14` normalizes to `>=3.14,<4.dev0`, whose `.dev0` upper bound trips uv's pre-release detection). Matches upstream LangChain's release workflow.

The stale comment is updated to reflect uv's actual index-priority behavior.

## Notes

- `--index-strategy unsafe-best-match` relaxes dependency-confusion protection, but this is the documented approach for the PyPI + TestPyPI smoke test. The job holds no publishing credentials — `id-token: write` lives only in the separate `publish` job, which is untouched.
- `uv sync` and the min-version steps don't use TestPyPI and are unaffected.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>