### PR TITLE
docs: fix copy-paste errors in CONTRIBUTING.md and broken Makefile paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ is split across separate test & release flows.
 
 ## Repository Structure
 
-If you plan on contributing to LangChain-Google code or documentation, it can be useful
+If you plan on contributing to LangChain-Azure code or documentation, it can be useful
 to understand the high level structure of the repository.
 
 LangChain-Azure is organized as a [monorepo](https://en.wikipedia.org/wiki/Monorepo) that contains multiple packages.
@@ -123,7 +123,7 @@ cd libs/{LIBRARY}
 make format
 ```
 
-Additionally, you can run the formatter only on the files that have been modified in your current branch as compared to the master branch using the format_diff command:
+Additionally, you can run the formatter only on the files that have been modified in your current branch as compared to the main branch using the format_diff command:
 
 ```bash
 make format_diff
@@ -148,7 +148,7 @@ cd libs/{LIBRARY}
 make lint
 ```
 
-In addition, you can run the linter only on the files that have been modified in your current branch as compared to the master branch using the lint_diff command:
+In addition, you can run the linter only on the files that have been modified in your current branch as compared to the main branch using the lint_diff command:
 
 ```bash
 make lint_diff

--- a/libs/azure-dynamic-sessions/Makefile
+++ b/libs/azure-dynamic-sessions/Makefile
@@ -30,7 +30,7 @@ test_watch:
 PYTHON_FILES=.
 MYPY_CACHE=.mypy_cache
 lint format: PYTHON_FILES=.
-lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/azure --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
+lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/azure-dynamic-sessions --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain_azure_dynamic_sessions
 lint_tests: PYTHON_FILES=tests
 lint_tests: MYPY_CACHE=.mypy_cache_test

--- a/libs/azure-storage/Makefile
+++ b/libs/azure-storage/Makefile
@@ -30,7 +30,7 @@ test_watch:
 PYTHON_FILES=.
 MYPY_CACHE=.mypy_cache
 lint format: PYTHON_FILES=.
-lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/azure --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
+lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/azure-storage --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain_azure_storage
 lint_tests: PYTHON_FILES=tests
 lint_tests: MYPY_CACHE=.mypy_cache_test

--- a/libs/sqlserver/Makefile
+++ b/libs/sqlserver/Makefile
@@ -30,7 +30,7 @@ test_watch:
 PYTHON_FILES=.
 MYPY_CACHE=.mypy_cache
 lint format: PYTHON_FILES=.
-lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/azure --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
+lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/sqlserver --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain_sqlserver
 lint_tests: PYTHON_FILES=tests
 lint_tests: MYPY_CACHE=.mypy_cache_test


### PR DESCRIPTION
## Summary

- Fix copy-paste error on line 49 of CONTRIBUTING.md: 'LangChain-Google' should be 'LangChain-Azure'
- Fix stale 'master' branch references on lines 126 and 151 of CONTRIBUTING.md (default branch is 'main')
- Fix broken `--relative` paths and branch name in `lint_diff`/`format_diff` targets in 3 Makefiles (libs/sqlserver, libs/azure-dynamic-sessions, libs/azure-storage) that reference nonexistent `libs/partners/azure` and wrong branch 'master'

## Testing

Verified all changes by grepping for the patterns before and after edits. These are documentation and build script path fixes with no behavioral changes.