### PR TITLE
fix(sqlserver): use not_in for $nin metadata filter operator

### DIFF
--- a/libs/sqlserver/langchain_sqlserver/vectorstores.py
+++ b/libs/sqlserver/langchain_sqlserver/vectorstores.py
@@ -1235,7 +1235,7 @@ class SQLServerVectorStore(VectorStore):
             if operator in {"$in"}:
                 return queried_field.in_([str(val) for val in filter_value])
             elif operator in {"$nin"}:
-                return queried_field.nin_([str(val) for val in filter_value])
+                return queried_field.not_in([str(val) for val in filter_value])
             elif operator in {"$like"}:
                 return queried_field.like(str(filter_value))
             else:

--- a/libs/sqlserver/tests/unit_tests/test_filters.py
+++ b/libs/sqlserver/tests/unit_tests/test_filters.py
@@ -1,0 +1,51 @@
+"""Unit tests for the metadata filter builder (no live DB required).
+
+These compile the SQLAlchemy expression produced by ``_handle_field_filter``
+so operators can be checked without connecting to SQL Server.
+"""
+
+from typing import cast
+
+from sqlalchemy import ColumnElement
+from sqlalchemy.dialects import mssql
+
+from langchain_sqlserver.vectorstores import SQLServerVectorStore
+
+
+def _make_store() -> SQLServerVectorStore:
+    """Build a store without running ``__init__`` (which connects to a DB).
+
+    Only the attributes used by ``_handle_field_filter`` are set.
+    """
+    store = SQLServerVectorStore.__new__(SQLServerVectorStore)
+    store._embedding_length = 4
+    store._use_binary_collation = False
+    store._embedding_store = store._get_embedding_store("t", None)
+    return store
+
+
+def _compile(store: SQLServerVectorStore, field: str, value: object) -> str:
+    clause = cast(ColumnElement, store._handle_field_filter(field, value))
+    return str(
+        clause.compile(dialect=mssql.dialect(), compile_kwargs={"literal_binds": True})
+    )
+
+
+def test_nin_operator_builds_not_in_clause() -> None:
+    """`$nin` must produce a NOT IN clause. It previously called a
+    non-existent `nin_` method and raised AttributeError at query time."""
+    sql = _compile(_make_store(), "color", {"$nin": ["red", "blue"]})
+    assert "NOT IN" in sql.upper()
+    assert "'red'" in sql and "'blue'" in sql
+
+
+def test_in_operator_builds_in_clause() -> None:
+    sql = _compile(_make_store(), "color", {"$in": ["red", "blue"]})
+    assert " IN " in sql.upper()
+    assert "NOT IN" not in sql.upper()
+
+
+def test_like_operator_builds_like_clause() -> None:
+    sql = _compile(_make_store(), "name", {"$like": "%foo%"})
+    assert "LIKE" in sql.upper()
+    assert "'%foo%'" in sql


### PR DESCRIPTION
### Description

Re-opens #812, which was merged and then reverted in #852 because the test it added broke CI.

**The original bug (still present on `main` after the revert):** `_handle_field_filter` handles the `$nin` operator with

```python
return queried_field.nin_([str(val) for val in filter_value])
```

SQLAlchemy has no `nin_` method, so **any** `$nin` metadata filter raises `AttributeError` at query time. The supported API is `not_in`.

### What caused the revert, and the fix

`tests/unit_tests/test_filters.py` builds the store with `__new__` (to avoid needing a live DB), so it must set every attribute `_get_embedding_store` reads. Between when #812 was opened and when it merged, the `use_binary_collation` work (#801) landed and made `_get_embedding_store` read `self._use_binary_collation`. The test helper did not set it, so once #812 merged, `main` failed with:

```
AttributeError: SQLServerVectorStore object has no attribute _use_binary_collation
```

This PR is the original one-line source fix plus the test helper now setting `_use_binary_collation = False`. Rebased on current `main`, so it accounts for the collation change.

### Testing

`tests/unit_tests/test_filters.py` covers `$nin`, `$in` and `$like` by compiling the filter expression to SQL, so no live database is required. Verified against current `main`: full sqlserver unit suite passes (17 passed, 1 skipped) and `make lint` (ruff + ruff format + mypy) is clean.

Sorry for the CI breakage on the first attempt -- I have double-checked this one against the post-collation `main`.