### PR TITLE
feat: add automated LangChain docs update workflow

### DIFF
--- a/.github/scripts/update_docs.py
+++ b/.github/scripts/update_docs.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""
+update_docs.py — Azure integration documentation update agent.
+
+Reads the azure-integration-docs skill instructions and drives an AI agent
+(via GitHub Models API) to generate or update LangChain documentation pages
+for the specified Azure integration library.
+
+The agent is equipped with tools that mirror how the skill is used interactively:
+it can explore and read files in both repos, then write updated .mdx files
+directly into the langchain-ai/docs working tree.
+
+Required environment variables:
+  GITHUB_TOKEN         GitHub token with models:read permission
+  LANGCHAIN_AZURE_ROOT Absolute path to the langchain-azure repo root
+  DOCS_ROOT            Absolute path to the langchain-ai/docs repo root
+  UPDATE_LIBRARY       Library path relative to repo root (e.g. libs/azure-ai)
+
+Optional environment variables:
+  UPDATE_PATH          Specific module sub-path (e.g. langchain_azure_ai/chat_models)
+  UPDATE_CHANGELOG     Changelog / release-notes text to use as context
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+MODELS_API_URL = "https://models.inference.ai.azure.com/chat/completions"
+MODEL = "gpt-4o"
+MAX_TURNS = 30           # Upper bound on agent conversation turns
+MAX_FILE_BYTES = 80_000  # Truncate source files larger than ~80 KB
+
+
+# ── File helpers ───────────────────────────────────────────────────────────────
+
+def read_text(path: Path) -> str:
+    """Read a text file, truncating very large files to stay within context limits."""
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        return f"[Error reading file: {exc}]"
+    if len(raw) > MAX_FILE_BYTES:
+        truncated = raw[:MAX_FILE_BYTES].decode("utf-8", errors="replace")
+        return truncated + f"\n\n[… file truncated at {MAX_FILE_BYTES} bytes …]"
+    return raw.decode("utf-8", errors="replace")
+
+
+def safe_resolve(root: Path, rel: str) -> Path | None:
+    """Resolve *rel* against *root*, rejecting any path-traversal attempts."""
+    try:
+        target = (root / rel).resolve()
+    except Exception:
+        return None
+    if not str(target).startswith(str(root.resolve())):
+        return None
+    return target
+
+
+def list_dir(path: Path) -> str:
+    """Return a human-readable directory listing."""
+    if not path.exists():
+        return f"[Directory not found: {path}]"
+    items: list[str] = []
+    for item in sorted(path.iterdir()):
+        if item.name.startswith("."):
+            continue
+        prefix = "[DIR] " if item.is_dir() else "      "
+        items.append(f"{prefix}{item.name}")
+    return "\n".join(items) if items else "(empty)"
+
+
+# ── Tool schema ────────────────────────────────────────────────────────────────
+
+TOOLS: list[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "list_langchain_azure_dir",
+            "description": (
+                "List the files and sub-directories inside a directory of the "
+                "langchain-azure repository. Use this to explore package structure "
+                "before deciding which files to read."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Directory path relative to the langchain-azure repo root.",
+                    }
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_langchain_azure_file",
+            "description": "Read a file from the langchain-azure repository.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path relative to the langchain-azure repo root.",
+                    }
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_docs_dir",
+            "description": (
+                "List the files and sub-directories inside a directory of the "
+                "langchain-ai/docs repository. Use this to find existing integration "
+                "pages and TEMPLATE.mdx files."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Directory path relative to the langchain-ai/docs repo root.",
+                    }
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_docs_file",
+            "description": "Read a file from the langchain-ai/docs repository.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path relative to the langchain-ai/docs repo root.",
+                    }
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "write_docs_file",
+            "description": (
+                "Write or update a documentation file in the langchain-ai/docs repository. "
+                "Call this once per file with the COMPLETE, final content. "
+                "Always read the relevant TEMPLATE.mdx and any existing page BEFORE calling this. "
+                "Use this for the main integration page AND for any index or provider pages "
+                "that the skill instructs you to update."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": (
+                            "File path relative to the docs repo root, "
+                            "e.g. 'src/oss/python/integrations/chat/azure_ai.mdx'."
+                        ),
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Complete file content to write.",
+                    },
+                },
+                "required": ["path", "content"],
+            },
+        },
+    },
+]
+
+
+# ── Tool execution ─────────────────────────────────────────────────────────────
+
+def execute_tool(
+    call: dict,
+    azure_root: Path,
+    docs_root: Path,
+    files_written: list[str],
+) -> str:
+    name = call["function"]["name"]
+    try:
+        args = json.loads(call["function"]["arguments"])
+    except json.JSONDecodeError as exc:
+        return f"[Error: invalid JSON in tool arguments — {exc}]"
+
+    rel: str = args.get("path", "")
+
+    if name == "list_langchain_azure_dir":
+        target = safe_resolve(azure_root, rel)
+        if target is None:
+            return "[Error: path traversal not allowed]"
+        return list_dir(target)
+
+    if name == "read_langchain_azure_file":
+        target = safe_resolve(azure_root, rel)
+        if target is None:
+            return "[Error: path traversal not allowed]"
+        if not target.is_file():
+            return f"[File not found: {rel}]"
+        return read_text(target)
+
+    if name == "list_docs_dir":
+        target = safe_resolve(docs_root, rel)
+        if target is None:
+            return "[Error: path traversal not allowed]"
+        return list_dir(target)
+
+    if name == "read_docs_file":
+        target = safe_resolve(docs_root, rel)
+        if target is None:
+            return "[Error: path traversal not allowed]"
+        if not target.is_file():
+            return f"[File not found: {rel}]"
+        return read_text(target)
+
+    if name == "write_docs_file":
+        content: str = args.get("content", "")
+        target = safe_resolve(docs_root, rel)
+        if target is None:
+            return "[Error: path traversal not allowed]"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        files_written.append(rel)
+        print(f"  ✓ Written: {rel}", flush=True)
+        return f"File written successfully: {rel}"
+
+    return f"[Unknown tool: {name}]"
+
+
+# ── API helpers ────────────────────────────────────────────────────────────────
+
+def call_models_api(token: str, messages: list[dict]) -> dict:
+    """Call the GitHub Models chat-completions endpoint with retry on 429."""
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": MODEL,
+        "messages": messages,
+        "tools": TOOLS,
+        "tool_choice": "auto",
+        "temperature": 0.1,
+    }
+
+    for attempt in range(4):
+        resp = requests.post(MODELS_API_URL, headers=headers, json=payload, timeout=180)
+        if resp.status_code == 429:
+            wait = 2 ** attempt * 15  # 15s, 30s, 60s, 120s
+            print(f"  [Rate limited — retrying in {wait}s]", flush=True)
+            time.sleep(wait)
+            continue
+        if not resp.ok:
+            print(f"API error {resp.status_code}: {resp.text}", file=sys.stderr)
+            sys.exit(1)
+        return resp.json()
+
+    print("ERROR: GitHub Models API rate limit exceeded after retries.", file=sys.stderr)
+    sys.exit(1)
+
+
+# ── Prompt builders ────────────────────────────────────────────────────────────
+
+def build_system_prompt(skill_content: str) -> str:
+    return f"""You are an automated documentation agent for LangChain Azure integrations.
+
+You have tools to read files from both the langchain-azure (source code) and langchain-ai/docs
+(documentation) repositories, and to write documentation files back to the docs repo.
+
+Follow the skill instructions below exactly. They govern what to read, how to structure pages,
+and which discovery surfaces to update:
+
+{skill_content}
+
+Recommended turn-by-turn workflow:
+1. Call list_docs_dir("src/oss/python/integrations") to see the available building-block folders.
+2. Identify the correct building block from the library path, then read its TEMPLATE.mdx.
+3. List and read relevant source files from langchain-azure: pyproject.toml, README.md, and
+   the key Python modules (especially __init__.py and the main implementation files).
+4. Read any existing Azure integration pages in the target docs folder.
+5. Call write_docs_file for the main integration page, then for any index.mdx and
+   providers/microsoft.mdx pages that need updating.
+6. Finish with a brief summary of what was written and what was not checked.
+
+Use tools to gather all required context before writing. Never invent class names, env vars,
+or install commands — verify each one against the source code you have read.
+"""
+
+
+def build_user_message(library: str, specific_path: str, changelog: str) -> str:
+    parts = [f"Update the LangChain documentation for the Azure integration library: **`{library}`**"]
+    if specific_path:
+        parts.append(f"\nFocus on the specific module path: `{specific_path}`")
+    if changelog:
+        parts.append(
+            f"\nThe following changelog entry provides context for what changed in this release:\n"
+            f"```\n{changelog}\n```"
+        )
+    parts.append(
+        "\nFollow the skill workflow: read the relevant template first, "
+        "then read the source code, then write the documentation."
+    )
+    return "\n".join(parts)
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    # Read inputs from environment (safe for multi-line values like changelog)
+    library = os.environ.get("UPDATE_LIBRARY", "").strip()
+    specific_path = os.environ.get("UPDATE_PATH", "").strip()
+    changelog = os.environ.get("UPDATE_CHANGELOG", "").strip()
+
+    if not library:
+        print("ERROR: UPDATE_LIBRARY environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("ERROR: GITHUB_TOKEN environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    azure_root = Path(os.environ.get("LANGCHAIN_AZURE_ROOT", ".")).resolve()
+    docs_root_str = os.environ.get("DOCS_ROOT", "")
+    if not docs_root_str:
+        print("ERROR: DOCS_ROOT environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+    docs_root = Path(docs_root_str).resolve()
+
+    if not docs_root.is_dir():
+        print(f"ERROR: DOCS_ROOT is not a valid directory: {docs_root}", file=sys.stderr)
+        sys.exit(1)
+
+    # Load the project-level skill instructions
+    skill_path = azure_root / ".github/skills/azure-integration-docs/SKILL.md"
+    if not skill_path.is_file():
+        print(f"ERROR: Skill file not found: {skill_path}", file=sys.stderr)
+        sys.exit(1)
+    skill_content = skill_path.read_text(encoding="utf-8")
+
+    print(f"Library  : {library}")
+    if specific_path:
+        print(f"Path     : {specific_path}")
+    if changelog:
+        print(f"Changelog: {changelog[:80]}{'…' if len(changelog) > 80 else ''}")
+    print(f"Model    : {MODEL}")
+    print()
+
+    messages: list[dict] = [
+        {"role": "system", "content": build_system_prompt(skill_content)},
+        {"role": "user", "content": build_user_message(library, specific_path, changelog)},
+    ]
+
+    files_written: list[str] = []
+
+    for turn in range(MAX_TURNS):
+        print(f"[Turn {turn + 1}/{MAX_TURNS}]", flush=True)
+        data = call_models_api(token, messages)
+        choice = data["choices"][0]
+        msg = choice["message"]
+        messages.append(msg)
+
+        finish_reason = choice["finish_reason"]
+
+        if finish_reason == "tool_calls":
+            tool_calls = msg.get("tool_calls", [])
+            tool_results: list[dict] = []
+
+            for tc in tool_calls:
+                fn_name = tc["function"]["name"]
+                raw_args = tc["function"]["arguments"]
+                preview = raw_args[:100].replace("\n", " ")
+                print(f"  → {fn_name}({preview}{'…' if len(raw_args) > 100 else ''})", flush=True)
+
+                result = execute_tool(tc, azure_root, docs_root, files_written)
+                tool_results.append({
+                    "role": "tool",
+                    "tool_call_id": tc["id"],
+                    "content": result,
+                })
+
+            messages.extend(tool_results)
+
+        elif finish_reason == "stop":
+            content = msg.get("content", "")
+            if content:
+                print(f"\nAgent summary:\n{content}", flush=True)
+            break
+
+        else:
+            print(f"Unexpected finish_reason: {finish_reason}", flush=True)
+            break
+
+    # Report outcome
+    print(f"\n{'─' * 60}")
+    if files_written:
+        unique_files = sorted(set(files_written))
+        print(f"✅ Documentation update complete — {len(unique_files)} file(s) written:")
+        for f in unique_files:
+            print(f"   • {f}")
+    else:
+        print("⚠️  No documentation files were written.", file=sys.stderr)
+        print(
+            "   The agent may have determined no changes were needed, "
+            "or an error occurred during the run.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/azure-integration-docs/SKILL.md
+++ b/.github/skills/azure-integration-docs/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: azure-integration-docs
+description: 'Maintain Azure integration documentation in the LangChain docs repo. Use when given a langchain-azure namespace, module path, or GitHub URL and you need to identify the integration building block, read the folder-local TEMPLATE.mdx for that exact docs folder, create or update the matching page under src/oss/python/integrations, structure the page around the Azure product surface when appropriate, fill it from verified source code and docstrings, and update Azure discovery pages such as the component index and Microsoft provider page.'
+argument-hint: 'Provide a langchain-azure namespace path, folder path, or GitHub URL.'
+---
+
+# Azure integration docs
+
+## When to use
+
+- Add or update documentation for Azure integrations maintained in the LangChain ecosystem.
+- Convert a `langchain-azure` namespace or GitHub URL into the correct docs page under `src/oss/python/integrations`.
+- Keep Azure docs aligned with the product surface users recognize, such as Microsoft Foundry, Azure AI Content Safety, Azure Storage, or Azure Cosmos DB, instead of forcing a class-by-class layout when the package represents one cohesive product area.
+- Keep Azure provider pages, component index pages, and usage examples aligned with new or changed Azure integrations.
+
+This skill is optimized for Azure-related packages currently maintained in `langchain-ai/langchain-azure`, including:
+
+- `azure-ai`: Microsoft Foundry
+- `azure-dynamic-sessions`: Azure Dynamic Sessions
+- `azure-storage`: Azure Storage
+- `cosmosdb`: Azure CosmosDB
+
+## Inputs
+
+Expected inputs usually look like one of these:
+
+- A GitHub URL such as `https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/agents/middleware`
+- A repo path such as `libs/azure-ai/langchain_azure_ai/chat_models`
+- A Python namespace such as `langchain_azure_ai.vectorstores.azure_cosmos_db_no_sql`
+
+## Workflow
+
+### 1. Normalize the source path
+
+Extract these parts from the input:
+
+- The package root under `libs/<provider>/`
+- The import package such as `langchain_azure_ai`
+- The component path such as `chat_models`, `embeddings`, `vectorstores`, `tools`, or `agents/middleware`
+
+If the input is only a URL, strip the repository prefix and work from the path after `tree/main/`.
+
+### 2. Map the namespace to a LangChain docs building block
+
+Use the module path to choose the docs folder.
+
+| Source path pattern | Docs building block | Target folder |
+| --- | --- | --- |
+| `agents/middleware`, `middleware` | middleware | `src/oss/python/integrations/middleware/` |
+| `chat_models`, `chat` | chat | `src/oss/python/integrations/chat/` |
+| `embeddings` | embeddings | `src/oss/python/integrations/embeddings/` |
+| `vectorstores`, `vector_stores` | vectorstores | `src/oss/python/integrations/vectorstores/` |
+| `tools`, `toolkits`, `agent_toolkits` | tools | `src/oss/python/integrations/tools/` |
+| `retrievers` | retrievers | `src/oss/python/integrations/retrievers/` |
+| `document_loaders` | document_loaders | `src/oss/python/integrations/document_loaders/` |
+
+If no mapping is clear, stop and ask which building block the namespace belongs to.
+
+### 3. Find the template before writing
+
+Look for `src/oss/python/integrations/<building-block>/TEMPLATE.mdx`.
+
+This is the authoritative template for that exact integration type. Different building blocks such as `chat`, `middleware`, `tools`, and `vectorstores` can have different required structures, section names, table formats, and expectations.
+
+Rules:
+
+- Always read the `TEMPLATE.mdx` in the same folder as the target page before drafting or editing.
+- Never reuse the structure of a different building block just because it looks similar.
+- Never assume a generic integration format if a folder-local `TEMPLATE.mdx` exists.
+- When updating an existing page, compare the current page against the folder-local template and normalize it toward that template unless the folder already has a deliberate stronger pattern.
+
+- If the template exists, use it as the starting point.
+- If the template does not exist, inspect an existing page in the same folder and use that as the canonical pattern. Prefer the ones that start with `azure` in the file name.
+- If neither a template nor a strong sibling example exists, stop and ask whether to create the page style first.
+
+Known template-backed folders in this repo currently include:
+
+- `chat`
+- `embeddings`
+- `middleware`
+- `retrievers`
+- `vectorstores`
+
+### 4. Choose whether to create or update a page
+
+Search the target folder for an existing Azure page before creating anything.
+
+- If a page already exists for that integration, update it.
+- If the provider already has one page per building block, extend that page instead of splitting it.
+- If there is no page yet, create a new snake_case file name that matches the integration name used elsewhere in the folder.
+
+Before editing an existing page, read:
+
+- The current target page
+- The folder-local `TEMPLATE.mdx`
+- At least one strong sibling page in the same folder
+
+Then decide whether the page should:
+
+- Be lightly corrected to match the template more closely
+- Be substantially restructured to match the template
+- Preserve a deliberate folder-specific pattern that is stronger than the raw template
+- Preserve or extend a product-oriented Azure page structure when the current page already groups several public classes under one Azure product or capability area
+
+Use existing file names as the source of truth. Examples already in this repo include:
+
+- `src/oss/python/integrations/chat/azure_ai.mdx`
+- `src/oss/python/integrations/tools/azure_dynamic_sessions.mdx`
+- `src/oss/python/integrations/document_loaders/azure_blob_storage.mdx`
+- `src/oss/python/integrations/vectorstores/azure_cosmos_db_no_sql.mdx`
+
+### 5. Gather source-of-truth content from code
+
+Read the public modules and exported classes in the source package.
+
+Prioritize these sources in order:
+
+1. Class docstrings and function docstrings
+2. Public exports in `__init__.py`
+3. Constructor signatures and default values in the source code
+4. Package README files and package-local docs or notebooks
+5. Tests that confirm import paths, default behavior, and supported parameters
+6. Inline examples in the package source
+7. Existing provider landing pages in this docs repo for cross-links and naming consistency
+
+Capture:
+
+- Primary class names and import paths
+- Package name for installation
+- Required credentials or environment variables
+- Supported capabilities and limitations
+- Default parameter values and notable non-default behavior
+- Short code snippets that reflect the public API
+
+For classes that contain a `project_endpoint` and `endpoint` parameter, state that you can use one or the other,
+but `project_endpoint` is recommended for better defaults and future compatibility. Explain that most of the time,
+those parameters can be inferred from environment variables so they don't need to be indicated on each instantiation.
+
+Accuracy rules:
+
+- Verify every documented class name against a public export path, not only against an internal module.
+- Verify every documented default value against the actual signature or tests.
+- Verify every environment variable name against source code or README text.
+- Verify every installation command against the package name used by the source repo.
+- If examples in tests, README, and docstrings disagree, prefer the public export path and current constructor signature, then mention uncertainty only if it cannot be resolved.
+- Do not infer JS support, serialization, or advanced features unless they are explicitly documented or clearly implemented.
+
+Do not invent features that are not stated or implied by the public API or docstrings.
+
+### 6. Fill the page from the template
+
+Replace placeholders with real values and keep the page specific to the chosen building block.
+
+Apply these rules:
+
+- Treat the folder-local `TEMPLATE.mdx` as a checklist, not inspiration. Every placeholder section must be either filled correctly or removed intentionally.
+- Match the title and description style already used in the folder.
+- Use the real package name in install commands.
+- Remove the credentials section when the integration does not require credentials.
+- If one page documents multiple Azure integrations for the same building block, add a short summary table near the top and give each integration its own section.
+- Use first-party terminology consistently, for example `Azure AI Foundry` rather than stale names unless the source package still uses the old identifier as part of its API.
+- Prefer relative internal links such as `/oss/integrations/chat/azure_ai`.
+- Use `@[` API links only when they fit existing repo conventions for that page.
+- Keep section ordering aligned with the template unless the folder's strongest existing examples consistently use a better structure.
+- If a sibling page in the same folder demonstrates a stronger pattern than the template, follow that folder pattern deliberately and preserve template-required content.
+
+When the target page documents multiple classes in one file:
+
+- Keep the template's top-level scaffolding such as overview, setup, installation, instantiation, and agent usage.
+- Add a summary table near the top that lists the documented classes and what each one does.
+- Give each class its own subsection with API reference, configuration highlights, and an example.
+
+### 6a. Prefer product-oriented structure when it matches the Azure surface
+
+The folder-local template remains mandatory, but do not mechanically mirror it when the clearer presentation is product-first.
+
+Use this product-oriented layout when one page documents several classes that together form one Azure product experience, for example Microsoft Foundry middleware backed by Azure AI Content Safety:
+
+- Keep the template-required top-level sections: intro, overview, setup, installation, instantiation, agent usage, and final API reference.
+- Use the intro and setup sections to explain the Azure product surface first, including the package, endpoint choices, credential model, and where the integration fits in LangChain.
+- In the overview table, prefer user-facing middleware or capability names with descriptions instead of exposing only raw class names when that better matches how the product is organized.
+- After the shared setup and agent usage sections, group the detailed content by Azure product capability area, for example `Azure AI Content Safety`, then place the specific middleware subsections inside that group.
+- Within each capability section, keep the concrete class name, import path, configuration options, and example code explicit and verified.
+- Use first-party Azure product terminology consistently. Prefer names such as `Microsoft Foundry`, `Azure AI Foundry`, and `Azure AI Content Safety` when those are the concepts users need to navigate the docs.
+- Preserve class-by-class organization only when the product framing would hide important distinctions or when the folder's established examples clearly favor class-first pages.
+
+This means the template governs required content and section coverage, while the strongest Azure page pattern governs presentation and grouping.
+
+### 7. Update Azure discovery surfaces
+
+When you add a new page or materially expand an existing one, update the places that help users find it.
+
+Usually this means:
+
+- `src/oss/python/integrations/<building-block>/index.mdx`
+- `src/oss/python/integrations/providers/microsoft.mdx`
+
+Update both the table entry and the card list when the index page has both.
+
+`src/docs.json` normally does not list each individual integration page directly for these sections, but if a navigation entry is actually required for the change you are making, update it as well.
+
+### 8. Validate before finishing
+
+Run the repo checks that make sense for the change.
+
+- Verify frontmatter is present and the `description` field contains no markdown.
+- Verify the final page still follows the correct folder-local `TEMPLATE.mdx` shape.
+- Check internal links and example imports.
+- Make sure the example code matches the current public API.
+- Test code examples before shipping them when feasible.
+- Re-check that headings, setup instructions, and tables match the conventions of the target folder rather than another integration type.
+
+Recommended validations:
+
+- `make lint`
+- `make broken-links`
+
+If full validation is too expensive, explain what was and was not checked.
+
+## Branching rules
+
+- If the namespace exposes several public classes in the same building block, prefer one provider page with multiple sections over many tiny pages.
+- If the code is mostly a thin wrapper around another Azure package, document the LangChain-facing API, not the upstream SDK in general.
+- If the docs repo already has a broader Microsoft page covering the same feature, keep that page aligned but do not duplicate full setup instructions unless the component page needs them.
+- If the existing Azure page is already organized around a coherent product surface, keep that organization and use the template as a completeness checklist rather than flattening the page back into a generic per-class template.
+- If docstrings are missing critical information such as auth model or installation package, stop and ask rather than guessing.
+- If the current page conflicts with the folder-local `TEMPLATE.mdx`, treat the template as correct unless multiple strong sibling pages in that same folder prove a newer pattern.
+- If a parameter default differs between docstring prose and the actual constructor signature, trust the signature and use tests as a tie-breaker.
+- If a class is public in an internal subpackage but not re-exported from the documented public namespace, document the public import path users should actually use.
+
+For Azure middleware pages specifically:
+
+- Prefer one Microsoft Foundry or Azure AI page with shared setup and grouped capability sections over several tiny class pages when the classes ship together and share the same package, credentials, and product story.
+- Keep shared setup material near the top and avoid repeating installation, credentials, or endpoint explanations in every middleware subsection.
+- If the page uses product labels in the overview table, keep the corresponding subsection headings aligned with those labels so users can scan from the table into the details.
+
+## Completion checklist
+
+- The correct building block was identified from the namespace.
+- The folder-local `TEMPLATE.mdx` for that exact building block was read and followed.
+- The target page was created or updated in the right folder.
+- The page content was derived from the public API and docstrings.
+- The page uses the folder-local template as a completeness checklist, even if the presentation is product-oriented.
+- Class names, defaults, env vars, and install commands were verified against code.
+- Placeholder text from the template was removed.
+- Relevant Azure index pages were updated.
+- `providers/microsoft.mdx` was updated when discoverability changed.
+- Validation status was reported clearly.
+
+## Example invocation
+
+`/azure-integration-docs https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-ai/langchain_azure_ai/agents/middleware`
+
+For that example, the expected first conclusion is:
+
+- Building block: `middleware`
+- Template: `src/oss/python/integrations/middleware/TEMPLATE.mdx`
+- Likely target page: `src/oss/python/integrations/middleware/azure_ai.mdx`
+
+Then inspect the middleware classes under that namespace and decide whether the page should document one middleware or several Azure AI middleware exports.

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -50,26 +50,31 @@ jobs:
       DOCS_ROOT: ${{ github.workspace }}/langchain-docs
 
     steps:
+      # Validate DOCS_REPO_TOKEN early to fail fast before any expensive steps.
+      # GITHUB_TOKEN is scoped to this repo and cannot push to langchain-ai/docs,
+      # so a separate PAT (repo scope on langchain-ai/docs) is always required
+      # for the push + PR step, even though the docs repo itself is public.
+      - name: Verify DOCS_REPO_TOKEN is configured
+        env:
+          DOCS_REPO_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+        run: |
+          if [ -z "${DOCS_REPO_TOKEN}" ]; then
+            echo "::error title=Missing secret::DOCS_REPO_TOKEN is not set."
+            echo "::error::Add a PAT with repo scope on langchain-ai/docs as a secret named DOCS_REPO_TOKEN."
+            echo "::error::(The docs repo is public so no token is needed to clone it, but a token IS"
+            echo "::error::required to push a branch and open a PR since GITHUB_TOKEN is scoped to this repo only.)"
+            exit 1
+          fi
+
       # ── 1. Source repo ─────────────────────────────────────────────────────
       - name: Checkout langchain-azure
         uses: actions/checkout@v4
         with:
           path: langchain-azure
 
-      # ── 2. Docs repo ───────────────────────────────────────────────────────
+      # ── 2. Docs repo (public — no token needed to clone) ──────────────────
       - name: Clone langchain-ai/docs
-        env:
-          DOCS_REPO_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
-        run: |
-          if [ -z "${DOCS_REPO_TOKEN}" ]; then
-            echo "::error title=Missing secret::DOCS_REPO_TOKEN is not configured."
-            echo "::error::Create a PAT with 'repo' scope on langchain-ai/docs and add it"
-            echo "::error::to this repository's secrets as DOCS_REPO_TOKEN."
-            exit 1
-          fi
-          git clone \
-            "https://x-access-token:${DOCS_REPO_TOKEN}@github.com/langchain-ai/docs.git" \
-            "$DOCS_ROOT"
+        run: git clone --depth 1 https://github.com/langchain-ai/docs.git "$DOCS_ROOT"
 
       # ── 3. Python environment ──────────────────────────────────────────────
       - name: Set up Python 3.11

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,0 +1,160 @@
+name: Update LangChain Documentation
+run-name: "Update docs for ${{ inputs.library }} by @${{ github.actor }}"
+
+# Trigger manually from the Actions tab.
+# Requires the DOCS_REPO_TOKEN secret (a PAT with `repo` scope on langchain-ai/docs).
+on:
+  workflow_dispatch:
+    inputs:
+      library:
+        description: "Library to update documentation for"
+        required: true
+        type: choice
+        options:
+          - libs/azure-ai
+          - libs/azure-dynamic-sessions
+          - libs/azure-storage
+          - libs/azure-cosmosdb
+          - libs/azure-postgresql
+          - libs/sqlserver
+      path:
+        description: >
+          Specific module path within the library (optional).
+          Leave empty to document the whole library.
+          Example: langchain_azure_ai/chat_models
+        required: false
+        type: string
+        default: ""
+      changelog:
+        description: >
+          Changelog or release-notes entry (optional).
+          Paste the relevant entry here to focus the documentation update
+          on what changed in this release.
+        required: false
+        type: string
+        default: ""
+
+# GITHUB_TOKEN needs:
+#   contents:read  — to check out langchain-azure
+#   models:read    — to call the GitHub Models API (GPT-4o)
+permissions:
+  contents: read
+  models: read
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+
+    env:
+      LANGCHAIN_AZURE_ROOT: ${{ github.workspace }}/langchain-azure
+      DOCS_ROOT: ${{ github.workspace }}/langchain-docs
+
+    steps:
+      # ── 1. Source repo ─────────────────────────────────────────────────────
+      - name: Checkout langchain-azure
+        uses: actions/checkout@v4
+        with:
+          path: langchain-azure
+
+      # ── 2. Docs repo ───────────────────────────────────────────────────────
+      - name: Clone langchain-ai/docs
+        env:
+          DOCS_REPO_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+        run: |
+          if [ -z "${DOCS_REPO_TOKEN}" ]; then
+            echo "::error title=Missing secret::DOCS_REPO_TOKEN is not configured."
+            echo "::error::Create a PAT with 'repo' scope on langchain-ai/docs and add it"
+            echo "::error::to this repository's secrets as DOCS_REPO_TOKEN."
+            exit 1
+          fi
+          git clone \
+            "https://x-access-token:${DOCS_REPO_TOKEN}@github.com/langchain-ai/docs.git" \
+            "$DOCS_ROOT"
+
+      # ── 3. Python environment ──────────────────────────────────────────────
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install --quiet requests
+
+      # ── 4. AI agent run ────────────────────────────────────────────────────
+      - name: Generate documentation updates
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_LIBRARY: ${{ inputs.library }}
+          UPDATE_PATH: ${{ inputs.path }}
+          UPDATE_CHANGELOG: ${{ inputs.changelog }}
+        run: python "$LANGCHAIN_AZURE_ROOT/.github/scripts/update_docs.py"
+
+      # ── 5. Detect changes ──────────────────────────────────────────────────
+      - name: Check for documentation changes
+        id: changes
+        run: |
+          cd "$DOCS_ROOT"
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Changed files:"
+            git status --short
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No documentation changes were generated — nothing to PR."
+          fi
+
+      # ── 6. Open PR in langchain-ai/docs ───────────────────────────────────
+      - name: Push branch and open PR
+        if: steps.changes.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}
+          LIBRARY: ${{ inputs.library }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          cd "$DOCS_ROOT"
+
+          # Replace path separators so the branch name is valid
+          BRANCH="azure-docs/${LIBRARY//\//-}-$(date +%Y%m%d-%H%M%S)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "docs: update Azure integration docs for ${LIBRARY}"
+          git push \
+            "https://x-access-token:${GH_TOKEN}@github.com/langchain-ai/docs.git" \
+            "$BRANCH"
+
+          # Build PR description
+          {
+            echo "## Azure Integration Documentation Update"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| **Library** | \`${LIBRARY}\` |"
+            echo "| **Triggered by** | @${ACTOR} |"
+            echo "| **Source run** | [${RUN_URL}](${RUN_URL}) |"
+            echo ""
+            echo "This PR was automatically generated by the"
+            echo "\`update_docs\` workflow in \`${{ github.repository }}\`."
+            echo "The documentation was produced by an AI agent that reads"
+            echo "the \`azure-integration-docs\` skill and the library source code."
+            echo ""
+            echo "### Review checklist"
+            echo "- [ ] All generated content is accurate and matches the current public API"
+            echo "- [ ] Run \`make lint\` in the docs repo"
+            echo "- [ ] Run \`make broken-links\` to verify internal links"
+            echo "- [ ] Code examples compile and import correctly"
+            echo "- [ ] Index and provider pages are consistent with the main page"
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --repo langchain-ai/docs \
+            --base main \
+            --head "$BRANCH" \
+            --title "docs: update Azure integration docs for ${LIBRARY}" \
+            --body-file /tmp/pr-body.md
+
+          echo ""
+          echo "✅ PR created in langchain-ai/docs for branch ${BRANCH}"


### PR DESCRIPTION
## Summary

Adds an on-demand GitHub Actions workflow that automatically generates or updates LangChain documentation for any Azure integration library and opens a PR in \langchain-ai/docs\.

## What's included

| File | Purpose |
| --- | --- |
| \.github/workflows/update_docs.yml\ | \workflow_dispatch\ entry point |
| \.github/scripts/update_docs.py\ | AI agent driver script |
| \.github/skills/azure-integration-docs/SKILL.md\ | Skill moved to project scope |

## How it works

\\\
workflow_dispatch
  ├── inputs: library (choice), path (optional), changelog (optional)
  ├── checkout langchain-azure
  ├── clone langchain-ai/docs  ← DOCS_REPO_TOKEN secret
  ├── run update_docs.py
  │     └── AI agent (GitHub Models / GPT-4o)
  │           ├── reads TEMPLATE.mdx from docs repo
  │           ├── reads source code from langchain-azure
  │           ├── reads existing Azure pages
  │           └── writes updated .mdx files
  └── git commit + gh pr create  → PR in langchain-ai/docs
\\\

The agent uses the \zure-integration-docs\ skill as its system prompt and is equipped with five tools (\list_langchain_azure_dir\, \ead_langchain_azure_file\, \list_docs_dir\, \ead_docs_file\, \write_docs_file\) that let it replicate the interactive skill workflow autonomously.

## One-time setup required

Add a **\DOCS_REPO_TOKEN\** repository secret — a classic PAT with \epo\ scope on \langchain-ai/docs\. This is needed to push the docs branch and open the PR.

The \GITHUB_TOKEN\ (with \models: read\ permission, granted by the workflow) is used for all LLM inference — no additional API keys needed.

## Inputs

| Input | Required | Description |
| --- | --- | --- |
| \library\ | ✅ | Library path (\libs/azure-ai\, etc.) |
| \path\ | ❌ | Specific module path within the library |
| \changelog\ | ❌ | Changelog / release-notes entry as context |