### PR TITLE
Implement user-based thread ID isolation

### DIFF
--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -163,7 +163,7 @@ The Responses host uses one conversation-state source per graph. The policy depe
 
 | Graph configuration | Conversation source | Graph input on later turns |
 |---|---|---|
-| Graph compiled with a checkpointer | LangGraph checkpoint state keyed by the conversation/thread id | Current request input only |
+| Graph compiled with a checkpointer | LangGraph checkpoint state keyed by the conversation/thread ID and, when available, the platform-provided user partition key | Current request input only |
 | Graph without a checkpointer | Responses transcript history from the underlying response provider | Prior Responses history plus current input |
 
 The Responses transcript provider is selected by the underlying `azure-ai-agentserver-responses` runtime. Local runs and tests use an in-memory provider by default. Foundry-hosted containers use the Foundry-backed storage provider when the platform environment variables are present. This transcript store is separate from the LangGraph checkpointer, which stores graph runtime state.

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
@@ -30,6 +30,7 @@ Then call the local server::
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Optional
@@ -108,6 +109,16 @@ def _message_count(
     skip_call_ids: frozenset[str] = frozenset(),
 ) -> int:
     return len(build_messages_input(items, skip_call_ids=skip_call_ids)["messages"])
+
+
+def _scope_thread_id(thread_id: str, context: ResponseContext) -> str:
+    """Namespace a LangGraph thread by the platform-provided user key."""
+    platform_context = getattr(context, "platform_context", None)
+    user_id_key = getattr(platform_context, "user_id_key", None)
+    if not isinstance(user_id_key, str):
+        return thread_id
+    user_namespace = hashlib.sha256(user_id_key.encode()).hexdigest()
+    return f"user-{user_namespace}:{thread_id}"
 
 
 def _response_field(response: Any, name: str) -> str | None:
@@ -461,10 +472,10 @@ class ResponsesHostServer:
 
         Sets ``configurable.thread_id`` so graphs compiled with a
         checkpointer naturally continue the right conversation.
-        ``conversation_id`` is used directly when available. For
-        ``previous_response_id`` chains, the host resolves the root response
-        through the Responses provider when possible so all turns share the
-        same thread id.
+        When the platform supplies a user isolation key, the thread ID is
+        namespaced by that key. For ``previous_response_id`` chains, the host
+        resolves the root response through the Responses provider when possible
+        so all turns from the same user share the same thread ID.
 
         Args:
             request: The parsed create-response request.
@@ -495,7 +506,7 @@ class ResponsesHostServer:
             thread_id = f"resp-{previous_response_id}"
         else:
             thread_id = f"resp-{context.response_id}"
-        return {"configurable": {"thread_id": thread_id}}
+        return {"configurable": {"thread_id": _scope_thread_id(thread_id, context)}}
 
     async def _resolve_thread_id(
         self,
@@ -514,7 +525,7 @@ class ResponsesHostServer:
             thread_id = resolved_thread_id or f"resp-{previous_response_id}"
         else:
             thread_id = f"resp-{context.response_id}"
-        return thread_id
+        return _scope_thread_id(thread_id, context)
 
     async def _thread_id_from_response_chain(
         self,

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
@@ -299,9 +299,10 @@ async def test_checkpointed_conversation_is_isolated_by_user() -> None:
         _request(),
         _context(conversation_id="shared", user_id_key="user-b"),
     )
-    assert first_config["configurable"]["thread_id"] != second_config[
-        "configurable"
-    ]["thread_id"]
+    assert (
+        first_config["configurable"]["thread_id"]
+        != second_config["configurable"]["thread_id"]
+    )
     assert first_config == await server.build_runnable_config(
         _request(),
         _context(conversation_id="shared", user_id_key="user-a"),
@@ -382,9 +383,10 @@ async def test_previous_response_id_thread_is_scoped_by_user() -> None:
         _context(conversation_id=None, provider=_Provider(), user_id_key="user-b"),
     )
 
-    assert first_config["configurable"]["thread_id"] != second_config[
-        "configurable"
-    ]["thread_id"]
+    assert (
+        first_config["configurable"]["thread_id"]
+        != second_config["configurable"]["thread_id"]
+    )
 
 
 async def test_conversation_management_debug_log_has_counts(

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -76,11 +77,13 @@ def _context(
     current_text: str = "hello",
     history: list[object] | None = None,
     provider: object | None = None,
+    user_id_key: str | None = None,
 ) -> MagicMock:
     context = MagicMock()
     context.response_id = response_id
     context.conversation_id = conversation_id
     context.isolation = None
+    context.platform_context = SimpleNamespace(user_id_key=user_id_key)
     context.get_input_items = AsyncMock(return_value=[_message_item(current_text)])
     context.get_history = AsyncMock(return_value=history or [])
     context._provider = provider
@@ -270,6 +273,52 @@ async def test_conversation_id_is_thread_id() -> None:
     assert config["configurable"]["thread_id"] == "conv-test"
 
 
+async def test_checkpointed_conversation_is_isolated_by_user() -> None:
+    server = ResponsesHostServer(make_checkpointed_echo_graph())
+
+    with _client(server) as client:
+        first = client.post(
+            "/responses",
+            headers={"x-agent-user-id": "user-a"},
+            json={"input": "secret-a", "conversation": {"id": "shared"}},
+        )
+        second = client.post(
+            "/responses",
+            headers={"x-agent-user-id": "user-b"},
+            json={"input": "hello-b", "conversation": {"id": "shared"}},
+        )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+
+    first_config = await server.build_runnable_config(
+        _request(),
+        _context(conversation_id="shared", user_id_key="user-a"),
+    )
+    second_config = await server.build_runnable_config(
+        _request(),
+        _context(conversation_id="shared", user_id_key="user-b"),
+    )
+    assert first_config["configurable"]["thread_id"] != second_config[
+        "configurable"
+    ]["thread_id"]
+    assert first_config == await server.build_runnable_config(
+        _request(),
+        _context(conversation_id="shared", user_id_key="user-a"),
+    )
+
+    first_state = await server.graph.aget_state(first_config)
+    second_state = await server.graph.aget_state(second_config)
+    assert [message.content for message in first_state.values["messages"]] == [
+        "secret-a",
+        "Echo: secret-a",
+    ]
+    assert [message.content for message in second_state.values["messages"]] == [
+        "hello-b",
+        "Echo: hello-b",
+    ]
+
+
 async def test_previous_response_id_chain_resolves_root_thread_id() -> None:
     class _Provider:
         async def get_response(
@@ -305,6 +354,37 @@ async def test_previous_response_id_chain_resolves_root_thread_id() -> None:
         )["configurable"]["thread_id"]
         == "resp-resp-3"
     )
+
+
+async def test_previous_response_id_thread_is_scoped_by_user() -> None:
+    class _Provider:
+        async def get_response(
+            self,
+            response_id: str,
+            *,
+            context: object = None,
+        ) -> dict[str, str | None]:
+            del context
+            responses: dict[str, dict[str, str | None]] = {
+                "resp-2": {"previous_response_id": "resp-1"},
+                "resp-1": {"previous_response_id": None},
+            }
+            return responses[response_id]
+
+    server = ResponsesHostServer(make_checkpointed_echo_graph())
+    request = _request(previous_response_id="resp-2")
+    first_config = await server.build_runnable_config(
+        request,
+        _context(conversation_id=None, provider=_Provider(), user_id_key="user-a"),
+    )
+    second_config = await server.build_runnable_config(
+        request,
+        _context(conversation_id=None, provider=_Provider(), user_id_key="user-b"),
+    )
+
+    assert first_config["configurable"]["thread_id"] != second_config[
+        "configurable"
+    ]["thread_id"]
 
 
 async def test_conversation_management_debug_log_has_counts(


### PR DESCRIPTION
- Enhance documentation to clarify the keying of conversation sources in the Responses host. 
- Update the document accordingly.