### PR TITLE
fix(sqlserver): use not_in for $nin metadata filter operator

### DIFF
--- a/libs/sqlserver/langchain_sqlserver/vectorstores.py
+++ b/libs/sqlserver/langchain_sqlserver/vectorstores.py
@@ -1213,7 +1213,7 @@ class SQLServerVectorStore(VectorStore):
             if operator in {"$in"}:
                 return queried_field.in_([str(val) for val in filter_value])
             elif operator in {"$nin"}:
-                return queried_field.nin_([str(val) for val in filter_value])
+                return queried_field.not_in([str(val) for val in filter_value])
             elif operator in {"$like"}:
                 return queried_field.like(str(filter_value))
             else:

--- a/libs/sqlserver/tests/unit_tests/test_filters.py
+++ b/libs/sqlserver/tests/unit_tests/test_filters.py
@@ -1,0 +1,50 @@
+"""Unit tests for the metadata filter builder (no live DB required).
+
+These compile the SQLAlchemy expression produced by ``_handle_field_filter``
+so operators can be checked without connecting to SQL Server.
+"""
+
+from typing import cast
+
+from sqlalchemy import ColumnElement
+from sqlalchemy.dialects import mssql
+
+from langchain_sqlserver.vectorstores import SQLServerVectorStore
+
+
+def _make_store() -> SQLServerVectorStore:
+    """Build a store without running ``__init__`` (which connects to a DB).
+
+    Only the attributes used by ``_handle_field_filter`` are set.
+    """
+    store = SQLServerVectorStore.__new__(SQLServerVectorStore)
+    store._embedding_length = 4
+    store._embedding_store = store._get_embedding_store("t", None)
+    return store
+
+
+def _compile(store: SQLServerVectorStore, field: str, value: object) -> str:
+    clause = cast(ColumnElement, store._handle_field_filter(field, value))
+    return str(
+        clause.compile(dialect=mssql.dialect(), compile_kwargs={"literal_binds": True})
+    )
+
+
+def test_nin_operator_builds_not_in_clause() -> None:
+    """`$nin` must produce a NOT IN clause. It previously called a
+    non-existent `nin_` method and raised AttributeError at query time."""
+    sql = _compile(_make_store(), "color", {"$nin": ["red", "blue"]})
+    assert "NOT IN" in sql.upper()
+    assert "'red'" in sql and "'blue'" in sql
+
+
+def test_in_operator_builds_in_clause() -> None:
+    sql = _compile(_make_store(), "color", {"$in": ["red", "blue"]})
+    assert " IN " in sql.upper()
+    assert "NOT IN" not in sql.upper()
+
+
+def test_like_operator_builds_like_clause() -> None:
+    sql = _compile(_make_store(), "name", {"$like": "%foo%"})
+    assert "LIKE" in sql.upper()
+    assert "'%foo%'" in sql


### PR DESCRIPTION
## Problem
The `$nin` metadata filter operator is broken. In `_handle_field_filter`, the `$nin` branch calls `queried_field.nin_(...)`:

```python
elif operator in {"$nin"}:
    return queried_field.nin_([str(val) for val in filter_value])
```

SQLAlchemy column elements have no `nin_` method (the correct method is `not_in()`), so **any** similarity search using a `$nin` metadata filter raises at query time:

```
AttributeError: Neither 'Function' object nor 'Comparator' object has an attribute 'nin_'
```

Example that triggers it:
```python
store.similarity_search("q", filter={"color": {"$nin": ["red", "blue"]}})
```

## Fix
Use the correct SQLAlchemy method:
```python
return queried_field.not_in([str(val) for val in filter_value])
```
This compiles to `JSON_VALUE(...) NOT IN (red, blue)` as expected.

## Tests
Added `tests/unit_tests/test_filters.py` covering the `$nin`, `$in`, and `$like` clauses. They compile the filter expression to SQL, so they run without a live database. Ruff + mypy clean; full unit suite passes.