### PR TITLE
feat(azure-storage): conform AzureBlobBackend to deepagents 0.7.0

### DIFF
--- a/libs/azure-storage/README.md
+++ b/libs/azure-storage/README.md
@@ -252,7 +252,7 @@ Recommended mitigations:
 
 - Set a `prefix` so the agent can only reach its own key namespace, never the whole container.
 - Enable [soft delete](https://learn.microsoft.com/azure/storage/blobs/soft-delete-blob-overview) and/or [blob versioning](https://learn.microsoft.com/azure/storage/blobs/versioning-overview) on the container so destructive tool calls are recoverable.
-- Scope the agent's credential to the container it should be able to modify.
+- Scope the agent's credential to the container it should be able to modify, following the [Azure RBAC best practices](https://learn.microsoft.com/azure/role-based-access-control/best-practices): assign the role at the container scope rather than the subscription or storage account, and pick the least-privileged built-in role for what the agent actually does — `Storage Blob Data Reader` for a read-only agent, `Storage Blob Data Contributor` only when it must write or delete.
 - Drop or gate the tools you don't want. Omit `delete` from the filesystem middleware, or add a Deep Agents permission rule that denies it or routes it through a human-approval interrupt:
 
   ```python

--- a/libs/azure-storage/README.md
+++ b/libs/azure-storage/README.md
@@ -196,7 +196,7 @@ container_loader = AzureBlobStorageLoader(
 
 ## Deep Agents Azure Blob Storage Backend Usage
 
-[Deep Agents](https://github.com/langchain-ai/deepagents) exposes a `BackendProtocol` — a pluggable interface for file operations (`read`, `write`, `edit`, `ls`, `glob`, `grep`, plus batch upload/download) that an agent uses as its virtual filesystem. This package provides `AzureBlobBackend`, an Azure Blob Storage implementation of that interface, so a deep agent can persist its workspace in a blob container.
+[Deep Agents](https://github.com/langchain-ai/deepagents) exposes a `BackendProtocol` — a pluggable interface for file operations (`read`, `write`, `edit`, `delete`, `ls`, `glob`, `grep`, plus batch upload/download) that an agent uses as its virtual filesystem. This package provides `AzureBlobBackend`, an Azure Blob Storage implementation of that interface, so a deep agent can persist its workspace in a blob container.
 
 The backend requires the optional `deepagents` extra (which itself requires Python 3.11+):
 
@@ -239,7 +239,36 @@ Runnable examples — including a workspace that persists across agent lifetimes
 composite agent with memory and subagents — live in
 [`samples/deepagents-storage-backend/`](../../samples/deepagents-storage-backend/README.md).
 
-File content is stored as UTF-8 text in blob bodies (binary uploads are preserved as bytes). Directories are synthesized from blob key prefixes (no directory marker blobs are created). The backend exposes both synchronous methods (`read`, `write`, `edit`, `ls`, `glob`, `grep`, `upload_files`, `download_files`) and their `a`-prefixed async counterparts (`aread`, `awrite`, …).
+File content is stored as UTF-8 text in blob bodies (binary uploads are preserved as bytes). Directories are synthesized from blob key prefixes (no directory marker blobs are created). The backend exposes both synchronous methods (`read`, `write`, `edit`, `delete`, `ls`, `glob`, `grep`, `upload_files`, `download_files`) and their `a`-prefixed async counterparts (`aread`, `awrite`, …).
+
+### Writes and deletes are destructive
+
+Two backend operations replace or remove data that is already in your container. Both follow the Deep Agents `BackendProtocol` contract, and both are driven by the agent:
+
+- **`write` replaces an existing file in full.** There is no create-only mode — `write_file` on a path that already exists overwrites it rather than erroring. Use `edit` when existing content must be preserved.
+- **`delete` is recursive.** Deleting a directory removes it and everything nested under it. Deleting `"/"` removes every blob in the configured `prefix` namespace, or — if no `prefix` is set — **every blob in the container**.
+
+Recommended mitigations:
+
+- Set a `prefix` so the agent can only reach its own key namespace, never the whole container.
+- Enable [soft delete](https://learn.microsoft.com/azure/storage/blobs/soft-delete-blob-overview) and/or [blob versioning](https://learn.microsoft.com/azure/storage/blobs/versioning-overview) on the container so destructive tool calls are recoverable.
+- Scope the agent's credential to the container it should be able to modify.
+- Drop or gate the tools you don't want. Omit `delete` from the filesystem middleware, or add a Deep Agents permission rule that denies it or routes it through a human-approval interrupt:
+
+  ```python
+  from deepagents import FilesystemMiddleware, create_deep_agent
+
+  agent = create_deep_agent(
+      backend=backend,
+      middleware=[
+          # Register every filesystem tool except `delete`.
+          FilesystemMiddleware(
+              backend=backend,
+              tools=["ls", "read_file", "write_file", "edit_file", "glob", "grep"],
+          )
+      ],
+  )
+  ```
 
 ### Authentication
 

--- a/libs/azure-storage/langchain_azure_storage/deepagents/backend.py
+++ b/libs/azure-storage/langchain_azure_storage/deepagents/backend.py
@@ -203,12 +203,8 @@ def _read_result_from_bytes(
 
     Returns raw (unformatted) content -- the Deep Agents middleware applies
     line numbering, the empty-file reminder, and base64 multimodal handling at
-    the tool boundary. For text content, ``slice_read_response`` also supplies
-    the pagination metadata (``total_lines``/``start_line``/``end_line``/
-    ``next_offset``), clamps degenerate windows a model can ask for (negative
-    ``offset`` reads from line 1, non-positive ``limit`` yields an empty read
-    flagged ``no_lines_requested``), and the middleware reports all of that
-    back to the model.
+    the tool boundary. ``slice_read_response`` supplies the pagination metadata
+    and clamps degenerate windows.
 
     Encoding is chosen the way the filesystem-like reference backends do it:
     files whose extension classifies as non-text (image/audio/video/file) are
@@ -268,15 +264,12 @@ def _delete_keys(
 ) -> list[str]:
     """Select the blob keys a recursive delete of one path should remove.
 
-    The listing that produced *blobs* is prefix-narrowed server-side for
-    efficiency, but a bare prefix also matches siblings that merely share a
-    name stem. This filter is what enforces the subtree boundary: a key
-    qualifies only by being the path's own blob or by sitting under its
-    slash-terminated prefix. See `AzureBlobBackend._delete_scope`.
+    The server-side listing prefix also matches siblings sharing a name stem
+    (``/src`` returns ``/src-backup``), so this filter is what enforces the
+    subtree boundary. Do not widen it to a bare prefix match.
 
-    Unlike `ls`, pseudo-directory marker blobs (keys ending in ``/``) are not
-    skipped: they are real blobs inside the subtree being removed, so a
-    recursive delete has to take them with it.
+    Marker blobs (keys ending in ``/``) are deliberately kept, unlike in `ls`:
+    they sit inside the subtree being removed.
     """
     return [
         blob.name
@@ -291,9 +284,8 @@ def _delete_failure_error(
 ) -> str:
     """Build the error for a recursive delete that could not remove everything.
 
-    Distinguishes a wholly failed delete from a partial one: retrying the
-    former is safe, while the latter has already changed the container and the
-    caller needs to know that.
+    A wholly failed delete is reported distinctly from a partial one: retrying
+    the former is safe, the latter has already changed the container.
     """
     failed_paths.sort()
     sample = ", ".join(failed_paths[:3])
@@ -308,13 +300,11 @@ def _delete_failure_error(
 
 
 def _normalize_max_count(max_count: int | None) -> int | None:
-    """Clamp a caller-supplied grep cap to a sane value.
+    """Clamp a caller-supplied grep cap.
 
-    ``max_count`` reaches the backend straight off the ``grep`` tool schema,
-    which declares no lower bound, so a model can send ``0`` or a negative
-    value. Left alone, a negative cap would be read as a slice-from-the-end and
-    silently drop matches. Clamping to ``0`` matches how the reference
-    backends' ``grep_matches_from_files`` treats the same input.
+    The ``grep`` tool schema sets no lower bound on ``max_count``, so a model
+    can send a negative value, which would otherwise slice from the end and
+    silently drop matches. Clamping to ``0`` matches ``grep_matches_from_files``.
     """
     if max_count is None:
         return None
@@ -322,17 +312,7 @@ def _normalize_max_count(max_count: int | None) -> int | None:
 
 
 def _windows(items: list[Any], size: int) -> Iterator[list[Any]]:
-    """Yield *items* in consecutive chunks of at most *size*.
-
-    Used by ``grep``/``agrep`` only when a ``max_count`` cap is in play: the
-    scan dispatches one chunk at a time so it can stop early, which bounds
-    wasted downloads past the cap to a single chunk rather than the whole
-    container. Chunking to the concurrency limit keeps every worker busy within
-    a chunk, and the barrier between chunks is the price of stopping early.
-
-    An uncapped scan has nothing to stop for, so it passes ``size ==
-    len(items)`` to get one chunk and keep the pool fully pipelined.
-    """
+    """Yield *items* in consecutive chunks of at most *size*."""
     for start in range(0, len(items), size):
         yield items[start : start + size]
 
@@ -1018,16 +998,10 @@ class AzureBlobBackend(BackendProtocol):
     def _delete_scope(self, normalized: str) -> tuple[str | None, str]:
         """Resolve *normalized* to the blob keys a recursive delete may touch.
 
-        Returns ``(exact_key, descendant_prefix)``. ``exact_key`` is the blob
-        stored at the path itself, or ``None`` for the root (which names no
-        blob of its own). ``descendant_prefix`` always carries a trailing
-        slash, which is what keeps the delete inside the intended subtree:
-        matching on ``"workspace/"`` selects ``/workspace/a.txt`` while
-        excluding the sibling ``/workspace-backup/a.txt`` that a bare
-        ``"workspace"`` prefix match would sweep up. Both are already confined
-        to the configured ``prefix`` namespace, since ``to_blob_key`` and
-        ``get_prefix_for_path`` prepend it and ``_validate_path`` has rejected
-        any ``..`` traversal.
+        Returns ``(exact_key, descendant_prefix)``. ``exact_key`` is ``None``
+        for the root, which names no blob of its own. ``descendant_prefix``
+        must keep its trailing slash -- that is what stops a delete of
+        ``/workspace`` from reaching ``/workspace-backup``.
         """
         descendant_prefix = get_prefix_for_path(self._prefix, normalized)
         if normalized == "/":
@@ -1204,10 +1178,8 @@ class AzureBlobBackend(BackendProtocol):
         blobs = await self._list_target_blobs_async(container, search_path)
         candidates = _grep_candidates(blobs, self._prefix, search_path, glob_matcher)
 
-        # Bounds in-flight downloads independently of the chunking below, which
-        # exists only to stop a capped scan early: an uncapped scan dispatches
-        # every candidate in one chunk and still must not open unbounded
-        # connections. The sync fork gets the same bound from its pool size.
+        # Concurrency bound must not come from the chunking below: an uncapped
+        # scan is a single chunk, so removing this opens unbounded connections.
         semaphore = asyncio.Semaphore(self._MAX_CONCURRENCY)
 
         async def scan(blob: Any) -> list[GrepMatch]:

--- a/libs/azure-storage/langchain_azure_storage/deepagents/backend.py
+++ b/libs/azure-storage/langchain_azure_storage/deepagents/backend.py
@@ -259,7 +259,7 @@ def _grep_candidates(
     return candidates
 
 
-def _delete_keys(
+def _keys_to_delete(
     blobs: list[Any], exact_key: str | None, descendant_prefix: str
 ) -> list[str]:
     """Select the blob keys a recursive delete of one path should remove.
@@ -915,7 +915,7 @@ class AzureBlobBackend(BackendProtocol):
         blobs = self._list_blobs_sync(
             container, exact_key if exact_key is not None else descendant_prefix
         )
-        keys = _delete_keys(blobs, exact_key, descendant_prefix)
+        keys = _keys_to_delete(blobs, exact_key, descendant_prefix)
         if not keys:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
@@ -966,7 +966,7 @@ class AzureBlobBackend(BackendProtocol):
         blobs = await self._list_blobs_async(
             container, exact_key if exact_key is not None else descendant_prefix
         )
-        keys = _delete_keys(blobs, exact_key, descendant_prefix)
+        keys = _keys_to_delete(blobs, exact_key, descendant_prefix)
         if not keys:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 

--- a/libs/azure-storage/langchain_azure_storage/deepagents/backend.py
+++ b/libs/azure-storage/langchain_azure_storage/deepagents/backend.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import logging
 import threading
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import PurePosixPath
 from typing import Any, Callable, Optional, Union
@@ -20,7 +21,6 @@ from azure.core.exceptions import (
     AzureError,
     ClientAuthenticationError,
     HttpResponseError,
-    ResourceExistsError,
     ResourceModifiedError,
     ResourceNotFoundError,
 )
@@ -32,6 +32,7 @@ from deepagents.backends.protocol import (
     INVALID_PATH,
     PERMISSION_DENIED,
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileDownloadResponse,
     FileInfo,
@@ -202,7 +203,9 @@ def _read_result_from_bytes(
 
     Returns raw (unformatted) content -- the Deep Agents middleware applies
     line numbering, the empty-file reminder, and base64 multimodal handling at
-    the tool boundary.
+    the tool boundary. For text content, ``slice_read_response`` also supplies
+    the pagination metadata (``total_lines``/``start_line``/``end_line``/
+    ``next_offset``) the middleware reports back to the model.
 
     Encoding is chosen the way the filesystem-like reference backends do it:
     files whose extension classifies as non-text (image/audio/video/file) are
@@ -217,12 +220,26 @@ def _read_result_from_bytes(
         except UnicodeDecodeError:
             pass
         else:
-            sliced = slice_read_response(
+            if limit <= 0:
+                # Workaround for a deepagents 0.7.0 bug: for a non-empty file,
+                # `slice_read_response(fd, offset, 0)` builds a zero-length
+                # window (`start_line=offset+1`, `end_line=offset`) that its own
+                # `ReadResult.__post_init__` then rejects with a ValueError. The
+                # `read_file` tool declares `limit` as a plain int with no lower
+                # bound, so a model can reach it. Return the empty window the
+                # caller asked for instead of raising.
+                #
+                # Tracked upstream at
+                # https://github.com/langchain-ai/deepagents/issues/5180.
+                # When removing this, note that the middleware runs
+                # `check_empty_content` on the read path, so returning empty
+                # content here makes it tell the model "File exists but has
+                # empty contents" for a file that is not empty -- re-check what
+                # the model actually sees once the upstream fix lands.
+                return ReadResult(file_data={"content": "", "encoding": "utf-8"})
+            return slice_read_response(
                 {"content": text, "encoding": "utf-8"}, offset, limit
             )
-            if isinstance(sliced, ReadResult):
-                return sliced
-            return ReadResult(file_data={"content": sliced, "encoding": "utf-8"})
 
     b64 = base64.b64encode(content_bytes).decode("ascii")
     return ReadResult(file_data={"content": b64, "encoding": "base64"})
@@ -258,6 +275,80 @@ def _grep_candidates(
             continue
         candidates.append(blob)
     return candidates
+
+
+def _delete_keys(
+    blobs: list[Any], exact_key: str | None, descendant_prefix: str
+) -> list[str]:
+    """Select the blob keys a recursive delete of one path should remove.
+
+    The listing that produced *blobs* is prefix-narrowed server-side for
+    efficiency, but a bare prefix also matches siblings that merely share a
+    name stem. This filter is what enforces the subtree boundary: a key
+    qualifies only by being the path's own blob or by sitting under its
+    slash-terminated prefix. See `AzureBlobBackend._delete_scope`.
+
+    Unlike `ls`, pseudo-directory marker blobs (keys ending in ``/``) are not
+    skipped: they are real blobs inside the subtree being removed, so a
+    recursive delete has to take them with it.
+    """
+    return [
+        blob.name
+        for blob in blobs
+        if (exact_key is not None and blob.name == exact_key)
+        or blob.name.startswith(descendant_prefix)
+    ]
+
+
+def _delete_failure_error(
+    file_path: str, failed_paths: list[str], attempted: int
+) -> str:
+    """Build the error for a recursive delete that could not remove everything.
+
+    Distinguishes a wholly failed delete from a partial one: retrying the
+    former is safe, while the latter has already changed the container and the
+    caller needs to know that.
+    """
+    failed_paths.sort()
+    sample = ", ".join(failed_paths[:3])
+    remainder = len(failed_paths) - min(len(failed_paths), 3)
+    suffix = f", and {remainder} more" if remainder else ""
+    if len(failed_paths) == attempted:
+        summary = f"failed on all {attempted} file(s)"
+    else:
+        removed = attempted - len(failed_paths)
+        summary = f"removed {removed} file(s) but failed on {len(failed_paths)}"
+    return f"Error: delete of '{file_path}' {summary}: {sample}{suffix}"
+
+
+def _normalize_max_count(max_count: int | None) -> int | None:
+    """Clamp a caller-supplied grep cap to a sane value.
+
+    ``max_count`` reaches the backend straight off the ``grep`` tool schema,
+    which declares no lower bound, so a model can send ``0`` or a negative
+    value. Left alone, a negative cap would be read as a slice-from-the-end and
+    silently drop matches. Clamping to ``0`` matches how the reference
+    backends' ``grep_matches_from_files`` treats the same input.
+    """
+    if max_count is None:
+        return None
+    return max(max_count, 0)
+
+
+def _windows(items: list[Any], size: int) -> Iterator[list[Any]]:
+    """Yield *items* in consecutive chunks of at most *size*.
+
+    Used by ``grep``/``agrep`` only when a ``max_count`` cap is in play: the
+    scan dispatches one chunk at a time so it can stop early, which bounds
+    wasted downloads past the cap to a single chunk rather than the whole
+    container. Chunking to the concurrency limit keeps every worker busy within
+    a chunk, and the barrier between chunks is the price of stopping early.
+
+    An uncapped scan has nothing to stop for, so it passes ``size ==
+    len(items)`` to get one chunk and keep the pool fully pipelined.
+    """
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
 
 
 def _grep_failure_result(failed_blobs: list[str]) -> GrepResult:
@@ -314,6 +405,13 @@ class AzureBlobBackend(BackendProtocol):
     layer. File content is stored in blob bodies (UTF-8 text, or raw bytes for
     binary uploads). Directories are synthesized on the fly from blob key
     prefixes (no directory marker blobs).
+
+    Two operations destroy data already in the container, both reachable as
+    agent tools: :meth:`write` replaces an existing file in full, and
+    :meth:`delete` removes a path plus everything nested under it. Deleting
+    ``"/"`` empties the configured ``prefix`` namespace -- or, with no
+    ``prefix``, the entire container. Set a ``prefix`` and enable container
+    soft-delete/versioning to bound the blast radius.
 
     The underlying Azure SDK clients are created lazily on first use and
     cached; call :meth:`close`/:meth:`aclose` (or use the backend as a
@@ -668,18 +766,18 @@ class AzureBlobBackend(BackendProtocol):
         )
 
     def write(self, file_path: str, content: str) -> WriteResult:
-        """Create a new file with the given content.
+        """Write content to a file, creating it or replacing it if it exists.
 
-        Fails if the file already exists; use ``edit``/``aedit`` to modify an
-        existing file.
+        An existing file is replaced in full. Use ``edit``/``aedit`` instead
+        when the existing content must be preserved.
 
         Args:
-            file_path: Virtual path for the new file.
+            file_path: Virtual path for the file.
             content: UTF-8 text content to write.
 
         Returns:
             A ``WriteResult`` with the path, or an error if the path is
-            invalid or the file exists.
+            invalid.
         """
         try:
             file_path = _validate_path(file_path)
@@ -687,28 +785,25 @@ class AzureBlobBackend(BackendProtocol):
             return WriteResult(error=str(exc))
 
         container = self._get_sync_container()
-        try:
-            container.get_blob_client(self._blob_key(file_path)).upload_blob(
-                content.encode("utf-8"),
-                overwrite=False,
-            )
-        except ResourceExistsError:
-            return WriteResult(error=_already_exists_error(file_path))
+        container.get_blob_client(self._blob_key(file_path)).upload_blob(
+            content.encode("utf-8"),
+            overwrite=True,
+        )
         return WriteResult(path=file_path)
 
     async def awrite(self, file_path: str, content: str) -> WriteResult:
-        """Create a new file with the given content.
+        """Write content to a file, creating it or replacing it if it exists.
 
-        Fails if the file already exists; use ``edit``/``aedit`` to modify an
-        existing file.
+        An existing file is replaced in full. Use ``edit``/``aedit`` instead
+        when the existing content must be preserved.
 
         Args:
-            file_path: Virtual path for the new file.
+            file_path: Virtual path for the file.
             content: UTF-8 text content to write.
 
         Returns:
             A ``WriteResult`` with the path, or an error if the path is
-            invalid or the file exists.
+            invalid.
         """
         try:
             file_path = _validate_path(file_path)
@@ -716,13 +811,10 @@ class AzureBlobBackend(BackendProtocol):
             return WriteResult(error=str(exc))
 
         container = await self._get_async_container()
-        try:
-            await container.get_blob_client(self._blob_key(file_path)).upload_blob(
-                content.encode("utf-8"),
-                overwrite=False,
-            )
-        except ResourceExistsError:
-            return WriteResult(error=_already_exists_error(file_path))
+        await container.get_blob_client(self._blob_key(file_path)).upload_blob(
+            content.encode("utf-8"),
+            overwrite=True,
+        )
         return WriteResult(path=file_path)
 
     def edit(
@@ -829,6 +921,133 @@ class AzureBlobBackend(BackendProtocol):
             return EditResult(error=_concurrent_modification_error(file_path))
         return EditResult(path=file_path, occurrences=int(occurrences))
 
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file, or a directory and everything nested under it.
+
+        Deletion is recursive: it removes the blob at *file_path* plus every
+        blob whose key starts with ``file_path + "/"``. Deleting ``"/"``
+        therefore removes every blob in the configured ``prefix`` namespace --
+        or, when no ``prefix`` is set, every blob in the container. Scope the
+        backend with ``prefix`` and enable container soft-delete/versioning if
+        an agent should not be able to do that.
+
+        Args:
+            file_path: Virtual path of the file or directory to delete.
+
+        Returns:
+            A ``DeleteResult`` with the path, or an error if the path is
+            invalid, nothing exists at or under it, or a blob could not be
+            deleted.
+        """
+        try:
+            file_path = _validate_path(file_path)
+        except _InvalidPath as exc:
+            return DeleteResult(error=str(exc))
+
+        container = self._get_sync_container()
+        exact_key, descendant_prefix = self._delete_scope(file_path)
+        blobs = self._list_blobs_sync(
+            container, exact_key if exact_key is not None else descendant_prefix
+        )
+        keys = _delete_keys(blobs, exact_key, descendant_prefix)
+        if not keys:
+            return DeleteResult(error=f"Error: File '{file_path}' not found")
+
+        def remove(key: str) -> str | None:
+            try:
+                container.get_blob_client(key).delete_blob()
+            except ResourceNotFoundError:
+                return None  # Raced with another deleter; treat as done.
+            except AzureError as exc:
+                logger.error("Failed to delete %s: %s", key, exc)
+                return from_blob_key(self._prefix, key)
+            return None
+
+        with ThreadPoolExecutor(max_workers=self._MAX_CONCURRENCY) as executor:
+            failed = [path for path in executor.map(remove, keys) if path is not None]
+
+        if failed:
+            return DeleteResult(
+                error=_delete_failure_error(file_path, failed, len(keys))
+            )
+        return DeleteResult(path=file_path)
+
+    async def adelete(self, file_path: str) -> DeleteResult:
+        """Delete a file, or a directory and everything nested under it.
+
+        Deletion is recursive: it removes the blob at *file_path* plus every
+        blob whose key starts with ``file_path + "/"``. Deleting ``"/"``
+        therefore removes every blob in the configured ``prefix`` namespace --
+        or, when no ``prefix`` is set, every blob in the container. Scope the
+        backend with ``prefix`` and enable container soft-delete/versioning if
+        an agent should not be able to do that.
+
+        Args:
+            file_path: Virtual path of the file or directory to delete.
+
+        Returns:
+            A ``DeleteResult`` with the path, or an error if the path is
+            invalid, nothing exists at or under it, or a blob could not be
+            deleted.
+        """
+        try:
+            file_path = _validate_path(file_path)
+        except _InvalidPath as exc:
+            return DeleteResult(error=str(exc))
+
+        container = await self._get_async_container()
+        exact_key, descendant_prefix = self._delete_scope(file_path)
+        blobs = await self._list_blobs_async(
+            container, exact_key if exact_key is not None else descendant_prefix
+        )
+        keys = _delete_keys(blobs, exact_key, descendant_prefix)
+        if not keys:
+            return DeleteResult(error=f"Error: File '{file_path}' not found")
+
+        semaphore = asyncio.Semaphore(self._MAX_CONCURRENCY)
+
+        async def remove(key: str) -> str | None:
+            async with semaphore:
+                try:
+                    await container.get_blob_client(key).delete_blob()
+                except ResourceNotFoundError:
+                    return None  # Raced with another deleter; treat as done.
+                except AzureError as exc:
+                    logger.error("Failed to delete %s: %s", key, exc)
+                    return from_blob_key(self._prefix, key)
+            return None
+
+        failed = [
+            path
+            for path in await asyncio.gather(*(remove(key) for key in keys))
+            if path is not None
+        ]
+
+        if failed:
+            return DeleteResult(
+                error=_delete_failure_error(file_path, failed, len(keys))
+            )
+        return DeleteResult(path=file_path)
+
+    def _delete_scope(self, normalized: str) -> tuple[str | None, str]:
+        """Resolve *normalized* to the blob keys a recursive delete may touch.
+
+        Returns ``(exact_key, descendant_prefix)``. ``exact_key`` is the blob
+        stored at the path itself, or ``None`` for the root (which names no
+        blob of its own). ``descendant_prefix`` always carries a trailing
+        slash, which is what keeps the delete inside the intended subtree:
+        matching on ``"workspace/"`` selects ``/workspace/a.txt`` while
+        excluding the sibling ``/workspace-backup/a.txt`` that a bare
+        ``"workspace"`` prefix match would sweep up. Both are already confined
+        to the configured ``prefix`` namespace, since ``to_blob_key`` and
+        ``get_prefix_for_path`` prepend it and ``_validate_path`` has rejected
+        any ``..`` traversal.
+        """
+        descendant_prefix = get_prefix_for_path(self._prefix, normalized)
+        if normalized == "/":
+            return None, descendant_prefix
+        return to_blob_key(self._prefix, normalized), descendant_prefix
+
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:
         """Find files matching a glob pattern.
 
@@ -888,7 +1107,12 @@ class AzureBlobBackend(BackendProtocol):
         return _glob_result(blobs, self._prefix, normalized_path, matcher)
 
     def grep(
-        self, pattern: str, path: str | None = None, glob: str | None = None
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
         """Search file contents for a literal substring.
 
@@ -900,6 +1124,11 @@ class AzureBlobBackend(BackendProtocol):
                 file names at any depth, a pattern with a slash is matched
                 against the path relative to *path*, and a leading ``/``
                 anchors to *path*.
+            max_count: Optional total cap on the number of matches returned
+                across all files. ``None`` (the default) returns every match.
+                When set, scanning stops once the cap is exceeded and the
+                result is flagged ``truncated=True``; exactly *max_count*
+                matches with none dropped is reported complete.
 
         Returns:
             A ``GrepResult`` whose ``matches`` holds matching lines, or whose
@@ -912,7 +1141,6 @@ class AzureBlobBackend(BackendProtocol):
         except (_InvalidPath, _InvalidGlob) as exc:
             return GrepResult(error=str(exc))
 
-        matches: list[GrepMatch] = []
         failed: list[str] = []
         container = self._get_sync_container()
         blobs = self._list_target_blobs_sync(container, search_path)
@@ -932,16 +1160,31 @@ class AzureBlobBackend(BackendProtocol):
                 return []
             return _grep_lines(content, pattern, virtual)
 
+        cap = _normalize_max_count(max_count)
+        # Only a capped scan needs to stop early, so only it pays for chunking.
+        window = self._MAX_CONCURRENCY if cap is not None else max(len(candidates), 1)
+        matches: list[GrepMatch] = []
+        truncated = False
         with ThreadPoolExecutor(max_workers=self._MAX_CONCURRENCY) as executor:
-            for blob_matches in executor.map(scan, candidates):
-                matches.extend(blob_matches)
+            for chunk in _windows(candidates, window):
+                for blob_matches in executor.map(scan, chunk):
+                    matches.extend(blob_matches)
+                if cap is not None and len(matches) > cap:
+                    del matches[cap:]
+                    truncated = True
+                    break
 
         if failed:
             return _grep_failure_result(failed)
-        return GrepResult(matches=matches)
+        return GrepResult(matches=matches, truncated=truncated)
 
     async def agrep(
-        self, pattern: str, path: str | None = None, glob: str | None = None
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        max_count: int | None = None,
     ) -> GrepResult:
         """Search file contents for a literal substring.
 
@@ -953,6 +1196,11 @@ class AzureBlobBackend(BackendProtocol):
                 file names at any depth, a pattern with a slash is matched
                 against the path relative to *path*, and a leading ``/``
                 anchors to *path*.
+            max_count: Optional total cap on the number of matches returned
+                across all files. ``None`` (the default) returns every match.
+                When set, scanning stops once the cap is exceeded and the
+                result is flagged ``truncated=True``; exactly *max_count*
+                matches with none dropped is reported complete.
 
         Returns:
             A ``GrepResult`` whose ``matches`` holds matching lines, or whose
@@ -965,11 +1213,15 @@ class AzureBlobBackend(BackendProtocol):
         except (_InvalidPath, _InvalidGlob) as exc:
             return GrepResult(error=str(exc))
 
-        matches: list[GrepMatch] = []
         failed: list[str] = []
         container = await self._get_async_container()
         blobs = await self._list_target_blobs_async(container, search_path)
         candidates = _grep_candidates(blobs, self._prefix, search_path, glob_matcher)
+
+        # Bounds in-flight downloads independently of the chunking below, which
+        # exists only to stop a capped scan early: an uncapped scan dispatches
+        # every candidate in one chunk and still must not open unbounded
+        # connections. The sync fork gets the same bound from its pool size.
         semaphore = asyncio.Semaphore(self._MAX_CONCURRENCY)
 
         async def scan(blob: Any) -> list[GrepMatch]:
@@ -988,12 +1240,22 @@ class AzureBlobBackend(BackendProtocol):
                     return []
             return _grep_lines(content, pattern, virtual)
 
-        for blob_matches in await asyncio.gather(*(scan(b) for b in candidates)):
-            matches.extend(blob_matches)
+        cap = _normalize_max_count(max_count)
+        # Only a capped scan needs to stop early, so only it pays for chunking.
+        window = self._MAX_CONCURRENCY if cap is not None else max(len(candidates), 1)
+        matches: list[GrepMatch] = []
+        truncated = False
+        for chunk in _windows(candidates, window):
+            for blob_matches in await asyncio.gather(*(scan(b) for b in chunk)):
+                matches.extend(blob_matches)
+            if cap is not None and len(matches) > cap:
+                del matches[cap:]
+                truncated = True
+                break
 
         if failed:
             return _grep_failure_result(failed)
-        return GrepResult(matches=matches)
+        return GrepResult(matches=matches, truncated=truncated)
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         """Upload one or more binary files, overwriting any that exist.
@@ -1169,13 +1431,6 @@ class AzureBlobBackend(BackendProtocol):
         return [
             blob async for blob in container.list_blobs(name_starts_with=prefix or None)
         ]
-
-
-def _already_exists_error(file_path: str) -> str:
-    return (
-        f"Cannot write to {file_path} because it already exists. "
-        f"Read and then make an edit, or write to a new path."
-    )
 
 
 def _concurrent_modification_error(file_path: str) -> str:

--- a/libs/azure-storage/langchain_azure_storage/deepagents/backend.py
+++ b/libs/azure-storage/langchain_azure_storage/deepagents/backend.py
@@ -205,7 +205,10 @@ def _read_result_from_bytes(
     line numbering, the empty-file reminder, and base64 multimodal handling at
     the tool boundary. For text content, ``slice_read_response`` also supplies
     the pagination metadata (``total_lines``/``start_line``/``end_line``/
-    ``next_offset``) the middleware reports back to the model.
+    ``next_offset``), clamps degenerate windows a model can ask for (negative
+    ``offset`` reads from line 1, non-positive ``limit`` yields an empty read
+    flagged ``no_lines_requested``), and the middleware reports all of that
+    back to the model.
 
     Encoding is chosen the way the filesystem-like reference backends do it:
     files whose extension classifies as non-text (image/audio/video/file) are
@@ -220,23 +223,6 @@ def _read_result_from_bytes(
         except UnicodeDecodeError:
             pass
         else:
-            if limit <= 0:
-                # Workaround for a deepagents 0.7.0 bug: for a non-empty file,
-                # `slice_read_response(fd, offset, 0)` builds a zero-length
-                # window (`start_line=offset+1`, `end_line=offset`) that its own
-                # `ReadResult.__post_init__` then rejects with a ValueError. The
-                # `read_file` tool declares `limit` as a plain int with no lower
-                # bound, so a model can reach it. Return the empty window the
-                # caller asked for instead of raising.
-                #
-                # Tracked upstream at
-                # https://github.com/langchain-ai/deepagents/issues/5180.
-                # When removing this, note that the middleware runs
-                # `check_empty_content` on the read path, so returning empty
-                # content here makes it tell the model "File exists but has
-                # empty contents" for a file that is not empty -- re-check what
-                # the model actually sees once the upstream fix lands.
-                return ReadResult(file_data={"content": "", "encoding": "utf-8"})
             return slice_read_response(
                 {"content": text, "encoding": "utf-8"}, offset, limit
             )

--- a/libs/azure-storage/pyproject.toml
+++ b/libs/azure-storage/pyproject.toml
@@ -37,12 +37,9 @@ dependencies = [
 # TODO(#815): drop the python_version marker when the package minimum moves to
 # 3.11 — revisit at Python 3.10 EOL (Oct 2026) or when langchain core drops 3.10.
 deepagents = [
-    # 0.7.1 is the floor, not 0.7.0: it fixes degenerate `read_file` windows
-    # (a non-positive `limit` raised a ValueError on 0.7.0). See
-    # https://github.com/langchain-ai/deepagents/issues/5180.
+    # 0.7.1, not 0.7.0: it fixes degenerate read windows (deepagents#5180).
     "deepagents>=0.7.1,<0.8; python_version>='3.11'",
-    # Kept in lockstep with deepagents' own wcmatch floor so our glob matching
-    # can't resolve to a version it no longer supports.
+    # Kept in lockstep with deepagents' own wcmatch floor.
     "wcmatch>=11.0; python_version>='3.11'",
 ]
 

--- a/libs/azure-storage/pyproject.toml
+++ b/libs/azure-storage/pyproject.toml
@@ -37,8 +37,10 @@ dependencies = [
 # TODO(#815): drop the python_version marker when the package minimum moves to
 # 3.11 — revisit at Python 3.10 EOL (Oct 2026) or when langchain core drops 3.10.
 deepagents = [
-    "deepagents>=0.6.12,<1; python_version>='3.11'",
-    "wcmatch>=10.1; python_version>='3.11'",
+    "deepagents>=0.7.0,<0.8; python_version>='3.11'",
+    # Kept in lockstep with deepagents' own wcmatch floor so our glob matching
+    # can't resolve to a version it no longer supports.
+    "wcmatch>=11.0; python_version>='3.11'",
 ]
 
 [project.urls]

--- a/libs/azure-storage/pyproject.toml
+++ b/libs/azure-storage/pyproject.toml
@@ -37,7 +37,10 @@ dependencies = [
 # TODO(#815): drop the python_version marker when the package minimum moves to
 # 3.11 — revisit at Python 3.10 EOL (Oct 2026) or when langchain core drops 3.10.
 deepagents = [
-    "deepagents>=0.7.0,<0.8; python_version>='3.11'",
+    # 0.7.1 is the floor, not 0.7.0: it fixes degenerate `read_file` windows
+    # (a non-positive `limit` raised a ValueError on 0.7.0). See
+    # https://github.com/langchain-ai/deepagents/issues/5180.
+    "deepagents>=0.7.1,<0.8; python_version>='3.11'",
     # Kept in lockstep with deepagents' own wcmatch floor so our glob matching
     # can't resolve to a version it no longer supports.
     "wcmatch>=11.0; python_version>='3.11'",

--- a/libs/azure-storage/tests/integration_tests/test_deepagents_backend.py
+++ b/libs/azure-storage/tests/integration_tests/test_deepagents_backend.py
@@ -31,24 +31,22 @@ if TYPE_CHECKING:
 
 
 class TestConcurrency:
-    async def test_concurrent_write_allows_only_one_success(
+    async def test_concurrent_writes_are_last_writer_wins(
         self, backend: AzureBlobBackend
     ) -> None:
-        # write() uses a conditional (If-None-Match: *) upload, so exactly one
-        # of two racing writers can create the blob.
+        # write() replaces unconditionally (deepagents 0.7.0 dropped the
+        # create-only contract), so racing writers both succeed. The guarantee
+        # left is that one of them wins outright -- never a torn blend of both.
         results = await asyncio.gather(
             backend.awrite("/race.txt", "first"),
             backend.awrite("/race.txt", "second"),
         )
 
-        succeeded = [result for result in results if result.error is None]
-        failed = [result for result in results if result.error is not None]
+        assert [result.error for result in results] == [None, None]
 
-        assert len(succeeded) == 1
-        assert len(failed) == 1
-        failure = failed[0].error
-        assert failure is not None
-        assert "already exists" in failure
+        final = await backend.aread("/race.txt")
+        assert final.file_data is not None
+        assert final.file_data["content"] in ("first", "second")
 
     async def test_concurrent_edits_never_lose_an_update(
         self, backend: AzureBlobBackend

--- a/libs/azure-storage/tests/integration_tests/test_deepagents_backend_contract.py
+++ b/libs/azure-storage/tests/integration_tests/test_deepagents_backend_contract.py
@@ -57,14 +57,27 @@ class TestWriteContract:
         assert read_back.file_data is not None
         assert read_back.file_data["content"] == content
 
-    def test_write_existing_file_fails(self, backend: AzureBlobBackend) -> None:
+    def test_write_existing_file_replaces_it(self, backend: AzureBlobBackend) -> None:
+        # deepagents 0.7.0 removed the create-only write contract; there is no
+        # compatibility mode, so an existing file is replaced in full.
         backend.write("/existing.txt", "First content")
         result = backend.write("/existing.txt", "Second content")
-        assert result.error is not None
-        assert "already exists" in result.error.lower()
+        assert result.error is None
+        assert result.path == "/existing.txt"
         read_back = backend.read("/existing.txt")
         assert read_back.file_data is not None
-        assert read_back.file_data["content"] == "First content"
+        assert read_back.file_data["content"] == "Second content"
+
+    def test_write_existing_file_truncates_longer_content(
+        self, backend: AzureBlobBackend
+    ) -> None:
+        # Replacement is a full overwrite, not a prefix write: no tail of the
+        # previous, longer content may survive.
+        backend.write("/truncate.txt", "aaaaaaaaaaaaaaaaaaaaaaaaa")
+        backend.write("/truncate.txt", "bbb")
+        read_back = backend.read("/truncate.txt")
+        assert read_back.file_data is not None
+        assert read_back.file_data["content"] == "bbb"
 
     def test_write_special_characters(self, backend: AzureBlobBackend) -> None:
         content = (
@@ -642,6 +655,97 @@ class TestGrepContract:
         assert result.matches == [
             {"path": "/grep_lines/long.txt", "line": 50, "text": "Line 50"}
         ]
+
+    def test_grep_max_count_caps_and_flags_truncation(
+        self, backend: AzureBlobBackend
+    ) -> None:
+        backend.write("/grep_cap/many.txt", "hit\n" * 20)
+        result = backend.grep("hit", path="/grep_cap", max_count=5)
+        assert result.error is None
+        assert result.matches is not None
+        assert len(result.matches) == 5
+        assert result.truncated is True
+
+    def test_grep_max_count_above_total_is_not_truncated(
+        self, backend: AzureBlobBackend
+    ) -> None:
+        backend.write("/grep_cap_high/few.txt", "hit\nhit\n")
+        result = backend.grep("hit", path="/grep_cap_high", max_count=100)
+        assert result.error is None
+        assert result.matches is not None
+        assert len(result.matches) == 2
+        assert result.truncated is False
+
+    async def test_agrep_max_count_caps_and_flags_truncation(
+        self, backend: AzureBlobBackend
+    ) -> None:
+        await backend.awrite("/agrep_cap/many.txt", "hit\n" * 20)
+        result = await backend.agrep("hit", path="/agrep_cap", max_count=5)
+        assert result.error is None
+        assert result.matches is not None
+        assert len(result.matches) == 5
+        assert result.truncated is True
+
+
+class TestDeleteContract:
+    async def test_delete_file(self, backend: AzureBlobBackend) -> None:
+        await backend.awrite("/del_one/f.txt", "content")
+        result = await backend.adelete("/del_one/f.txt")
+        assert result.error is None
+        assert result.path == "/del_one/f.txt"
+        read_back = await backend.aread("/del_one/f.txt")
+        assert read_back.error is not None
+        assert "not found" in read_back.error.lower()
+
+    async def test_delete_directory_is_recursive(
+        self, backend: AzureBlobBackend
+    ) -> None:
+        await backend.awrite("/del_dir/a.txt", "a")
+        await backend.awrite("/del_dir/nested/b.txt", "b")
+        await backend.awrite("/del_dir/nested/deep/c.txt", "c")
+        result = await backend.adelete("/del_dir")
+        assert result.error is None
+
+        remaining = await backend.als("/del_dir")
+        assert remaining.error is None
+        assert remaining.entries == []
+
+    async def test_delete_leaves_sibling_sharing_name_stem(
+        self, backend: AzureBlobBackend
+    ) -> None:
+        # "/del_sib/src" and "/del_sib/src-backup" share a key stem; a prefix
+        # match that ignored the "/" boundary would delete both.
+        await backend.awrite("/del_sib/src/keep.txt", "gone")
+        await backend.awrite("/del_sib/src-backup/keep.txt", "kept")
+        await backend.awrite("/del_sib/srcx.txt", "kept")
+
+        result = await backend.adelete("/del_sib/src")
+        assert result.error is None
+
+        assert (await backend.aread("/del_sib/src/keep.txt")).error is not None
+        survivor = await backend.aread("/del_sib/src-backup/keep.txt")
+        assert survivor.file_data is not None
+        assert survivor.file_data["content"] == "kept"
+        sibling_file = await backend.aread("/del_sib/srcx.txt")
+        assert sibling_file.file_data is not None
+        assert sibling_file.file_data["content"] == "kept"
+
+    async def test_delete_missing_path_errors(self, backend: AzureBlobBackend) -> None:
+        result = await backend.adelete("/del_missing/nope.txt")
+        assert result.error is not None
+        assert "not found" in result.error.lower()
+
+    async def test_delete_invalid_path_errors(self, backend: AzureBlobBackend) -> None:
+        result = await backend.adelete("/del_bad/../escape.txt")
+        assert result.error is not None
+        assert "invalid path" in result.error.lower()
+
+    def test_delete_sync(self, backend: AzureBlobBackend) -> None:
+        backend.write("/del_sync/f.txt", "content")
+        result = backend.delete("/del_sync/f.txt")
+        assert result.error is None
+        assert result.path == "/del_sync/f.txt"
+        assert backend.read("/del_sync/f.txt").error is not None
 
 
 class TestUploadDownloadContract:

--- a/libs/azure-storage/tests/integration_tests/test_deepagents_backend_contract.py
+++ b/libs/azure-storage/tests/integration_tests/test_deepagents_backend_contract.py
@@ -234,10 +234,22 @@ class TestReadContract:
         assert "Short line" in result.file_data["content"]
 
     def test_read_with_zero_limit(self, backend: AzureBlobBackend) -> None:
+        # A zero-line window is never inspected, so it must not error and must
+        # be distinguishable from a genuinely empty file (deepagents >= 0.7.1).
         backend.write("/zero_limit.txt", "Line 1\nLine 2\nLine 3")
         result = backend.read("/zero_limit.txt", offset=0, limit=0)
-        content = result.file_data["content"] if result.file_data else ""
-        assert "Line 1" not in content or content.strip() == ""
+        assert result.error is None
+        assert result.file_data is not None
+        assert result.file_data["content"] == ""
+        assert result.no_lines_requested is True
+
+    def test_read_with_negative_offset(self, backend: AzureBlobBackend) -> None:
+        backend.write("/neg_offset.txt", "Line 1\nLine 2\nLine 3")
+        result = backend.read("/neg_offset.txt", offset=-10, limit=2)
+        assert result.error is None
+        assert result.file_data is not None
+        assert result.file_data["content"] == "Line 1\nLine 2\n"
+        assert result.start_line == 1
 
     def test_read_offset_beyond_file_length(self, backend: AzureBlobBackend) -> None:
         backend.write("/offset_beyond.txt", "Line 1\nLine 2\nLine 3")

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_delete.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_delete.py
@@ -88,6 +88,24 @@ class TestADelete:
             ],
         )
 
+    async def test_delete_ignores_trailing_slash(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_async
+        container.list_blobs = async_list(
+            [make_blob("pfx/src", 5), make_blob("pfx/src/a.py", 5)]
+        )
+        blob = AsyncMock(spec=AsyncBlobClient)
+        container.get_blob_client.return_value = blob
+        result = await backend.adelete("/src/")
+        assert result.error is None
+        container.list_blobs.assert_called_once_with(name_starts_with="pfx/src")
+        _assert_deleted(container, blob, ["pfx/src", "pfx/src/a.py"])
+
     async def test_delete_does_not_touch_sibling_sharing_name_stem(
         self,
         backend: AzureBlobBackend,
@@ -268,6 +286,24 @@ class TestDelete:
                 "pfx/src/deep/b.py",
             ],
         )
+
+    def test_delete_ignores_trailing_slash(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_sync
+        container.list_blobs.return_value = [
+            make_blob("pfx/src", 5),
+            make_blob("pfx/src/a.py", 5),
+        ]
+        blob = MagicMock(spec=BlobClient)
+        container.get_blob_client.return_value = blob
+        result = backend.delete("/src/")
+        assert result.error is None
+        container.list_blobs.assert_called_once_with(name_starts_with="pfx/src")
+        _assert_deleted(container, blob, ["pfx/src", "pfx/src/a.py"])
 
     def test_delete_does_not_touch_sibling_sharing_name_stem(
         self,

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_delete.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_delete.py
@@ -1,0 +1,433 @@
+"""Unit tests for ``AzureBlobBackend.adelete()`` / ``delete()`` (mocked, no I/O).
+
+The async and sync methods are independent forks, so every case is covered
+against both. Fixtures live in the parent ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# The backend needs the optional [deepagents] extra (Python >= 3.11 only).
+pytest.importorskip("deepagents")
+
+from azure.core.exceptions import (  # noqa: E402
+    HttpResponseError,
+    ResourceNotFoundError,
+)
+from azure.storage.blob import BlobClient  # noqa: E402
+from azure.storage.blob.aio import BlobClient as AsyncBlobClient  # noqa: E402
+
+from langchain_azure_storage.deepagents import AzureBlobBackend  # noqa: E402
+
+# Every test constructs a backend, so silence the beta warning module-wide.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore::langchain_core._api.beta_decorator.LangChainBetaWarning"
+)
+
+
+def _assert_deleted(container: MagicMock, blob: Any, expected: list[str]) -> None:
+    """Assert exactly *expected* keys were resolved **and** actually deleted.
+
+    Checking the resolved keys alone would pass a backend that lists correctly
+    and then never calls ``delete_blob``, so the call count on the shared blob
+    mock is asserted too.
+    """
+    resolved = sorted(call.args[0] for call in container.get_blob_client.call_args_list)
+    assert resolved == sorted(expected)
+    assert blob.delete_blob.call_count == len(expected)
+
+
+class TestADelete:
+    async def test_delete_single_file(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_async
+        container.list_blobs = async_list([make_blob("pfx/f.txt", 5)])
+        blob = AsyncMock(spec=AsyncBlobClient)
+        container.get_blob_client.return_value = blob
+        result = await backend.adelete("/f.txt")
+        assert result.error is None
+        assert result.path == "/f.txt"
+        container.list_blobs.assert_called_once_with(name_starts_with="pfx/f.txt")
+        _assert_deleted(container, blob, ["pfx/f.txt"])
+
+    async def test_delete_directory_is_recursive(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_async
+        container.list_blobs = async_list(
+            [
+                make_blob("pfx/src", 5),
+                make_blob("pfx/src/a.py", 5),
+                make_blob("pfx/src/deep/b.py", 5),
+            ]
+        )
+        blob = AsyncMock(spec=AsyncBlobClient)
+        container.get_blob_client.return_value = blob
+        result = await backend.adelete("/src")
+        assert result.error is None
+        _assert_deleted(
+            container,
+            blob,
+            [
+                "pfx/src",
+                "pfx/src/a.py",
+                "pfx/src/deep/b.py",
+            ],
+        )
+
+    async def test_delete_does_not_touch_sibling_sharing_name_stem(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # The server-side listing prefix "pfx/src" also returns "pfx/src-backup".
+        # Only the exact key and keys under "pfx/src/" may be deleted.
+        _, container = patched_async
+        container.list_blobs = async_list(
+            [
+                make_blob("pfx/src/a.py", 5),
+                make_blob("pfx/src-backup/a.py", 5),
+                make_blob("pfx/srcx.py", 5),
+            ]
+        )
+        blob = AsyncMock(spec=AsyncBlobClient)
+        container.get_blob_client.return_value = blob
+        result = await backend.adelete("/src")
+        assert result.error is None
+        _assert_deleted(container, blob, ["pfx/src/a.py"])
+
+    async def test_delete_root_removes_only_prefix_namespace(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # Deleting "/" is a recursive wipe, but the configured prefix still
+        # bounds it: the listing is scoped to "pfx/" so blobs elsewhere in the
+        # container are never enumerated, let alone deleted.
+        _, container = patched_async
+        container.list_blobs = async_list(
+            [make_blob("pfx/a.txt", 5), make_blob("pfx/d/b.txt", 5)]
+        )
+        blob = AsyncMock(spec=AsyncBlobClient)
+        container.get_blob_client.return_value = blob
+        result = await backend.adelete("/")
+        assert result.error is None
+        assert result.path == "/"
+        container.list_blobs.assert_called_once_with(name_starts_with="pfx/")
+        _assert_deleted(container, blob, ["pfx/a.txt", "pfx/d/b.txt"])
+
+    async def test_delete_missing_path_returns_not_found(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+    ) -> None:
+        _, container = patched_async
+        container.list_blobs = async_list([])
+        result = await backend.adelete("/nope.txt")
+        assert result.error is not None
+        assert "not found" in result.error.lower()
+        container.get_blob_client.assert_not_called()
+
+    async def test_delete_invalid_path(self, backend: AzureBlobBackend) -> None:
+        result = await backend.adelete("/src/../bad.txt")
+        assert result.error is not None
+        assert "invalid path" in result.error.lower()
+
+    async def test_delete_tolerates_blob_removed_concurrently(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_async
+        container.list_blobs = async_list([make_blob("pfx/f.txt", 5)])
+        blob = AsyncMock(spec=AsyncBlobClient)
+        blob.delete_blob.side_effect = ResourceNotFoundError("gone")
+        container.get_blob_client.return_value = blob
+        result = await backend.adelete("/f.txt")
+        assert result.error is None
+        assert result.path == "/f.txt"
+
+    async def test_delete_reports_partial_failure(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_async
+        container.list_blobs = async_list(
+            [make_blob("pfx/d/a.txt", 5), make_blob("pfx/d/b.txt", 5)]
+        )
+
+        def _client(key: str) -> AsyncMock:
+            blob = AsyncMock(spec=AsyncBlobClient)
+            if key.endswith("b.txt"):
+                blob.delete_blob.side_effect = HttpResponseError("boom")
+            return blob
+
+        container.get_blob_client.side_effect = _client
+        result = await backend.adelete("/d")
+        assert result.error is not None
+        assert "removed 1 file(s) but failed on 1" in result.error
+        assert "/d/b.txt" in result.error
+
+    async def test_delete_reports_total_failure_distinctly(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # Nothing was removed, so the error must not imply a partial delete --
+        # retrying a wholly failed delete is safe, a half-done one is not.
+        _, container = patched_async
+        container.list_blobs = async_list([make_blob("pfx/d/a.txt", 5)])
+        blob = AsyncMock(spec=AsyncBlobClient)
+        blob.delete_blob.side_effect = HttpResponseError("boom")
+        container.get_blob_client.return_value = blob
+        result = await backend.adelete("/d")
+        assert result.error is not None
+        assert "failed on all 1 file(s)" in result.error
+        assert "removed" not in result.error
+
+    async def test_delete_removes_pseudo_directory_marker_blob(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # `ls` skips marker blobs (keys ending in "/"), but they are real blobs
+        # inside the subtree, so a recursive delete has to take them with it.
+        # This is the one place the two paths deliberately disagree.
+        _, container = patched_async
+        container.list_blobs = async_list(
+            [make_blob("pfx/src/", 0), make_blob("pfx/src/a.py", 5)]
+        )
+        blob = AsyncMock(spec=AsyncBlobClient)
+        container.get_blob_client.return_value = blob
+        result = await backend.adelete("/src")
+        assert result.error is None
+        _assert_deleted(container, blob, ["pfx/src/", "pfx/src/a.py"])
+
+
+class TestDelete:
+    def test_delete_single_file(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_sync
+        container.list_blobs.return_value = [make_blob("pfx/f.txt", 5)]
+        blob = MagicMock(spec=BlobClient)
+        container.get_blob_client.return_value = blob
+        result = backend.delete("/f.txt")
+        assert result.error is None
+        assert result.path == "/f.txt"
+        container.list_blobs.assert_called_once_with(name_starts_with="pfx/f.txt")
+        _assert_deleted(container, blob, ["pfx/f.txt"])
+
+    def test_delete_directory_is_recursive(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_sync
+        container.list_blobs.return_value = [
+            make_blob("pfx/src", 5),
+            make_blob("pfx/src/a.py", 5),
+            make_blob("pfx/src/deep/b.py", 5),
+        ]
+        blob = MagicMock(spec=BlobClient)
+        container.get_blob_client.return_value = blob
+        result = backend.delete("/src")
+        assert result.error is None
+        _assert_deleted(
+            container,
+            blob,
+            [
+                "pfx/src",
+                "pfx/src/a.py",
+                "pfx/src/deep/b.py",
+            ],
+        )
+
+    def test_delete_does_not_touch_sibling_sharing_name_stem(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # The server-side listing prefix "pfx/src" also returns "pfx/src-backup".
+        # Only the exact key and keys under "pfx/src/" may be deleted.
+        _, container = patched_sync
+        container.list_blobs.return_value = [
+            make_blob("pfx/src/a.py", 5),
+            make_blob("pfx/src-backup/a.py", 5),
+            make_blob("pfx/srcx.py", 5),
+        ]
+        blob = MagicMock(spec=BlobClient)
+        container.get_blob_client.return_value = blob
+        result = backend.delete("/src")
+        assert result.error is None
+        _assert_deleted(container, blob, ["pfx/src/a.py"])
+
+    def test_delete_root_removes_only_prefix_namespace(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # Deleting "/" is a recursive wipe, but the configured prefix still
+        # bounds it: the listing is scoped to "pfx/" so blobs elsewhere in the
+        # container are never enumerated, let alone deleted.
+        _, container = patched_sync
+        container.list_blobs.return_value = [
+            make_blob("pfx/a.txt", 5),
+            make_blob("pfx/d/b.txt", 5),
+        ]
+        blob = MagicMock(spec=BlobClient)
+        container.get_blob_client.return_value = blob
+        result = backend.delete("/")
+        assert result.error is None
+        assert result.path == "/"
+        container.list_blobs.assert_called_once_with(name_starts_with="pfx/")
+        _assert_deleted(container, blob, ["pfx/a.txt", "pfx/d/b.txt"])
+
+    def test_delete_missing_path_returns_not_found(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+    ) -> None:
+        _, container = patched_sync
+        container.list_blobs.return_value = []
+        result = backend.delete("/nope.txt")
+        assert result.error is not None
+        assert "not found" in result.error.lower()
+        container.get_blob_client.assert_not_called()
+
+    def test_delete_invalid_path(self, backend: AzureBlobBackend) -> None:
+        result = backend.delete("/src/../bad.txt")
+        assert result.error is not None
+        assert "invalid path" in result.error.lower()
+
+    def test_delete_tolerates_blob_removed_concurrently(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_sync
+        container.list_blobs.return_value = [make_blob("pfx/f.txt", 5)]
+        blob = MagicMock(spec=BlobClient)
+        blob.delete_blob.side_effect = ResourceNotFoundError("gone")
+        container.get_blob_client.return_value = blob
+        result = backend.delete("/f.txt")
+        assert result.error is None
+        assert result.path == "/f.txt"
+
+    def test_delete_reports_partial_failure(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_sync
+        container.list_blobs.return_value = [
+            make_blob("pfx/d/a.txt", 5),
+            make_blob("pfx/d/b.txt", 5),
+        ]
+
+        def _client(key: str) -> MagicMock:
+            blob = MagicMock(spec=BlobClient)
+            if key.endswith("b.txt"):
+                blob.delete_blob.side_effect = HttpResponseError("boom")
+            return blob
+
+        container.get_blob_client.side_effect = _client
+        result = backend.delete("/d")
+        assert result.error is not None
+        assert "removed 1 file(s) but failed on 1" in result.error
+        assert "/d/b.txt" in result.error
+
+    def test_delete_reports_total_failure_distinctly(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # Nothing was removed, so the error must not imply a partial delete --
+        # retrying a wholly failed delete is safe, a half-done one is not.
+        _, container = patched_sync
+        container.list_blobs.return_value = [make_blob("pfx/d/a.txt", 5)]
+        blob = MagicMock(spec=BlobClient)
+        blob.delete_blob.side_effect = HttpResponseError("boom")
+        container.get_blob_client.return_value = blob
+        result = backend.delete("/d")
+        assert result.error is not None
+        assert "failed on all 1 file(s)" in result.error
+        assert "removed" not in result.error
+
+    def test_delete_removes_pseudo_directory_marker_blob(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # `ls` skips marker blobs (keys ending in "/"), but they are real blobs
+        # inside the subtree, so a recursive delete has to take them with it.
+        # This is the one place the two paths deliberately disagree.
+        _, container = patched_sync
+        container.list_blobs.return_value = [
+            make_blob("pfx/src/", 0),
+            make_blob("pfx/src/a.py", 5),
+        ]
+        blob = MagicMock(spec=BlobClient)
+        container.get_blob_client.return_value = blob
+        result = backend.delete("/src")
+        assert result.error is None
+        _assert_deleted(container, blob, ["pfx/src/", "pfx/src/a.py"])
+
+
+class TestDeleteWithoutPrefix:
+    """A prefix-less backend deletes container-wide -- the documented footgun."""
+
+    def test_delete_root_without_prefix_lists_whole_container(
+        self,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        backend = AzureBlobBackend.from_connection_string(
+            "DefaultEndpointsProtocol=https;AccountName=fake;AccountKey=ZmFrZQ==;",
+            "test",
+        )
+        _, container = patched_sync
+        container.list_blobs.return_value = [make_blob("a.txt", 5)]
+        blob = MagicMock(spec=BlobClient)
+        container.get_blob_client.return_value = blob
+        result = backend.delete("/")
+        assert result.error is None
+        container.list_blobs.assert_called_once_with(name_starts_with=None)
+        _assert_deleted(container, blob, ["a.txt"])

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_delete.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_delete.py
@@ -118,9 +118,7 @@ class TestADelete:
         async_list: Callable[[list[Any]], MagicMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # Deleting "/" is a recursive wipe, but the configured prefix still
-        # bounds it: the listing is scoped to "pfx/" so blobs elsewhere in the
-        # container are never enumerated, let alone deleted.
+        # A root wipe is still bounded by the configured prefix.
         _, container = patched_async
         container.list_blobs = async_list(
             [make_blob("pfx/a.txt", 5), make_blob("pfx/d/b.txt", 5)]
@@ -198,8 +196,7 @@ class TestADelete:
         async_list: Callable[[list[Any]], MagicMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # Nothing was removed, so the error must not imply a partial delete --
-        # retrying a wholly failed delete is safe, a half-done one is not.
+        # Must not imply a partial delete: retrying a total failure is safe.
         _, container = patched_async
         container.list_blobs = async_list([make_blob("pfx/d/a.txt", 5)])
         blob = AsyncMock(spec=AsyncBlobClient)
@@ -217,9 +214,7 @@ class TestADelete:
         async_list: Callable[[list[Any]], MagicMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # `ls` skips marker blobs (keys ending in "/"), but they are real blobs
-        # inside the subtree, so a recursive delete has to take them with it.
-        # This is the one place the two paths deliberately disagree.
+        # Unlike `ls`, delete keeps marker blobs: they are in the subtree.
         _, container = patched_async
         container.list_blobs = async_list(
             [make_blob("pfx/src/", 0), make_blob("pfx/src/a.py", 5)]
@@ -300,9 +295,7 @@ class TestDelete:
         patched_sync: tuple[MagicMock, MagicMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # Deleting "/" is a recursive wipe, but the configured prefix still
-        # bounds it: the listing is scoped to "pfx/" so blobs elsewhere in the
-        # container are never enumerated, let alone deleted.
+        # A root wipe is still bounded by the configured prefix.
         _, container = patched_sync
         container.list_blobs.return_value = [
             make_blob("pfx/a.txt", 5),
@@ -378,8 +371,7 @@ class TestDelete:
         patched_sync: tuple[MagicMock, MagicMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # Nothing was removed, so the error must not imply a partial delete --
-        # retrying a wholly failed delete is safe, a half-done one is not.
+        # Must not imply a partial delete: retrying a total failure is safe.
         _, container = patched_sync
         container.list_blobs.return_value = [make_blob("pfx/d/a.txt", 5)]
         blob = MagicMock(spec=BlobClient)
@@ -396,9 +388,7 @@ class TestDelete:
         patched_sync: tuple[MagicMock, MagicMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # `ls` skips marker blobs (keys ending in "/"), but they are real blobs
-        # inside the subtree, so a recursive delete has to take them with it.
-        # This is the one place the two paths deliberately disagree.
+        # Unlike `ls`, delete keeps marker blobs: they are in the subtree.
         _, container = patched_sync
         container.list_blobs.return_value = [
             make_blob("pfx/src/", 0),

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_grep.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_grep.py
@@ -193,8 +193,7 @@ class TestAGrep:
         setup_async_grep: Callable[[MagicMock, list[Any], Any], None],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # Hitting the cap with nothing dropped is a complete result, so the
-        # model is not told to narrow a search that already returned everything.
+        # Cap reached with nothing dropped is complete, not truncated.
         _, container = patched_async
         setup_async_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\n")
         result = await backend.agrep("hit", max_count=2)
@@ -225,11 +224,7 @@ class TestAGrep:
         make_blob: Callable[..., MagicMock],
         max_count: int,
     ) -> None:
-        # `max_count` arrives straight off the grep tool schema, which sets no
-        # lower bound, so a model can send 0 or a negative. Left unclamped, a
-        # negative would be read as a slice-from-the-end and silently drop a
-        # match while reporting success. Clamping to 0 matches how the
-        # reference backends' `grep_matches_from_files` treats the same input.
+        # A negative cap must not slice from the end and drop a match.
         _, container = patched_async
         setup_async_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\nhit\n")
         result = await backend.agrep("hit", max_count=max_count)
@@ -245,9 +240,7 @@ class TestAGrep:
         make_async_download_blob: Callable[..., AsyncMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # An uncapped scan has nothing to stop for, so it dispatches every
-        # candidate in one chunk rather than paying for a barrier every
-        # `_MAX_CONCURRENCY` blobs. Concurrency stays bounded by the semaphore.
+        # Uncapped has nothing to stop for, so it must not pay for chunking.
         blobs = [make_blob(f"pfx/f{i}.py", 5) for i in range(100)]
         _, container = patched_async
         container.list_blobs = async_list(blobs)
@@ -266,10 +259,7 @@ class TestAGrep:
         make_async_download_blob: Callable[..., AsyncMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # The cap exists to bound egress, not just output: once it is exceeded
-        # the scan must stop fetching the remaining candidates. Candidates are
-        # dispatched in windows of `_MAX_CONCURRENCY`, so with far more blobs
-        # than that only the first window should be downloaded.
+        # The cap bounds egress, not just output: stop fetching past it.
         blobs = [make_blob(f"pfx/f{i}.py", 5) for i in range(100)]
         _, container = patched_async
         container.list_blobs = async_list(blobs)
@@ -416,8 +406,7 @@ class TestGrep:
         setup_sync_grep: Callable[[MagicMock, list[Any], Any], None],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # Hitting the cap with nothing dropped is a complete result, so the
-        # model is not told to narrow a search that already returned everything.
+        # Cap reached with nothing dropped is complete, not truncated.
         _, container = patched_sync
         setup_sync_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\n")
         result = backend.grep("hit", max_count=2)
@@ -448,11 +437,7 @@ class TestGrep:
         make_blob: Callable[..., MagicMock],
         max_count: int,
     ) -> None:
-        # `max_count` arrives straight off the grep tool schema, which sets no
-        # lower bound, so a model can send 0 or a negative. Left unclamped, a
-        # negative would be read as a slice-from-the-end and silently drop a
-        # match while reporting success. Clamping to 0 matches how the
-        # reference backends' `grep_matches_from_files` treats the same input.
+        # A negative cap must not slice from the end and drop a match.
         _, container = patched_sync
         setup_sync_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\nhit\n")
         result = backend.grep("hit", max_count=max_count)
@@ -467,9 +452,7 @@ class TestGrep:
         make_sync_download_blob: Callable[..., MagicMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # An uncapped scan has nothing to stop for, so it dispatches every
-        # candidate in one chunk rather than paying for a barrier every
-        # `_MAX_CONCURRENCY` blobs. Concurrency stays bounded by the pool size.
+        # Uncapped has nothing to stop for, so it must not pay for chunking.
         _, container = patched_sync
         container.list_blobs.return_value = [
             make_blob(f"pfx/f{i}.py", 5) for i in range(100)
@@ -488,10 +471,7 @@ class TestGrep:
         make_sync_download_blob: Callable[..., MagicMock],
         make_blob: Callable[..., MagicMock],
     ) -> None:
-        # The cap exists to bound egress, not just output: once it is exceeded
-        # the scan must stop fetching the remaining candidates. Candidates are
-        # dispatched in windows of `_MAX_CONCURRENCY`, so with far more blobs
-        # than that only the first window should be downloaded.
+        # The cap bounds egress, not just output: stop fetching past it.
         _, container = patched_sync
         container.list_blobs.return_value = [
             make_blob(f"pfx/f{i}.py", 5) for i in range(100)

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_grep.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_grep.py
@@ -171,6 +171,115 @@ class TestAGrep:
         assert result.error is not None
         assert "invalid path" in result.error.lower()
 
+    async def test_grep_max_count_truncates(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        setup_async_grep: Callable[[MagicMock, list[Any], Any], None],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_async
+        setup_async_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\nhit\n")
+        result = await backend.agrep("hit", max_count=2)
+        assert result.error is None
+        assert result.matches is not None
+        assert [m["line"] for m in result.matches] == [1, 2]
+        assert result.truncated is True
+
+    async def test_grep_max_count_exactly_reached_is_not_truncated(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        setup_async_grep: Callable[[MagicMock, list[Any], Any], None],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # Hitting the cap with nothing dropped is a complete result, so the
+        # model is not told to narrow a search that already returned everything.
+        _, container = patched_async
+        setup_async_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\n")
+        result = await backend.agrep("hit", max_count=2)
+        assert result.matches is not None
+        assert len(result.matches) == 2
+        assert result.truncated is False
+
+    async def test_grep_without_max_count_is_uncapped(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        setup_async_grep: Callable[[MagicMock, list[Any], Any], None],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_async
+        setup_async_grep(container, [make_blob("pfx/f.py", 5)], "hit\n" * 50)
+        result = await backend.agrep("hit")
+        assert result.matches is not None
+        assert len(result.matches) == 50
+        assert result.truncated is False
+
+    @pytest.mark.parametrize("max_count", [0, -1])
+    async def test_grep_non_positive_max_count_returns_no_matches(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        setup_async_grep: Callable[[MagicMock, list[Any], Any], None],
+        make_blob: Callable[..., MagicMock],
+        max_count: int,
+    ) -> None:
+        # `max_count` arrives straight off the grep tool schema, which sets no
+        # lower bound, so a model can send 0 or a negative. Left unclamped, a
+        # negative would be read as a slice-from-the-end and silently drop a
+        # match while reporting success. Clamping to 0 matches how the
+        # reference backends' `grep_matches_from_files` treats the same input.
+        _, container = patched_async
+        setup_async_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\nhit\n")
+        result = await backend.agrep("hit", max_count=max_count)
+        assert result.error is None
+        assert result.matches == []
+        assert result.truncated is True
+
+    async def test_grep_uncapped_scans_every_candidate(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_async_download_blob: Callable[..., AsyncMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # An uncapped scan has nothing to stop for, so it dispatches every
+        # candidate in one chunk rather than paying for a barrier every
+        # `_MAX_CONCURRENCY` blobs. Concurrency stays bounded by the semaphore.
+        blobs = [make_blob(f"pfx/f{i}.py", 5) for i in range(100)]
+        _, container = patched_async
+        container.list_blobs = async_list(blobs)
+        container.get_blob_client.return_value = make_async_download_blob("hit\n")
+        result = await backend.agrep("hit")
+        assert result.truncated is False
+        assert result.matches is not None
+        assert len(result.matches) == 100
+        assert container.get_blob_client.call_count == 100
+
+    async def test_grep_max_count_stops_downloading_further_blobs(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        async_list: Callable[[list[Any]], MagicMock],
+        make_async_download_blob: Callable[..., AsyncMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # The cap exists to bound egress, not just output: once it is exceeded
+        # the scan must stop fetching the remaining candidates. Candidates are
+        # dispatched in windows of `_MAX_CONCURRENCY`, so with far more blobs
+        # than that only the first window should be downloaded.
+        blobs = [make_blob(f"pfx/f{i}.py", 5) for i in range(100)]
+        _, container = patched_async
+        container.list_blobs = async_list(blobs)
+        container.get_blob_client.return_value = make_async_download_blob("hit\n")
+        result = await backend.agrep("hit", max_count=1)
+        assert result.truncated is True
+        assert result.matches is not None
+        assert len(result.matches) == 1
+        assert container.get_blob_client.call_count == backend._MAX_CONCURRENCY
+
 
 class TestGrep:
     def test_grep_finds_matches(
@@ -284,3 +393,112 @@ class TestGrep:
         result = backend.grep("x", path="/src/../bad")
         assert result.error is not None
         assert "invalid path" in result.error.lower()
+
+    def test_grep_max_count_truncates(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        setup_sync_grep: Callable[[MagicMock, list[Any], Any], None],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_sync
+        setup_sync_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\nhit\n")
+        result = backend.grep("hit", max_count=2)
+        assert result.error is None
+        assert result.matches is not None
+        assert [m["line"] for m in result.matches] == [1, 2]
+        assert result.truncated is True
+
+    def test_grep_max_count_exactly_reached_is_not_truncated(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        setup_sync_grep: Callable[[MagicMock, list[Any], Any], None],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # Hitting the cap with nothing dropped is a complete result, so the
+        # model is not told to narrow a search that already returned everything.
+        _, container = patched_sync
+        setup_sync_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\n")
+        result = backend.grep("hit", max_count=2)
+        assert result.matches is not None
+        assert len(result.matches) == 2
+        assert result.truncated is False
+
+    def test_grep_without_max_count_is_uncapped(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        setup_sync_grep: Callable[[MagicMock, list[Any], Any], None],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        _, container = patched_sync
+        setup_sync_grep(container, [make_blob("pfx/f.py", 5)], "hit\n" * 50)
+        result = backend.grep("hit")
+        assert result.matches is not None
+        assert len(result.matches) == 50
+        assert result.truncated is False
+
+    @pytest.mark.parametrize("max_count", [0, -1])
+    def test_grep_non_positive_max_count_returns_no_matches(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        setup_sync_grep: Callable[[MagicMock, list[Any], Any], None],
+        make_blob: Callable[..., MagicMock],
+        max_count: int,
+    ) -> None:
+        # `max_count` arrives straight off the grep tool schema, which sets no
+        # lower bound, so a model can send 0 or a negative. Left unclamped, a
+        # negative would be read as a slice-from-the-end and silently drop a
+        # match while reporting success. Clamping to 0 matches how the
+        # reference backends' `grep_matches_from_files` treats the same input.
+        _, container = patched_sync
+        setup_sync_grep(container, [make_blob("pfx/f.py", 5)], "hit\nhit\nhit\n")
+        result = backend.grep("hit", max_count=max_count)
+        assert result.error is None
+        assert result.matches == []
+        assert result.truncated is True
+
+    def test_grep_uncapped_scans_every_candidate(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_sync_download_blob: Callable[..., MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # An uncapped scan has nothing to stop for, so it dispatches every
+        # candidate in one chunk rather than paying for a barrier every
+        # `_MAX_CONCURRENCY` blobs. Concurrency stays bounded by the pool size.
+        _, container = patched_sync
+        container.list_blobs.return_value = [
+            make_blob(f"pfx/f{i}.py", 5) for i in range(100)
+        ]
+        container.get_blob_client.return_value = make_sync_download_blob("hit\n")
+        result = backend.grep("hit")
+        assert result.truncated is False
+        assert result.matches is not None
+        assert len(result.matches) == 100
+        assert container.get_blob_client.call_count == 100
+
+    def test_grep_max_count_stops_downloading_further_blobs(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_sync_download_blob: Callable[..., MagicMock],
+        make_blob: Callable[..., MagicMock],
+    ) -> None:
+        # The cap exists to bound egress, not just output: once it is exceeded
+        # the scan must stop fetching the remaining candidates. Candidates are
+        # dispatched in windows of `_MAX_CONCURRENCY`, so with far more blobs
+        # than that only the first window should be downloaded.
+        _, container = patched_sync
+        container.list_blobs.return_value = [
+            make_blob(f"pfx/f{i}.py", 5) for i in range(100)
+        ]
+        container.get_blob_client.return_value = make_sync_download_blob("hit\n")
+        result = backend.grep("hit", max_count=1)
+        assert result.truncated is True
+        assert result.matches is not None
+        assert len(result.matches) == 1
+        assert container.get_blob_client.call_count == backend._MAX_CONCURRENCY

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_read.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_read.py
@@ -60,8 +60,6 @@ class TestARead:
         result = await backend.aread("/f.txt", offset=1, limit=2)
         assert result.file_data is not None
         assert result.file_data["content"] == "l2\nl3\n"
-        # deepagents 0.7.0 pagination metadata, supplied by slice_read_response
-        # and reported back to the model by the middleware.
         assert (result.start_line, result.end_line) == (2, 3)
         assert result.total_lines == 5
         assert result.next_offset == 3
@@ -74,10 +72,7 @@ class TestARead:
         make_async_download_blob: Callable[..., AsyncMock],
         limit: int,
     ) -> None:
-        # Degenerate windows are reachable from the model: the read_file tool
-        # declares no bounds on offset/limit. deepagents >= 0.7.1 clamps them in
-        # slice_read_response and flags the never-inspected window, so the
-        # middleware can tell it apart from a genuinely empty file.
+        # An uninspected window must be distinguishable from an empty file.
         _, container = patched_async
         container.get_blob_client.return_value = make_async_download_blob("l1\nl2\n")
         result = await backend.aread("/f.txt", limit=limit)
@@ -85,7 +80,6 @@ class TestARead:
         assert result.file_data is not None
         assert result.file_data["content"] == ""
         assert result.no_lines_requested is True
-        # An uninspected window carries no pagination metadata.
         assert (result.start_line, result.end_line) == (None, None)
         assert (result.total_lines, result.next_offset) == (None, None)
 
@@ -224,8 +218,6 @@ class TestRead:
         result = backend.read("/f.txt", offset=1, limit=2)
         assert result.file_data is not None
         assert result.file_data["content"] == "l2\nl3\n"
-        # deepagents 0.7.0 pagination metadata, supplied by slice_read_response
-        # and reported back to the model by the middleware.
         assert (result.start_line, result.end_line) == (2, 3)
         assert result.total_lines == 5
         assert result.next_offset == 3
@@ -238,10 +230,7 @@ class TestRead:
         make_sync_download_blob: Callable[..., MagicMock],
         limit: int,
     ) -> None:
-        # Degenerate windows are reachable from the model: the read_file tool
-        # declares no bounds on offset/limit. deepagents >= 0.7.1 clamps them in
-        # slice_read_response and flags the never-inspected window, so the
-        # middleware can tell it apart from a genuinely empty file.
+        # An uninspected window must be distinguishable from an empty file.
         _, container = patched_sync
         container.get_blob_client.return_value = make_sync_download_blob("l1\nl2\n")
         result = backend.read("/f.txt", limit=limit)
@@ -249,7 +238,6 @@ class TestRead:
         assert result.file_data is not None
         assert result.file_data["content"] == ""
         assert result.no_lines_requested is True
-        # An uninspected window carries no pagination metadata.
         assert (result.start_line, result.end_line) == (None, None)
         assert (result.total_lines, result.next_offset) == (None, None)
 

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_read.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_read.py
@@ -60,6 +60,27 @@ class TestARead:
         result = await backend.aread("/f.txt", offset=1, limit=2)
         assert result.file_data is not None
         assert result.file_data["content"] == "l2\nl3\n"
+        # deepagents 0.7.0 pagination metadata, supplied by slice_read_response
+        # and reported back to the model by the middleware.
+        assert (result.start_line, result.end_line) == (2, 3)
+        assert result.total_lines == 5
+        assert result.next_offset == 3
+
+    async def test_read_with_zero_limit_returns_empty_window(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        make_async_download_blob: Callable[..., AsyncMock],
+    ) -> None:
+        # `limit=0` is reachable from the model (the read_file tool declares no
+        # lower bound) and makes deepagents 0.7.0's slice_read_response build a
+        # window its own ReadResult validation rejects. Ours returns empty.
+        _, container = patched_async
+        container.get_blob_client.return_value = make_async_download_blob("l1\nl2\n")
+        result = await backend.aread("/f.txt", limit=0)
+        assert result.error is None
+        assert result.file_data is not None
+        assert result.file_data["content"] == ""
 
     async def test_read_offset_out_of_range(
         self,
@@ -182,6 +203,27 @@ class TestRead:
         result = backend.read("/f.txt", offset=1, limit=2)
         assert result.file_data is not None
         assert result.file_data["content"] == "l2\nl3\n"
+        # deepagents 0.7.0 pagination metadata, supplied by slice_read_response
+        # and reported back to the model by the middleware.
+        assert (result.start_line, result.end_line) == (2, 3)
+        assert result.total_lines == 5
+        assert result.next_offset == 3
+
+    def test_read_with_zero_limit_returns_empty_window(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_sync_download_blob: Callable[..., MagicMock],
+    ) -> None:
+        # `limit=0` is reachable from the model (the read_file tool declares no
+        # lower bound) and makes deepagents 0.7.0's slice_read_response build a
+        # window its own ReadResult validation rejects. Ours returns empty.
+        _, container = patched_sync
+        container.get_blob_client.return_value = make_sync_download_blob("l1\nl2\n")
+        result = backend.read("/f.txt", limit=0)
+        assert result.error is None
+        assert result.file_data is not None
+        assert result.file_data["content"] == ""
 
     def test_read_offset_out_of_range(
         self,

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_read.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_read.py
@@ -66,21 +66,42 @@ class TestARead:
         assert result.total_lines == 5
         assert result.next_offset == 3
 
-    async def test_read_with_zero_limit_returns_empty_window(
+    @pytest.mark.parametrize("limit", [0, -3])
+    async def test_read_with_non_positive_limit_returns_empty_window(
+        self,
+        backend: AzureBlobBackend,
+        patched_async: tuple[MagicMock, MagicMock],
+        make_async_download_blob: Callable[..., AsyncMock],
+        limit: int,
+    ) -> None:
+        # Degenerate windows are reachable from the model: the read_file tool
+        # declares no bounds on offset/limit. deepagents >= 0.7.1 clamps them in
+        # slice_read_response and flags the never-inspected window, so the
+        # middleware can tell it apart from a genuinely empty file.
+        _, container = patched_async
+        container.get_blob_client.return_value = make_async_download_blob("l1\nl2\n")
+        result = await backend.aread("/f.txt", limit=limit)
+        assert result.error is None
+        assert result.file_data is not None
+        assert result.file_data["content"] == ""
+        assert result.no_lines_requested is True
+        # An uninspected window carries no pagination metadata.
+        assert (result.start_line, result.end_line) == (None, None)
+        assert (result.total_lines, result.next_offset) == (None, None)
+
+    async def test_read_with_negative_offset_reads_from_first_line(
         self,
         backend: AzureBlobBackend,
         patched_async: tuple[MagicMock, MagicMock],
         make_async_download_blob: Callable[..., AsyncMock],
     ) -> None:
-        # `limit=0` is reachable from the model (the read_file tool declares no
-        # lower bound) and makes deepagents 0.7.0's slice_read_response build a
-        # window its own ReadResult validation rejects. Ours returns empty.
         _, container = patched_async
         container.get_blob_client.return_value = make_async_download_blob("l1\nl2\n")
-        result = await backend.aread("/f.txt", limit=0)
+        result = await backend.aread("/f.txt", offset=-5, limit=1)
         assert result.error is None
         assert result.file_data is not None
-        assert result.file_data["content"] == ""
+        assert result.file_data["content"] == "l1\n"
+        assert result.start_line == 1
 
     async def test_read_offset_out_of_range(
         self,
@@ -209,21 +230,42 @@ class TestRead:
         assert result.total_lines == 5
         assert result.next_offset == 3
 
-    def test_read_with_zero_limit_returns_empty_window(
+    @pytest.mark.parametrize("limit", [0, -3])
+    def test_read_with_non_positive_limit_returns_empty_window(
+        self,
+        backend: AzureBlobBackend,
+        patched_sync: tuple[MagicMock, MagicMock],
+        make_sync_download_blob: Callable[..., MagicMock],
+        limit: int,
+    ) -> None:
+        # Degenerate windows are reachable from the model: the read_file tool
+        # declares no bounds on offset/limit. deepagents >= 0.7.1 clamps them in
+        # slice_read_response and flags the never-inspected window, so the
+        # middleware can tell it apart from a genuinely empty file.
+        _, container = patched_sync
+        container.get_blob_client.return_value = make_sync_download_blob("l1\nl2\n")
+        result = backend.read("/f.txt", limit=limit)
+        assert result.error is None
+        assert result.file_data is not None
+        assert result.file_data["content"] == ""
+        assert result.no_lines_requested is True
+        # An uninspected window carries no pagination metadata.
+        assert (result.start_line, result.end_line) == (None, None)
+        assert (result.total_lines, result.next_offset) == (None, None)
+
+    def test_read_with_negative_offset_reads_from_first_line(
         self,
         backend: AzureBlobBackend,
         patched_sync: tuple[MagicMock, MagicMock],
         make_sync_download_blob: Callable[..., MagicMock],
     ) -> None:
-        # `limit=0` is reachable from the model (the read_file tool declares no
-        # lower bound) and makes deepagents 0.7.0's slice_read_response build a
-        # window its own ReadResult validation rejects. Ours returns empty.
         _, container = patched_sync
         container.get_blob_client.return_value = make_sync_download_blob("l1\nl2\n")
-        result = backend.read("/f.txt", limit=0)
+        result = backend.read("/f.txt", offset=-5, limit=1)
         assert result.error is None
         assert result.file_data is not None
-        assert result.file_data["content"] == ""
+        assert result.file_data["content"] == "l1\n"
+        assert result.start_line == 1
 
     def test_read_offset_out_of_range(
         self,

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_write.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_write.py
@@ -13,7 +13,6 @@ import pytest
 # The backend needs the optional [deepagents] extra (Python >= 3.11 only).
 pytest.importorskip("deepagents")
 
-from azure.core.exceptions import ResourceExistsError  # noqa: E402
 from azure.storage.blob import BlobClient  # noqa: E402
 from azure.storage.blob.aio import BlobClient as AsyncBlobClient  # noqa: E402
 
@@ -37,22 +36,24 @@ class TestAWrite:
         result = await backend.awrite("/new.txt", "hello")
         assert result.error is None
         assert result.path == "/new.txt"
-        # Path-to-blob-key resolution and the create-only upload condition.
+        # Path-to-blob-key resolution and the create-or-replace upload condition.
         container.get_blob_client.assert_called_once_with("pfx/new.txt")
-        blob.upload_blob.assert_called_once_with(b"hello", overwrite=False)
+        blob.upload_blob.assert_called_once_with(b"hello", overwrite=True)
 
-    async def test_write_existing_file_fails(
+    async def test_write_existing_file_overwrites(
         self,
         backend: AzureBlobBackend,
         patched_async: tuple[MagicMock, MagicMock],
     ) -> None:
+        # deepagents 0.7.0 removed the create-only write contract: `write_file`
+        # replaces an existing file rather than returning a file-exists error.
         _, container = patched_async
         blob = AsyncMock(spec=AsyncBlobClient)
-        blob.upload_blob.side_effect = ResourceExistsError("exists")
         container.get_blob_client.return_value = blob
-        result = await backend.awrite("/exists.txt", "hello")
-        assert result.error is not None
-        assert "already exists" in result.error
+        result = await backend.awrite("/exists.txt", "replacement")
+        assert result.error is None
+        assert result.path == "/exists.txt"
+        blob.upload_blob.assert_called_once_with(b"replacement", overwrite=True)
 
     async def test_write_invalid_path(self, backend: AzureBlobBackend) -> None:
         result = await backend.awrite("/src/../bad.txt", "x")
@@ -72,22 +73,24 @@ class TestWrite:
         result = backend.write("/new.txt", "hello")
         assert result.error is None
         assert result.path == "/new.txt"
-        # Path-to-blob-key resolution and the create-only upload condition.
+        # Path-to-blob-key resolution and the create-or-replace upload condition.
         container.get_blob_client.assert_called_once_with("pfx/new.txt")
-        blob.upload_blob.assert_called_once_with(b"hello", overwrite=False)
+        blob.upload_blob.assert_called_once_with(b"hello", overwrite=True)
 
-    def test_write_existing_file_fails(
+    def test_write_existing_file_overwrites(
         self,
         backend: AzureBlobBackend,
         patched_sync: tuple[MagicMock, MagicMock],
     ) -> None:
+        # deepagents 0.7.0 removed the create-only write contract: `write_file`
+        # replaces an existing file rather than returning a file-exists error.
         _, container = patched_sync
         blob = MagicMock(spec=BlobClient)
-        blob.upload_blob.side_effect = ResourceExistsError("exists")
         container.get_blob_client.return_value = blob
-        result = backend.write("/exists.txt", "x")
-        assert result.error is not None
-        assert "already exists" in result.error
+        result = backend.write("/exists.txt", "replacement")
+        assert result.error is None
+        assert result.path == "/exists.txt"
+        blob.upload_blob.assert_called_once_with(b"replacement", overwrite=True)
 
     def test_write_invalid_path(self, backend: AzureBlobBackend) -> None:
         result = backend.write("/src/../bad.txt", "x")

--- a/libs/azure-storage/tests/unit_tests/deepagents/backend/test_write.py
+++ b/libs/azure-storage/tests/unit_tests/deepagents/backend/test_write.py
@@ -45,8 +45,7 @@ class TestAWrite:
         backend: AzureBlobBackend,
         patched_async: tuple[MagicMock, MagicMock],
     ) -> None:
-        # deepagents 0.7.0 removed the create-only write contract: `write_file`
-        # replaces an existing file rather than returning a file-exists error.
+        # 0.7.0 removed the create-only contract; write replaces.
         _, container = patched_async
         blob = AsyncMock(spec=AsyncBlobClient)
         container.get_blob_client.return_value = blob
@@ -82,8 +81,7 @@ class TestWrite:
         backend: AzureBlobBackend,
         patched_sync: tuple[MagicMock, MagicMock],
     ) -> None:
-        # deepagents 0.7.0 removed the create-only write contract: `write_file`
-        # replaces an existing file rather than returning a file-exists error.
+        # 0.7.0 removed the create-only contract; write replaces.
         _, container = patched_sync
         blob = MagicMock(spec=BlobClient)
         container.get_blob_client.return_value = blob

--- a/libs/azure-storage/uv.lock
+++ b/libs/azure-storage/uv.lock
@@ -608,7 +608,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.7.0"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -616,11 +616,12 @@ dependencies = [
     { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" } },
     { name = "langchain-google-genai" },
     { name = "langsmith", version = "0.10.12", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/6b/f61d30d45e25e8dc720b4928da029162329e8f22173bbbe190083e19a75e/deepagents-0.7.0.tar.gz", hash = "sha256:36c49bced5de9ef0deb1e9c05a449adf931706e25ba5f99449d7436eccbc694b", size = 263583, upload-time = "2026-07-29T16:27:29.241Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/e3/00c98c6b677ba89270b09dcb950848c794d507168b3dc53fa4d5cfb6a2e3/deepagents-0.7.1.tar.gz", hash = "sha256:a556a8af8dac84ee5708d7e97752eda40d613d19e25cc79b7d0e8c728da03c40", size = 270546, upload-time = "2026-07-30T20:34:26.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/0a/ee3a0518a90bae0ee3f48e23061fe185804d0d3476cb75f21ab834f4698c/deepagents-0.7.0-py3-none-any.whl", hash = "sha256:c0ceb3c12f44638cdb81ea95652d6d6fa8ec76a2372ae8016aa2dd9a493762b1", size = 289723, upload-time = "2026-07-29T16:27:28.178Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/3306ab2f544e08ea33852f92d0fb3ab8fbf437c84e5f58189f0e4f895087/deepagents-0.7.1-py3-none-any.whl", hash = "sha256:cbcfb856e95ecc8a969b9d036b1d6b760524ca9a5b83f00e53ae568ddebfd343", size = 297359, upload-time = "2026-07-30T20:34:24.846Z" },
 ]
 
 [[package]]
@@ -1084,7 +1085,7 @@ requires-dist = [
     { name = "azure-core", specifier = ">=1.38.0" },
     { name = "azure-identity", specifier = "~=1.25" },
     { name = "azure-storage-blob", extras = ["aio"], specifier = "~=12.26" },
-    { name = "deepagents", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=0.7.0,<0.8" },
+    { name = "deepagents", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=0.7.1,<0.8" },
     { name = "langchain-core", specifier = ">=1.2.5,<2.0" },
     { name = "wcmatch", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=11.0" },
 ]

--- a/libs/azure-storage/uv.lock
+++ b/libs/azure-storage/uv.lock
@@ -185,21 +185,21 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.112.0"
+version = "0.120.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.11'" },
-    { name = "distro", marker = "python_full_version >= '3.11'" },
-    { name = "docstring-parser", marker = "python_full_version >= '3.11'" },
-    { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "jiter", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "sniffio", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/dd/808c144d4a883fcfd12fe0d7689b1d86bbbea6666c1cc957ad19f1017c22/anthropic-0.112.0.tar.gz", hash = "sha256:e180cd91aa5b9b32e4007fe69892ab128d8a86b9f90825103b1903fbc977d0af", size = 937460, upload-time = "2026-06-24T18:45:56.844Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/10/4ca013cb166f226bd89e0aeb0fcaff94f45ddf716d4925ce89475d3c587b/anthropic-0.120.2.tar.gz", hash = "sha256:9722efc10c27a30a69f5338ddacdb35bc6a64297a4e4ba729bf83af873d5fb3a", size = 1008421, upload-time = "2026-07-28T17:38:26.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/26/ea71185027956325be1903d4fcaf7461d5ef40ca8f0e64f992e24ea9db0e/anthropic-0.112.0-py3-none-any.whl", hash = "sha256:bcc6268612c716dbb77133dd60fc41d26016d1b81dee9a52314d210193638751", size = 931954, upload-time = "2026-06-24T18:45:58.205Z" },
+    { url = "https://files.pythonhosted.org/packages/63/af/0f5db57b9397a0f3b7fc204cbef143401a7cadaf982330f97f1ce3d39f34/anthropic-0.120.2-py3-none-any.whl", hash = "sha256:0f0bc2b381dc0eb41c8d886b815d79c2041cd2374f83aed36f574b6dc9c579c1", size = 1022851, upload-time = "2026-07-28T17:38:25.466Z" },
 ]
 
 [[package]]
@@ -341,11 +341,11 @@ wheels = [
 
 [[package]]
 name = "bracex"
-version = "2.6"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
 ]
 
 [[package]]
@@ -608,19 +608,19 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.6.12"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-anthropic", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "langchain-google-genai", marker = "python_full_version >= '3.11'" },
-    { name = "langsmith", marker = "python_full_version >= '3.11'" },
-    { name = "wcmatch", marker = "python_full_version >= '3.11'" },
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "langchain-google-genai" },
+    { name = "langsmith", version = "0.10.12", source = { registry = "https://pypi.org/simple" } },
+    { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/db/a6acdc72a9e90c3f07ed10de35c951734a02d4facb693bb59684ad368801/deepagents-0.6.12.tar.gz", hash = "sha256:1f281c0bc5a63132f62e2ee345c1dc593b23188da6e23016401f6879fbe54b5f", size = 211364, upload-time = "2026-06-25T17:26:52.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/6b/f61d30d45e25e8dc720b4928da029162329e8f22173bbbe190083e19a75e/deepagents-0.7.0.tar.gz", hash = "sha256:36c49bced5de9ef0deb1e9c05a449adf931706e25ba5f99449d7436eccbc694b", size = 263583, upload-time = "2026-07-29T16:27:29.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/49/af7219b3c13520fee047bb807cfaefba17f8e4584c551d946773589a4f08/deepagents-0.6.12-py3-none-any.whl", hash = "sha256:28b8fa0119ca0a689e3e18e288c4634e4046062acfc87a1cb34289d3af3a1c88", size = 236120, upload-time = "2026-06-25T17:26:51.736Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0a/ee3a0518a90bae0ee3f48e23061fe185804d0d3476cb75f21ab834f4698c/deepagents-0.7.0-py3-none-any.whl", hash = "sha256:c0ceb3c12f44638cdb81ea95652d6d6fa8ec76a2372ae8016aa2dd9a493762b1", size = 289723, upload-time = "2026-07-29T16:27:28.178Z" },
 ]
 
 [[package]]
@@ -646,7 +646,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -788,8 +788,8 @@ name = "google-auth"
 version = "2.55.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.11'" },
-    { name = "pyasn1-modules", marker = "python_full_version >= '3.11'" },
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
 wheels = [
@@ -798,7 +798,7 @@ wheels = [
 
 [package.optional-dependencies]
 requests = [
-    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "requests" },
 ]
 
 [[package]]
@@ -806,16 +806,16 @@ name = "google-genai"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.11'" },
-    { name = "distro", marker = "python_full_version >= '3.11'" },
-    { name = "google-auth", extra = ["requests"], marker = "python_full_version >= '3.11'" },
-    { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "sniffio", marker = "python_full_version >= '3.11'" },
-    { name = "tenacity", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
-    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/52/0244e310812f3063d09d60b30ae29ab7df9343bd005744cd5eeaa6ba39b4/google_genai-2.8.0.tar.gz", hash = "sha256:37a9b3cb127d763e7f4ca47452ae3562c87728773bd1b149f7b559c239da2bc1", size = 564955, upload-time = "2026-06-03T22:55:38.397Z" }
 wheels = [
@@ -1012,30 +1012,30 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.11"
+version = "1.3.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "langgraph", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "langgraph" },
+    { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/a2/91a7197c604a3ce1b774b3c10dd114c3c745c6186a304fc2573b3f94d400/langchain-1.3.11.tar.gz", hash = "sha256:f3cf9cd4d2329b1a03eb8fd92b9d73e4e58a4d52570d67725fc77fbe0f104b32", size = 633374, upload-time = "2026-06-22T23:00:33.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/a4/3a181967294f8876362cc4ba36840d50b8286fa23bb3f5e602b69eb3cb1e/langchain-1.3.11-py3-none-any.whl", hash = "sha256:7ae011f95a09b22feea1e8ae4e43f0b6164aebf4c61b8ad845b45f72ff3a90a2", size = 133639, upload-time = "2026-06-22T23:00:31.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
 ]
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.8"
+version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anthropic", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "anthropic" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/22/40ab129b08329ca295b391aa1d48267692b42594757084c6918e22b655ac/langchain_anthropic-1.4.8.tar.gz", hash = "sha256:c76891b2044d56105ff13c106ed12650637b53bd598a4bdf15b4796eefa2a4ec", size = 708524, upload-time = "2026-06-26T21:28:46.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/5b/25ffc9cc66a8260db9e2da2836ee33b260dfbb874d1ea2f99d70023f2b1d/langchain_anthropic-1.5.3.tar.gz", hash = "sha256:48a7e4fc3856c42f9dcb4396ba112afcdd8dee21b70a402bc43283c970de3941", size = 713962, upload-time = "2026-07-28T17:02:55.903Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/14/746235c4da89d9bc6a608c5f489f628e03feb8f697195c146e452c8f23c8/langchain_anthropic-1.4.8-py3-none-any.whl", hash = "sha256:778e9301b6fd517824f76ec1776975ce8add97a1f6a36c50ae3c2f4b03a66f7f", size = 52366, upload-time = "2026-06-26T21:28:45.535Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/19/584ab8517718f48bb411d051be713ebd8b58351741f8a4ca23d6a305cb1b/langchain_anthropic-1.5.3-py3-none-any.whl", hash = "sha256:b1b72b7c9e4bf5c044660629ebbcb79cef18c140fdc80174750eb86de13ec8bc", size = 54034, upload-time = "2026-07-28T17:02:54.594Z" },
 ]
 
 [[package]]
@@ -1047,7 +1047,7 @@ dependencies = [
     { name = "azure-identity" },
     { name = "azure-storage-blob", extra = ["aio"] },
     { name = "langchain-core", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -1062,7 +1062,7 @@ codespell = [
 ]
 dev = [
     { name = "langchain-core", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 lint = [
     { name = "pytest" },
@@ -1084,9 +1084,9 @@ requires-dist = [
     { name = "azure-core", specifier = ">=1.38.0" },
     { name = "azure-identity", specifier = "~=1.25" },
     { name = "azure-storage-blob", extras = ["aio"], specifier = "~=12.26" },
-    { name = "deepagents", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=0.6.12,<1" },
+    { name = "deepagents", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=0.7.0,<0.8" },
     { name = "langchain-core", specifier = ">=1.2.5,<2.0" },
-    { name = "wcmatch", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=10.1" },
+    { name = "wcmatch", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=11.0" },
 ]
 provides-extras = ["deepagents"]
 
@@ -1112,15 +1112,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "jsonpatch", marker = "python_full_version < '3.11'" },
-    { name = "langchain-protocol", version = "0.0.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "langsmith", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pydantic", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "tenacity", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "uuid-utils", marker = "python_full_version < '3.11'" },
+    { name = "jsonpatch" },
+    { name = "langchain-protocol", version = "0.0.15", source = { registry = "https://pypi.org/simple" } },
+    { name = "langsmith", version = "0.8.18", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
@@ -1129,41 +1129,41 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.8"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version >= '3.11' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "jsonpatch", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-protocol", version = "0.0.18", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "langsmith", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "tenacity", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
-    { name = "uuid-utils", marker = "python_full_version >= '3.11'" },
+    { name = "jsonpatch" },
+    { name = "langchain-protocol", version = "0.0.18", source = { registry = "https://pypi.org/simple" } },
+    { name = "langsmith", version = "0.10.12", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload-time = "2026-06-18T19:39:23.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/58/3ad53096eee1e07728e8219ded30ae308b0f2b8b7b26b8ebb6371917c0f5/langchain_core-1.5.2.tar.gz", hash = "sha256:2d13ab35b42eec63d4669a483776b8cdd778ee764107149369fb369d84c08c41", size = 972322, upload-time = "2026-07-28T16:38:37.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload-time = "2026-06-18T19:39:21.902Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e4/024e402a65f5ee2eb6ae9667b5ffc5f08776cb4e712f5a11ee1997d56083/langchain_core-1.5.2-py3-none-any.whl", hash = "sha256:a687dd7c3b22c6c1294e1c1eeb61fb6f3a308e6015a1d75b576b3836ad5b5aed", size = 561643, upload-time = "2026-07-28T16:38:36.38Z" },
 ]
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.2.6"
+version = "4.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filetype", marker = "python_full_version >= '3.11'" },
-    { name = "google-genai", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "filetype" },
+    { name = "google-genai" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/08/68e4f90b273d1d8dc3a7a948e6535e60baac726adbb2a8341dcf17662f54/langchain_google_genai-4.2.6.tar.gz", hash = "sha256:653dc331e691ddd79784d9ff6a4082749e0f873394c6dc782c414eb4409850eb", size = 280074, upload-time = "2026-06-26T06:18:58.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/2f/e03b63ad3a61fd1aa479bbc0f3df5d27abb8f9159d111cba96629df844ef/langchain_google_genai-4.3.2.tar.gz", hash = "sha256:6471769a4463fedb10d2d19a9b56c31de1cde505edf7fffd8cdbf98af8c1d7da", size = 286018, upload-time = "2026-07-27T16:27:39.214Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/3c/9a6b43bced0238f95640555e14423fe4a8268e3f4f536f67e26e79e633d4/langchain_google_genai-4.2.6-py3-none-any.whl", hash = "sha256:c40db0c2d033a5fb6db8e2cc3fb6d49c5678b89b337a64da095fb73ec9f72021", size = 70457, upload-time = "2026-06-26T06:18:57.781Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cb/4a2eb187b108a240d57cf8dcf67e818ca75365f769444bf5716e2823cd98/langchain_google_genai-4.3.2-py3-none-any.whl", hash = "sha256:f3b1c09b264612fd1735a9590987bfa0cccca0bc0111691543decb5a03b8667d", size = 72770, upload-time = "2026-07-27T16:27:38.052Z" },
 ]
 
 [[package]]
@@ -1174,7 +1174,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
 wheels = [
@@ -1190,7 +1190,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
 wheels = [
@@ -1202,12 +1202,12 @@ name = "langgraph"
 version = "1.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "langgraph-checkpoint", marker = "python_full_version >= '3.11'" },
-    { name = "langgraph-prebuilt", marker = "python_full_version >= '3.11'" },
-    { name = "langgraph-sdk", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "xxhash", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/7a/ea09b05bb0cbddfa43bd34fc581357e87fc3f21a751cc0d419688c3106da/langgraph-1.2.6.tar.gz", hash = "sha256:f9b45a34f13930c94d96cdb76277447ad2cc70ec2d18cd2764d7fdadb36cdc1b", size = 714400, upload-time = "2026-06-18T20:58:21.514Z" }
 wheels = [
@@ -1219,8 +1219,8 @@ name = "langgraph-checkpoint"
 version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "ormsgpack", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "ormsgpack" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
@@ -1232,8 +1232,8 @@ name = "langgraph-prebuilt"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "langgraph-checkpoint", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "langgraph-checkpoint" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
 wheels = [
@@ -1245,11 +1245,11 @@ name = "langgraph-sdk"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "langchain-protocol", version = "0.0.18", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "orjson", marker = "python_full_version >= '3.11'" },
-    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "httpx" },
+    { name = "langchain-core", version = "1.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "langchain-protocol", version = "0.0.18", source = { registry = "https://pypi.org/simple" } },
+    { name = "orjson" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
 wheels = [
@@ -1260,6 +1260,9 @@ wheels = [
 name = "langsmith"
 version = "0.8.18"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
 dependencies = [
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
@@ -1268,14 +1271,42 @@ dependencies = [
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "uuid-utils" },
-    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" } },
     { name = "xxhash" },
     { name = "zstandard" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/d9/a6681aa9847bbbc5ec21abe20a5e233b94e5edcfe39624db607ac7e8ccb4/langsmith-0.8.18.tar.gz", hash = "sha256:32dde9c0e67e053e0fb738921fc8ced768af7b8fa83d7a0e3fd63597cf8776dd", size = 4526988, upload-time = "2026-06-19T13:12:17.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/70/0e0cc80a3b064c8d6c8d697c3125ed86e39d5a7393ec6dc8b07cb1cf13c4/langsmith-0.8.18-py3-none-any.whl", hash = "sha256:3940183349993faef48e6c7d08e4822ee9cefd906b362d0e3c2d650314d2f282", size = 508108, upload-time = "2026-06-19T13:12:15.348Z" },
+]
+
+[[package]]
+name = "langsmith"
+version = "0.10.12"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.11' and python_full_version < '3.15'",
+]
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "xxhash" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c3/7203f18c6ca0ff4c65087fe8694511fadc8a0037c37010e43d25b9ecacd8/langsmith-0.10.12.tar.gz", hash = "sha256:e27cace529a5c54546ecdc2d3fa7af6d8a84a5b9333e99b497f47cafffa16ef5", size = 4749918, upload-time = "2026-07-29T14:22:52.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/f8/de3b66a9b9212ed41541814d8e062909c009837e650a4c2e43425ee1b43c/langsmith-0.10.12-py3-none-any.whl", hash = "sha256:d280fff7a03ecf612c3fdb172bf716467cfb9c0b9d90661b3523c2d8ee1b9a6e", size = 681040, upload-time = "2026-07-29T14:22:50.372Z" },
 ]
 
 [[package]]
@@ -1890,7 +1921,7 @@ name = "pyasn1-modules"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyasn1", marker = "python_full_version >= '3.11'" },
+    { name = "pyasn1" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
@@ -2337,14 +2368,14 @@ wheels = [
 
 [[package]]
 name = "wcmatch"
-version = "10.1"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bracex", marker = "python_full_version >= '3.11'" },
+    { name = "bracex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/25/1da725838132221e33568973da484ff43813662ccc06ebf7f6e3abddfcd5/wcmatch-11.0.tar.gz", hash = "sha256:55d95c2447789712774b198ceec72939e88b5618f1f8f0a9b605bf7740b63b96", size = 141360, upload-time = "2026-07-10T05:50:24.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+    { url = "https://files.pythonhosted.org/packages/28/12/f38b6fee116274d7221743caab07d765032e1370bb54cad8714f87aeb0e8/wcmatch-11.0-py3-none-any.whl", hash = "sha256:3a5977ace27e075eef67eb03d539563f1a19018b62881949a42932cf66926934", size = 42914, upload-time = "2026-07-10T05:50:22.995Z" },
 ]
 
 [[package]]

--- a/samples/deepagents-storage-backend/composite_with_memories.py
+++ b/samples/deepagents-storage-backend/composite_with_memories.py
@@ -67,17 +67,20 @@ _FILE_TOOLS = {"write_file": "wrote", "edit_file": "edited", "read_file": "read"
 
 
 async def seed_memory(backend: BackendProtocol) -> None:
-    """Seed an AGENTS.md memory file with project conventions.
+    """Seed an AGENTS.md memory file with project conventions, if absent.
 
     Written through the composite backend, so ``MEMORY_PATH`` is the same path
     the agents see. The ``/memories/`` route sends it to Azure Blob Storage.
 
     The agents can rewrite this file themselves — memory is left writable so the
-    workspace can accumulate conventions across sessions.
-
-    ``awrite`` fails if the file already exists; that's fine here, since an
-    existing AGENTS.md is sufficient for this example.
+    workspace can accumulate conventions across sessions. Seeding is therefore
+    guarded by a read: since deepagents 0.7.0, ``awrite`` replaces an existing
+    file instead of refusing to, so writing unconditionally would wipe whatever
+    the agents learned on every re-run.
     """
+    if (await backend.aread(MEMORY_PATH)).error is None:
+        return
+
     result = await backend.awrite(
         MEMORY_PATH,
         "# Project Conventions\n\n"
@@ -85,7 +88,7 @@ async def seed_memory(backend: BackendProtocol) -> None:
         "- Include docstrings on every public function\n"
         "- Write pytest-style tests\n",
     )
-    if result.error is not None and "already exists" not in result.error:
+    if result.error is not None:
         print(f"Warning: failed to seed AGENTS.md: {result.error}")
 
 


### PR DESCRIPTION
Updates `AzureBlobBackend` for the `BackendProtocol` changes in [deepagents 0.7.0](https://www.langchain.com/blog/deep-agents-v0-7). `write` now replaces existing files, `delete` is supported, and `grep` accepts a `max_count` cap.

---

## Why now

Our 1.1.0 release pins `deepagents>=0.6.12,<1`. We probably should have set an upper limit of `<0.7` so that users don't get auto-upgraded to 0.7.0.

## What changed

**`write`/`awrite` now overwrite an existing file.**
0.7.0 removed the create-only contract and shipped no compatibility mode. Its `write_file` tool description tells the model the file will be replaced. We were still returning "already exists", which the agent had no way to act on.

**Added `delete`/`adelete`.**
It removes the path plus everything nested under it, and returns not-found for a missing path. Same semantics as `StateBackend` and `StoreBackend`.

**`grep`/`agrep` accept `max_count` and set `truncated`.**
This clears two mypy override errors against the new protocol signature.

It also cuts egress. When a cap is set we scan candidates in chunks and stop once we pass it, rather than downloading every blob in the container and letting the middleware throw away all but 1000 matches. Uncapped scans dispatch everything at once, since there's nothing to stop for. Concurrency is bounded either way, by the thread pool on the sync side and a semaphore on the async side.

`max_count` is clamped to zero or higher. A negative value would be read as a slice from the end, dropping a match while still reporting success.

**Guarded `read(..., limit=0)`.**
This appears to be a regression. On 0.7.0 this raises `ValueError` for any non-empty file while previously it returned an empty read. Filed upstream as [deepagents#5180](https://github.com/langchain-ai/deepagents/issues/5180). The code comment links the issue so the workaround can be removed later.

**Raised two pins.**
`deepagents>=0.7.0,<0.8`, matching what quickjs, daytona, modal, vercel-sandbox, and runloop all moved to. `wcmatch>=11.0`, matching deepagents' own floor, which is why we pinned it in the first place.

**Read pagination now works.**
`slice_read_response` returns `total_lines`, `start_line`, `end_line`, and `next_offset` in 0.7.0. We pick those up with no code change, so `read_file` can tell the model how many lines remain.

## What users will notice

`AzureBlobBackend` is `@beta` and 1.1.0 is a day old, so the exposure is small. Still worth calling out:

- Anyone calling `write()` directly loses the create-guard. The change is silent, with no error.
- Agents now get a recursive delete tool pointed at a live container. `delete("/")` with no `prefix` set empties the whole thing. The class docstring and README cover the mitigations: set a `prefix`, turn on soft-delete or versioning, or leave `delete` out of `FilesystemMiddleware(tools=...)`.
- The pin narrows at both ends. Anyone on deepagents 0.6.x now has to take 0.7.0, which brings its own breaks: no default `TodoListMiddleware`, lean default prompts, and `virtual_mode=True`.
- Python 3.10 users and document-loader users are unaffected.

## Sample fix

`composite_with_memories.py` seeded `AGENTS.md` by writing unconditionally and ignoring the file-exists error. Under the new write semantics that wipes accumulated memory on every run, so it now seeds only when the file is absent.

## Testing

229 unit tests and 99 integration tests against Azurite. `ruff check` and `mypy` are clean on both the package and the tests.
