### PR TITLE
fix(azure-ai): fall back to message metadata for gen_ai.response.id

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
+++ b/libs/azure-ai/langchain_azure_ai/callbacks/tracers/inference_tracing.py
@@ -2317,8 +2317,23 @@ class AzureAIOpenTelemetryTracer(BaseCallbackHandler):
             self._accumulate_usage_to_agent_spans(
                 record, input_tokens, output_tokens, total_tokens
             )
-        if "id" in llm_output:
-            record.span.set_attribute(Attrs.RESPONSE_ID, str(llm_output["id"]))
+        # Resolve the response id. Depending on the LangChain code path the id is
+        # exposed in different places:
+        #   - Chat Completions API: LLMResult.llm_output["id"]
+        #   - Responses API: AIMessage.response_metadata["id"]
+        # Fall back to the message metadata so the attribute is emitted in both
+        # cases (see issue #655).
+        response_id: Any = llm_output.get("id")
+        if not response_id:
+            for gen in chat_generations:
+                message = getattr(gen, "message", None)
+                metadata = getattr(message, "response_metadata", None)
+                if isinstance(metadata, Mapping):
+                    response_id = metadata.get("id")
+                    if response_id:
+                        break
+        if response_id:
+            record.span.set_attribute(Attrs.RESPONSE_ID, str(response_id))
         if "model_name" in llm_output:
             record.span.set_attribute(Attrs.RESPONSE_MODEL, llm_output["model_name"])
             record.attributes[Attrs.RESPONSE_MODEL] = llm_output["model_name"]

--- a/libs/azure-ai/tests/unit_tests/test_inference_tracing.py
+++ b/libs/azure-ai/tests/unit_tests/test_inference_tracing.py
@@ -776,6 +776,57 @@ def test_usage_and_response_metadata() -> None:
     assert attrs.get(tracing.Attrs.OPENAI_RESPONSE_SYSTEM_FINGERPRINT) == "fingerprint"
 
 
+def test_response_id_falls_back_to_message_response_metadata() -> None:
+    """The response id may only be present on the AIMessage metadata.
+
+    This happens on the Responses API path, where ``langchain-openai`` stores the
+    id in ``AIMessage.response_metadata["id"]`` rather than in
+    ``LLMResult.llm_output["id"]`` (see issue #655).
+    """
+    t = tracing.AzureAIOpenTelemetryTracer()
+    run_id = uuid4()
+    serialized = {"kwargs": {"model": "m"}}
+    prompts = cast(List[str], [{"role": "user", "content": "hi"}])
+    t.on_llm_start(
+        serialized,
+        prompts,
+        run_id=run_id,
+        invocation_params={"model": "m"},
+    )
+    gen = ChatGeneration(
+        message=AIMessage(content="ok", response_metadata={"id": "resp-from-message"})
+    )
+    # Note: llm_output has no "id" key, so the tracer must fall back.
+    result = LLMResult(generations=[[gen]], llm_output={"model_name": "m"})
+    t.on_llm_end(result, run_id=run_id)
+    span = get_last_span_for(t)
+    assert span.attributes.get(tracing.Attrs.RESPONSE_ID) == "resp-from-message"
+
+
+def test_response_id_prefers_llm_output_over_message_metadata() -> None:
+    """When both locations carry an id, ``llm_output["id"]`` wins."""
+    t = tracing.AzureAIOpenTelemetryTracer()
+    run_id = uuid4()
+    serialized = {"kwargs": {"model": "m"}}
+    prompts = cast(List[str], [{"role": "user", "content": "hi"}])
+    t.on_llm_start(
+        serialized,
+        prompts,
+        run_id=run_id,
+        invocation_params={"model": "m"},
+    )
+    gen = ChatGeneration(
+        message=AIMessage(content="ok", response_metadata={"id": "from-message"})
+    )
+    result = LLMResult(
+        generations=[[gen]],
+        llm_output={"model_name": "m", "id": "from-llm-output"},
+    )
+    t.on_llm_end(result, run_id=run_id)
+    span = get_last_span_for(t)
+    assert span.attributes.get(tracing.Attrs.RESPONSE_ID) == "from-llm-output"
+
+
 def test_usage_metadata_input_output_keys() -> None:
     t = tracing.AzureAIOpenTelemetryTracer()
     run_id = uuid4()


### PR DESCRIPTION
Fixes #655.

## Problem
`AzureAIOpenTelemetryTracer.on_llm_end` only stamps `gen_ai.response.id` when it finds `LLMResult.llm_output["id"]`. That field is populated on the **Chat Completions** path, but on the **Responses API** path `langchain-openai` exposes the id only on `AIMessage.response_metadata["id"]`. As a result `gen_ai.response.id` is missing on that path, and the traces do not show up in the Foundry portal.

## Fix
Resolve the response id with a fallback: use `llm_output["id"]` when present, otherwise walk the chat generations and read `AIMessage.response_metadata["id"]`. The attribute is now emitted on both paths, and `llm_output["id"]` still takes precedence.

```python
response_id = llm_output.get("id")
if not response_id:
    for gen in chat_generations:
        message = getattr(gen, "message", None)
        metadata = getattr(message, "response_metadata", None)
        if isinstance(metadata, Mapping):
            response_id = metadata.get("id")
            if response_id:
                break
if response_id:
    record.span.set_attribute(Attrs.RESPONSE_ID, str(response_id))
```

## Tests
Added two unit tests in `tests/unit_tests/test_inference_tracing.py`:
- `test_response_id_falls_back_to_message_response_metadata` — id only on `AIMessage.response_metadata` is now emitted.
- `test_response_id_prefers_llm_output_over_message_metadata` — `llm_output["id"]` wins when both are present.

Full `test_inference_tracing.py` module passes (138 tests); ruff + mypy clean.

Fixes #655