### PR TITLE
Comment out make integration_tests rule

### DIFF
--- a/libs/azure-storage/Makefile
+++ b/libs/azure-storage/Makefile
@@ -21,8 +21,14 @@ tests:
 # Runs all integration tests: document loaders and the Deep Agents backend.
 # See tests/integration_tests/conftest.py for the required environment
 # variables (live account or Azurite emulator).
-integration_tests:
-	$(UV_RUN_TEST) --group test_integration pytest tests/integration_tests/
+#
+# NOTE: This is currently commented out as "make integration_tests" is used
+# in release CI which does not have test resources available. We can
+# uncomment this when we have Azurite or live storage account fully integrated in
+# our CI workflow. Feel free to uncomment and run locally to use the
+# make workflow for running integration tests.
+# integration_tests:
+#     $(UV_RUN_TEST) --group test_integration pytest tests/integration_tests/
 
 test_watch:
 	$(UV_RUN_TEST) ptw --snapshot-update --now . -- -vv $(TEST_FILE)


### PR DESCRIPTION
The release CI uses this rule automatically and Azure storage resources nor Azurite are not setup to be able to run the integration tests as part of the release.