### PR TITLE
Fix toolbox MCP tool errors from aborting agent runs

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/tools/_toolbox.py
+++ b/libs/azure-ai/langchain_azure_ai/tools/_toolbox.py
@@ -6,13 +6,15 @@ import asyncio
 import logging
 import re
 from concurrent.futures import ThreadPoolExecutor
+from inspect import signature
 from types import TracebackType
 from typing import Any, List, Optional, Type, Union
 from urllib.parse import urlparse
 
 from azure.core.credentials import TokenCredential
 from langchain_core.documents.base import Blob
-from langchain_core.tools import BaseTool
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import BaseTool, ToolException
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from langchain_azure_ai._api.base import experimental
@@ -293,6 +295,79 @@ def _extract_consent_url(exc: BaseException) -> str:
             if url:
                 return url
     return str(exc)
+
+
+def _call_with_supported_kwargs(
+    func: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Call *func* with only the keyword arguments it accepts."""
+    params = signature(func).parameters
+    if any(param.kind == param.VAR_KEYWORD for param in params.values()):
+        return func(*args, **kwargs)
+    supported = {key: val for key, val in kwargs.items() if key in params}
+    return func(*args, **supported)
+
+
+class _ToolboxToolErrorWrapper(BaseTool):
+    """Convert ordinary toolbox tool exceptions into LangChain tool errors."""
+
+    wrapped_tool: BaseTool
+
+    def __init__(self, tool: BaseTool) -> None:
+        super().__init__(
+            name=tool.name,
+            description=tool.description,
+            args_schema=tool.args_schema,
+            return_direct=tool.return_direct,
+            verbose=tool.verbose,
+            callbacks=tool.callbacks,
+            tags=tool.tags,
+            metadata=tool.metadata,
+            handle_tool_error=True,
+            handle_validation_error=tool.handle_validation_error,
+            response_format=tool.response_format,
+            wrapped_tool=tool,
+        )
+
+    def _run(
+        self,
+        *args: Any,
+        config: Optional[RunnableConfig] = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run the wrapped tool synchronously."""
+        try:
+            return _call_with_supported_kwargs(
+                self.wrapped_tool._run,
+                args,
+                {**kwargs, "config": config, "run_manager": run_manager},
+            )
+        except ToolException:
+            raise
+        except Exception as exc:
+            raise ToolException(str(exc)) from exc
+
+    async def _arun(
+        self,
+        *args: Any,
+        config: Optional[RunnableConfig] = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Run the wrapped tool asynchronously."""
+        try:
+            return await _call_with_supported_kwargs(
+                self.wrapped_tool._arun,
+                args,
+                {**kwargs, "config": config, "run_manager": run_manager},
+            )
+        except ToolException:
+            raise
+        except Exception as exc:
+            raise ToolException(str(exc)) from exc
 
 
 # ── Toolbox ────────────────────────────────────────────────────────────────────
@@ -908,6 +983,7 @@ class AzureAIProjectToolbox(BaseModel):
         # message has no corresponding tool_message response.
         for t in tools:
             t.handle_tool_error = True
+        tools = [_ToolboxToolErrorWrapper(t) for t in tools]
 
         # Some MCP servers return tool schemas that omit ``properties`` on
         # object-typed inputs; fix them so the framework accepts the schema.

--- a/libs/azure-ai/langchain_azure_ai/tools/_toolbox.py
+++ b/libs/azure-ai/langchain_azure_ai/tools/_toolbox.py
@@ -313,7 +313,7 @@ def _call_with_supported_kwargs(
 class _ToolboxToolErrorWrapper(BaseTool):
     """Convert ordinary toolbox tool exceptions into LangChain tool errors."""
 
-    wrapped_tool: BaseTool
+    wrapped_tool: BaseTool = Field(exclude=True, repr=False)
 
     def __init__(self, tool: BaseTool) -> None:
         super().__init__(

--- a/libs/azure-ai/tests/unit_tests/test_toolbox.py
+++ b/libs/azure-ai/tests/unit_tests/test_toolbox.py
@@ -164,6 +164,32 @@ class TestAzureAIProjectToolboxApproval:
             await toolbox.get_tools_requiring_approval()
 
 
+class TestAzureAIProjectToolboxTools:
+    async def test_tool_execution_error_returns_tool_result(self) -> None:
+        from langchain_core.tools import tool
+
+        @tool
+        async def github_search(query: str) -> str:
+            """Search GitHub repositories."""
+            raise RuntimeError("GitHub MCP returned non-200 status code: 502")
+
+        class FakeClient:
+            async def get_tools(self) -> list[Any]:
+                return [github_search]
+
+        toolbox = AzureAIProjectToolbox(
+            project_endpoint="https://resource.services.ai.azure.com/api/projects/p",
+            toolbox_name="tb",
+            credential="token",
+        )
+
+        tools = await toolbox._fetch_tools(FakeClient())
+
+        result = await tools[0].ainvoke({"query": "langchain-ai/langchain-azure"})
+
+        assert "GitHub MCP returned non-200 status code: 502" in result
+
+
 class TestAzureAIProjectToolboxAuthHeaders:
     def _install_fake_httpx(self, monkeypatch: pytest.MonkeyPatch) -> None:
         class FakeAuth:

--- a/libs/azure-ai/tests/unit_tests/test_toolbox.py
+++ b/libs/azure-ai/tests/unit_tests/test_toolbox.py
@@ -168,10 +168,12 @@ class TestAzureAIProjectToolboxTools:
     async def test_tool_execution_error_returns_tool_result(self) -> None:
         from langchain_core.tools import tool
 
+        err_msg = "GitHub MCP returned non-200 status code."
+
         @tool
         async def github_search(query: str) -> str:
             """Search GitHub repositories."""
-            raise RuntimeError("GitHub MCP returned non-200 status code: 502")
+            raise RuntimeError(err_msg)
 
         class FakeClient:
             async def get_tools(self) -> list[Any]:
@@ -187,7 +189,7 @@ class TestAzureAIProjectToolboxTools:
 
         result = await tools[0].ainvoke({"query": "langchain-ai/langchain-azure"})
 
-        assert "GitHub MCP returned non-200 status code: 502" in result
+        assert err_msg in result
 
 
 class TestAzureAIProjectToolboxAuthHeaders:

--- a/libs/azure-ai/tests/unit_tests/test_toolbox.py
+++ b/libs/azure-ai/tests/unit_tests/test_toolbox.py
@@ -16,6 +16,7 @@ from langchain_azure_ai.tools._toolbox import (
     _normalize_scheme,
     _resource_name_from_uri,
     _run_async,
+    _ToolboxToolErrorWrapper,
 )
 
 pytestmark = pytest.mark.filterwarnings(
@@ -165,6 +166,20 @@ class TestAzureAIProjectToolboxApproval:
 
 
 class TestAzureAIProjectToolboxTools:
+    def test_tool_wrapper_excludes_wrapped_tool_from_dump_and_repr(self) -> None:
+        from langchain_core.tools import tool
+
+        @tool
+        def echo(text: str) -> str:
+            """Echo text."""
+            return text
+
+        wrapped = _ToolboxToolErrorWrapper(echo)
+
+        assert wrapped.wrapped_tool is echo
+        assert "wrapped_tool" not in wrapped.model_dump()
+        assert "wrapped_tool=" not in repr(wrapped)
+
     async def test_tool_execution_error_returns_tool_result(self) -> None:
         from langchain_core.tools import tool
 
@@ -189,7 +204,7 @@ class TestAzureAIProjectToolboxTools:
 
         result = await tools[0].ainvoke({"query": "langchain-ai/langchain-azure"})
 
-        assert err_msg in result
+        assert err_msg in str(result)
 
 
 class TestAzureAIProjectToolboxAuthHeaders:


### PR DESCRIPTION
## Summary

Fixes an issue where execution-time errors from Azure AI Foundry Toolbox MCP tools, such as a GitHub remote MCP returning a non-200 response, could propagate out of the tool call and abort the agent run.

The toolbox now wraps returned MCP tools so ordinary execution exceptions are converted into LangChain `ToolException`s. Since toolbox tools already set `handle_tool_error=True`, these failures are returned as tool results instead of breaking the LangGraph invocation.

## Changes

- Added a regression test that reproduces a toolbox MCP tool execution error escaping the tool call.
- Added a private toolbox tool wrapper that preserves the original tool metadata and delegates sync/async execution.
- Converts non-`ToolException` execution failures into `ToolException` so LangChain can produce a tool error result.

## Validation

- `.\.venv\Scripts\python -m pytest tests/unit_tests/test_toolbox.py`
- Result: `31 passed`