### PR TITLE
fix(azure-ai): return empty list from async MMR search when no results

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/vectorstores/azuresearch.py
+++ b/libs/azure-ai/langchain_azure_ai/vectorstores/azuresearch.py
@@ -2020,6 +2020,8 @@ async def _areorder_results_with_maximal_marginal_relevance(
         )
         async for result in results
     ]
+    if not docs:
+        return []
     documents, scores, vectors = map(list, zip(*docs))
 
     # Get the new order of results.

--- a/libs/azure-ai/tests/unit_tests/test_azure_search.py
+++ b/libs/azure-ai/tests/unit_tests/test_azure_search.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+import asyncio
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional
 from unittest.mock import patch
 
 import pytest
@@ -269,3 +270,44 @@ def test_ids_used_correctly() -> None:
         ids_used_at_upload = vector_store.add_documents(documents, ids=ids_provided)
         assert len(ids_provided) == len(ids_used_at_upload)
         assert ids_provided == ids_used_at_upload
+
+
+@pytest.mark.requires("azure.search.documents")
+def test_reorder_mmr_returns_empty_for_no_results() -> None:
+    """The sync MMR reorder helper returns an empty list when the search
+    yielded no candidates."""
+    import numpy as np
+
+    from langchain_azure_ai.vectorstores.azuresearch import (
+        _reorder_results_with_maximal_marginal_relevance,
+    )
+
+    result = _reorder_results_with_maximal_marginal_relevance(
+        iter([]),  # type: ignore[arg-type]
+        query_embedding=np.array([1.0, 0.0, 0.0, 0.0]),
+    )
+    assert result == []
+
+
+@pytest.mark.requires("azure.search.documents")
+def test_areorder_mmr_returns_empty_for_no_results() -> None:
+    """The async MMR reorder helper must also return an empty list, mirroring
+    the sync path, instead of raising a ValueError when unpacking an empty
+    ``zip`` of results."""
+    import numpy as np
+
+    from langchain_azure_ai.vectorstores.azuresearch import (
+        _areorder_results_with_maximal_marginal_relevance,
+    )
+
+    async def _empty_results() -> AsyncIterator[Dict[Any, Any]]:
+        return
+        yield  # pragma: no cover  -- makes this an (empty) async generator
+
+    async def _run() -> List[Any]:
+        return await _areorder_results_with_maximal_marginal_relevance(
+            _empty_results(),  # type: ignore[arg-type]
+            query_embedding=np.array([1.0, 0.0, 0.0, 0.0]),
+        )
+
+    assert asyncio.run(_run()) == []


### PR DESCRIPTION
### Description

`AzureSearch.amax_marginal_relevance_search` / `amax_marginal_relevance_search_with_score` crash with `ValueError` when the underlying async search returns **zero** candidates (empty index, or a filter that matches nothing).

The async reranking helper builds the candidate list and then immediately unpacks it:

```python
docs = [(...) async for result in results]
documents, scores, vectors = map(list, zip(*docs))   # <-- zip(*[]) -> unpack 0 into 3
```

With no results, `zip(*[])` yields nothing, so the three-way unpack raises:

```
ValueError: not enough values to unpack (expected 3, got 0)
```

The **synchronous** twin `_reorder_results_with_maximal_marginal_relevance` already handles this with an early `if not docs: return []`; the async version was missing that guard, so the two paths diverge for the empty case.

Repro:

```
sync empty  -> []
async empty -> RAISED ValueError not enough values to unpack (expected 3, got 0)
```

### Fix

Add the same `if not docs: return []` guard to `_areorder_results_with_maximal_marginal_relevance`, so the async MMR search returns an empty list — matching the sync path — instead of raising.

### Testing

Added two unit tests to `tests/unit_tests/test_azure_search.py` (guarded by the existing `@pytest.mark.requires("azure.search.documents")` marker): one asserts the sync helper returns `[]` for empty input (regression parity), and one drives the async helper with an empty async generator and asserts `[]`. The async test uses `asyncio.run`, so no new test dependency is introduced. `ruff`, `ruff format`, and `mypy` are clean.