### PR TITLE
fix(sqlserver): honor string distance_strategy in relevance scoring

### DIFF
--- a/libs/sqlserver/langchain_sqlserver/vectorstores.py
+++ b/libs/sqlserver/langchain_sqlserver/vectorstores.py
@@ -708,12 +708,16 @@ class SQLServerVectorStore(VectorStore):
             return self.override_relevance_score_fn
 
         # If the relevance score function is not provided, we default to using
-        # the distance strategy specified by the user.
-        if self._distance_strategy == DistanceStrategy.COSINE:
+        # the distance strategy specified by the user. Normalize through the
+        # `distance_strategy` property so string inputs (including mixed/upper
+        # case, which the property accepts) map to the right scoring function
+        # instead of falling through to the ValueError below.
+        strategy = self.distance_strategy
+        if strategy == DistanceStrategy.COSINE.value:
             return self._cosine_relevance_score_fn
-        elif self._distance_strategy == DistanceStrategy.DOT:
+        elif strategy == DistanceStrategy.DOT.value:
             return self._max_inner_product_relevance_score_fn
-        elif self._distance_strategy == DistanceStrategy.EUCLIDEAN:
+        elif strategy == DistanceStrategy.EUCLIDEAN.value:
             return self._euclidean_relevance_score_fn
         else:
             raise ValueError(

--- a/libs/sqlserver/tests/unit_tests/test_relevance_score.py
+++ b/libs/sqlserver/tests/unit_tests/test_relevance_score.py
@@ -1,0 +1,54 @@
+"""Unit tests for relevance-score-function selection (no live DB).
+
+``_select_relevance_score_fn`` must honour every distance strategy that the
+``distance_strategy`` property accepts. That property normalizes string inputs
+case-insensitively, so a store built with ``distance_strategy="COSINE"`` is
+valid; the selector must map it to the cosine scoring function rather than
+raising.
+"""
+
+import pytest
+
+from langchain_sqlserver.vectorstores import DistanceStrategy, SQLServerVectorStore
+
+
+def _make_store(strategy: object) -> SQLServerVectorStore:
+    store = SQLServerVectorStore.__new__(SQLServerVectorStore)
+    store.override_relevance_score_fn = None
+    store._distance_strategy = strategy  # type: ignore[assignment]
+    return store
+
+
+@pytest.mark.parametrize(
+    "strategy, expected",
+    [
+        (DistanceStrategy.COSINE, "_cosine_relevance_score_fn"),
+        (DistanceStrategy.DOT, "_max_inner_product_relevance_score_fn"),
+        (DistanceStrategy.EUCLIDEAN, "_euclidean_relevance_score_fn"),
+        ("cosine", "_cosine_relevance_score_fn"),
+        ("dot", "_max_inner_product_relevance_score_fn"),
+        ("euclidean", "_euclidean_relevance_score_fn"),
+        # Mixed / upper case strings are accepted by the `distance_strategy`
+        # property, so the selector must accept them too.
+        ("COSINE", "_cosine_relevance_score_fn"),
+        ("Dot", "_max_inner_product_relevance_score_fn"),
+        ("Euclidean", "_euclidean_relevance_score_fn"),
+    ],
+)
+def test_select_relevance_score_fn(strategy: object, expected: str) -> None:
+    store = _make_store(strategy)
+    assert store._select_relevance_score_fn().__name__ == expected
+
+
+def test_select_relevance_score_fn_prefers_override() -> None:
+    store = SQLServerVectorStore.__new__(SQLServerVectorStore)
+    override = lambda distance: distance  # noqa: E731
+    store.override_relevance_score_fn = override
+    store._distance_strategy = "unsupported"  # type: ignore[assignment]
+    assert store._select_relevance_score_fn() is override
+
+
+def test_select_relevance_score_fn_rejects_unknown_strategy() -> None:
+    store = _make_store("manhattan")
+    with pytest.raises(ValueError):
+        store._select_relevance_score_fn()


### PR DESCRIPTION
### Description

`SQLServerVectorStore` accepts its `distance_strategy` as either a `DistanceStrategy` enum **or** a string. The `distance_strategy` property normalizes string input case-insensitively (via `str.lower(...)`), so constructing a store with `distance_strategy="COSINE"` is valid and `similarity_search` works.

However, `_select_relevance_score_fn` compared the **raw** `self._distance_strategy` directly against the enum members:

```python
if self._distance_strategy == DistanceStrategy.COSINE:
    ...
```

`DistanceStrategy` is a `str` enum with lowercase values (`"cosine"`, `"dot"`, `"euclidean"`). A lowercase string like `"cosine"` matches by str-enum equality, but any mixed/upper-case string (`"COSINE"`, `"Euclidean"`, `"DOT"`) fails every branch and raises `ValueError`.

**Effect:** for a store built with a case-variant distance-strategy string, `similarity_search` succeeds (it goes through the normalizing property) but `similarity_search_with_relevance_scores` crashes — a silent inconsistency.

Before:

```
<DistanceStrategy.COSINE>  -> _cosine_relevance_score_fn
"cosine"                   -> _cosine_relevance_score_fn
"COSINE"                   -> ValueError
"Euclidean"                -> ValueError
"DOT"                      -> ValueError
```

After: all of the above resolve to the correct scoring function.

### Fix

Normalize through the existing `distance_strategy` property before matching, so enum and string inputs (any case) map to the right scoring function.

### Testing

Added `tests/unit_tests/test_relevance_score.py` — parametrized, no live DB — covering enum inputs, lowercase strings, mixed/upper-case strings, the `override_relevance_score_fn` short-circuit, and the unknown-strategy `ValueError`. Full unit suite green; `ruff`, `ruff format`, and `mypy` clean.