### PR TITLE
fix(azure-ai): surface whole AIMessages from the LangGraph messages channel

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_stream.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_stream.py
@@ -12,10 +12,17 @@ tool calls and tool-message results are surfaced to the client in real time.
 Lifecycle per turn (a "turn" is everything appended after the last
 :class:`HumanMessage`):
 
-1. Token text from any LLM node arrives as :class:`AIMessageChunk`
-   payloads under the ``messages`` channel. Consecutive non-empty
-   chunks are streamed through one ``message`` output item with
-   ``output_text.delta`` events.
+1. Assistant text arrives under the ``messages`` channel in one of two
+   shapes. A streaming chat model produces :class:`AIMessageChunk`
+   payloads that share one message id. A non-streaming chat model call,
+   or a node that returns an :class:`AIMessage` directly (e.g. a
+   deterministic ``finalize`` node), produces a single whole
+   :class:`AIMessage`. LangGraph emits each message on this channel
+   exactly once — its ``StreamMessagesHandler`` deduplicates by message
+   id across token chunks, LLM completions and node returns — so the
+   converter treats both shapes the same way: consecutive non-empty
+   payloads sharing a message id are streamed through one ``message``
+   output item with ``output_text.delta`` events.
 2. Reasoning summaries (emitted when the chat model is configured with
    ``reasoning={"summary": "auto"}``) arrive in the same
    :class:`AIMessageChunk` payloads as ``reasoning`` content blocks.
@@ -42,7 +49,6 @@ from typing import Any, cast
 from azure.ai.agentserver.responses import ResponseEventStream
 from langchain_core.messages import (
     AIMessage,
-    AIMessageChunk,
     BaseMessage,
     ToolMessage,
 )
@@ -141,16 +147,8 @@ class StreamConverter:
         self._reasoning_buffer: list[str] = []
         self._emitted_tool_call_ids: set[str] = set()
         self._emitted_tool_output_call_ids: set[str] = set()
-        # AIMessage ids whose text was streamed token-by-token via
-        # ``stream_mode="messages"`` (LLM nodes). Used to avoid re-emitting the
-        # same assistant text as a whole ``message`` item when the node's
-        # ``updates`` payload arrives carrying the finished AIMessage.
-        self._streamed_message_ids: set[str] = set()
-        # AIMessage ids already surfaced as a whole ``message`` item from an
-        # ``updates`` payload (non-LLM nodes that return assistant text
-        # directly, e.g. a deterministic ``finalize`` node), so we emit each
-        # such message exactly once.
-        self._emitted_message_ids: set[str] = set()
+        # Id of the message currently streamed into the open ``message`` item.
+        self._current_message_id: str | None = None
 
     async def checkpoint(self) -> AsyncIterator[Any]:
         """Close partial output and emit an Agent Server checkpoint event."""
@@ -159,20 +157,32 @@ class StreamConverter:
         yield self._stream.checkpoint()
 
     async def handle_message_chunk(self, payload: Any) -> AsyncIterator[Any]:
-        """Handle a payload from ``stream_mode="messages"``."""
-        message_chunk = _extract_message_chunk(payload)
-        if message_chunk is None:
+        """Handle a payload from ``stream_mode="messages"``.
+
+        The payload carries either one token chunk of a streaming chat model
+        response or a whole :class:`AIMessage` (non-streaming LLM call, or a
+        node that built the message itself). Payloads sharing a message id
+        accumulate into a single ``message`` output item; a different id
+        closes the open item and starts a new one.
+        """
+        message = _extract_ai_message(payload)
+        if message is None:
             return
 
-        chunk_id = getattr(message_chunk, "id", None)
-        if isinstance(chunk_id, str) and chunk_id:
-            self._streamed_message_ids.add(chunk_id)
+        message_id = message.id if isinstance(message.id, str) and message.id else None
+        if (
+            message_id is not None
+            and self._current_message_id is not None
+            and message_id != self._current_message_id
+        ):
+            async for event in self._close_open_message():
+                yield event
 
-        for fragment in extract_reasoning_summary_fragments(message_chunk.content):
+        for fragment in extract_reasoning_summary_fragments(message.content):
             async for event in self._emit_reasoning_fragment(fragment):
                 yield event
 
-        text = extract_text(message_chunk.content)
+        text = extract_text(message.content)
         if not text:
             return
 
@@ -187,6 +197,7 @@ class StreamConverter:
         if self._text_builder is None:
             self._text_builder = self._message_builder.add_text_content()
             yield self._text_builder.emit_added()
+        self._current_message_id = message_id
         self._text_buffer.append(text)
         yield self._text_builder.emit_delta(text)
 
@@ -233,8 +244,8 @@ class StreamConverter:
 
             for message in messages:
                 if isinstance(message, AIMessage):
-                    async for event in self._emit_ai_message_text(message):
-                        yield event
+                    # Assistant text is not emitted here: LangGraph already
+                    # published this message on the ``messages`` channel.
                     for call in message.tool_calls or []:
                         async for event in self._emit_tool_call(call):
                             yield event
@@ -258,6 +269,7 @@ class StreamConverter:
         if self._message_builder is not None:
             yield self._message_builder.emit_done()
             self._message_builder = None
+        self._current_message_id = None
 
     async def _close_open_reasoning(self) -> AsyncIterator[Any]:
         if self._reasoning_part_builder is not None:
@@ -270,49 +282,6 @@ class StreamConverter:
         if self._reasoning_builder is not None:
             yield self._reasoning_builder.emit_done()
             self._reasoning_builder = None
-
-    async def _emit_ai_message_text(self, message: AIMessage) -> AsyncIterator[Any]:
-        """Emit a whole ``message`` item for assistant text from a node update.
-
-        LangGraph's ``stream_mode="messages"`` only streams tokens from chat
-        model invocations. A node that returns an :class:`AIMessage` with text
-        content *without* calling an LLM (e.g. a deterministic ``finalize``
-        node) therefore never produces ``messages``-mode chunks, so its text
-        would otherwise be dropped from the stream. Here we surface it as a
-        complete ``message`` output item.
-
-        The emission is deduplicated two ways so LLM-streamed text is not
-        doubled up: messages whose id was already streamed token-by-token
-        (tracked in ``_streamed_message_ids``) are skipped, as are messages
-        already emitted here (``_emitted_message_ids``).
-        """
-        text = extract_text(message.content)
-        if not text:
-            return
-        message_id = message.id
-        if isinstance(message_id, str) and message_id:
-            if message_id in self._streamed_message_ids:
-                return
-            if message_id in self._emitted_message_ids:
-                return
-            self._emitted_message_ids.add(message_id)
-        elif self._text_buffer:
-            # No id to dedup on, but text was already streamed this segment.
-            return
-
-        async for event in self._close_open_reasoning():
-            yield event
-        async for event in self._close_open_message():
-            yield event
-
-        message_builder = self._stream.add_output_item_message()
-        yield message_builder.emit_added()
-        text_builder = message_builder.add_text_content()
-        yield text_builder.emit_added()
-        yield text_builder.emit_delta(text)
-        yield text_builder.emit_text_done(text)
-        yield text_builder.emit_done()
-        yield message_builder.emit_done()
 
     async def _emit_tool_call(self, call: Any) -> AsyncIterator[Any]:
         name = str(call.get("name") or "")
@@ -376,13 +345,19 @@ def _extract_checkpoint_ref(payload: Any) -> CheckpointRef | None:
     return HostingRunnableConfig(cast(RunnableConfig, config)).checkpoint_ref
 
 
-def _extract_message_chunk(payload: Any) -> AIMessageChunk | None:
-    """Pull an ``AIMessageChunk`` out of a ``messages`` payload."""
-    if isinstance(payload, AIMessageChunk):
+def _extract_ai_message(payload: Any) -> AIMessage | None:
+    """Pull an ``AIMessage`` out of a ``messages`` payload.
+
+    Accepts :class:`AIMessage` and its :class:`AIMessageChunk` subclass so
+    both token chunks and whole messages are surfaced. Other message types
+    (notably :class:`ToolMessage`, which LangGraph also publishes on this
+    channel) are ignored here and handled from the ``updates`` channel.
+    """
+    if isinstance(payload, AIMessage):
         return payload
     if isinstance(payload, tuple) and payload:
         candidate = payload[0]
-        if isinstance(candidate, AIMessageChunk):
+        if isinstance(candidate, AIMessage):
             return candidate
     return None
 

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_stream.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_stream.py
@@ -281,6 +281,73 @@ async def test_chunk_without_reasoning_emits_no_reasoning_events() -> None:
     assert "response.output_text.delta" in types
 
 
+async def test_whole_ai_message_is_streamed() -> None:
+    """A node that returns an ``AIMessage`` without calling an LLM publishes a
+    whole message (not a chunk) on the ``messages`` channel; its text must
+    still reach the client."""
+    events = await _drive(
+        [
+            (
+                "messages",
+                (AIMessage(content="Trip confirmed.", id="msg-1"), {}),
+            ),
+            ("updates", {"finalize": {"messages": [AIMessage(content="ignored")]}}),
+        ]
+    )
+
+    text_deltas = [
+        event.delta for event in events if event.type == "response.output_text.delta"
+    ]
+    assert text_deltas == ["Trip confirmed."]
+
+
+async def test_ai_message_in_updates_does_not_duplicate_text() -> None:
+    """LangGraph deduplicates on the ``messages`` channel, so the finished
+    ``AIMessage`` echoed back in ``updates`` must not re-emit its text."""
+    message = AIMessage(content="The answer is 42.", id="msg-1")
+    events = await _drive(
+        [
+            ("messages", (AIMessageChunk(content="The answer ", id="msg-1"), {})),
+            ("messages", (AIMessageChunk(content="is 42.", id="msg-1"), {})),
+            ("updates", {"agent": {"messages": [message]}}),
+        ]
+    )
+
+    text_deltas = [
+        event.delta for event in events if event.type == "response.output_text.delta"
+    ]
+    assert text_deltas == ["The answer ", "is 42."]
+    assert _types(events).count("response.output_item.added") == 1
+
+
+async def test_new_message_id_opens_a_new_output_item() -> None:
+    """Two messages emitted within one superstep must not be glued into a
+    single ``message`` output item."""
+    events = await _drive(
+        [
+            ("messages", (AIMessage(content="first", id="msg-1"), {})),
+            ("messages", (AIMessage(content="second", id="msg-2"), {})),
+        ]
+    )
+
+    types = _types(events)
+    assert types.count("response.output_item.added") == 2
+    done_texts = [
+        event.text for event in events if event.type == "response.output_text.done"
+    ]
+    assert done_texts == ["first", "second"]
+
+
+async def test_tool_message_on_messages_channel_is_ignored() -> None:
+    """``ToolMessage`` also reaches the ``messages`` channel; it is surfaced
+    from ``updates`` instead, so it must produce no message item here."""
+    events = await _drive(
+        [("messages", (ToolMessage(content="sunny", tool_call_id="call_1"), {}))]
+    )
+
+    assert events == []
+
+
 async def test_checkpoint_event_captures_config_and_commits_response() -> None:
     stream = ResponseEventStream(response_id="resp-test")
     stream.emit_created()
@@ -291,8 +358,8 @@ async def test_checkpoint_event_captures_config_and_commits_response() -> None:
             _agen(
                 [
                     (
-                        "updates",
-                        {"agent": {"messages": [AIMessage(content="committed")]}},
+                        "messages",
+                        (AIMessage(content="committed", id="msg-1"), {}),
                     ),
                     (
                         "checkpoints",


### PR DESCRIPTION
Follow-up fix on top of `aochengwang/resilient`. Targets that branch, not `main`.

## Problem

The branch added `StreamConverter._emit_ai_message_text()` to stop assistant text
from deterministic (non-LLM) nodes being dropped. The symptom was real, but the
diagnosis in the docstring is not:

> LangGraph's `stream_mode="messages"` only streams tokens from chat model invocations.

That is not true for LangGraph 1.x (we depend on `langgraph>=1.1.1,<3.0`; 1.2.9
locally). `StreamMessagesHandler` publishes on the `messages` channel from three
places, not one:

| callback | emits |
| --- | --- |
| `on_llm_new_token` | one `AIMessageChunk` per token |
| `on_llm_end` | the whole `AIMessage` (covers non-streamed `ainvoke` calls) |
| `on_chain_end` | every `BaseMessage` a node returned |

All three go through `_emit(..., dedupe=True)` against a shared `seen` set, and
`on_chain_start` pre-seeds `seen` with the node's **input** messages.

So a `finalize` node returning `AIMessage(content="...")` **is** published — as a
plain `AIMessage`, not an `AIMessageChunk`. It was being discarded one layer
earlier, in `_extract_message_chunk()`:

```python
if isinstance(payload, AIMessageChunk):   # AIMessage is the parent class,
    return payload                        # so a whole message never matches
...
return None
```

Recovering the text from the `updates` channel instead worked around that filter,
but introduced three problems:

1. **Unreachable fallback.** `handle_update()` calls `_close_open_message()`
   before iterating messages, and that resets `self._text_buffer = []`. The
   `elif self._text_buffer:` guard in `_emit_ai_message_text()` can therefore
   never be true, so an `AIMessage` without an id is always emitted — duplicating
   text that was already streamed.
2. **Weaker dedup than LangGraph's.** `_streamed_message_ids` / `_emitted_message_ids`
   only cover the current response. LangGraph's `seen` additionally covers node
   *inputs*, so it suppresses history that a node hands back (summarisation /
   history-rewrite nodes, HITL resume). The branch's version re-emits it.
3. **Still dropped non-streamed LLM output.** A node calling `model.ainvoke()`
   produces no token chunks; its `on_llm_end` message was filtered out by
   `_extract_message_chunk` just the same, and the `updates` path only ran for
   `AIMessage`s carrying text, so this case stayed broken.

The sample in this branch (`99_resilient`) only has `agent` / `tools` / `approval`
nodes, so none of these paths are exercised, and `test_stream.py` had no coverage
for the new method.

## Fix

`libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_stream.py`

- `_extract_message_chunk` → `_extract_ai_message`, matching on `AIMessage` so it
  accepts both token chunks and whole messages. `ToolMessage` (also published on
  this channel) still falls through and is handled from `updates` as before.
- Removed `_emit_ai_message_text()` and both dedup sets. Deduplication is left to
  LangGraph, which already does it correctly and more completely.
- Added `_current_message_id`: a new message id closes the open `message` output
  item. Without it two whole messages arriving in the same superstep (parallel
  nodes, or two `ainvoke` calls in one node) would be concatenated into a single
  output item.

Net effect: −50 lines of duplicated bookkeeping, and non-streamed LLM output now
reaches the client too.

## Tests

`libs/azure-ai/tests/unit_tests/agents/hosting/test_stream.py`

- `test_whole_ai_message_is_streamed` — node-built `AIMessage` text reaches the client.
- `test_ai_message_in_updates_does_not_duplicate_text` — the finished `AIMessage`
  echoed in `updates` after token streaming emits no extra text and no second item.
- `test_new_message_id_opens_a_new_output_item` — two messages are not glued together.
- `test_tool_message_on_messages_channel_is_ignored` — `ToolMessage` produces no
  message item.
- `test_checkpoint_event_captures_config_and_commits_response` now drives its
  output item through the `messages` channel, since `updates` no longer emits text.

Verified against a real two-node LangGraph graph (no LLM): both node-built
messages appear on the `messages` channel as plain `AIMessage` and are emitted as
two separate output items. `ruff check` and `ruff format --check` pass.

## Note for the base branch (not fixed here)

`make test` cannot run on `aochengwang/resilient` as locked. `pyproject.toml` /
`uv.lock` still pin `azure-ai-agentserver-responses` at `1.0.0b8`, and neither
`1.0.0b8` nor the latest published `1.0.0b9` exports `ConversationChainMetadataNamespace`,
`ResponseEventStream.internal_metadata`, or `ResponseEventStream.checkpoint()`.
`langchain_azure_ai/agents/hosting/_responses/__init__.py` therefore fails to
import and the whole hosting test package errors at collection. The dependency
floor needs raising once that preview build ships. I verified the changes here by
stubbing those three symbols locally.