### PR TITLE
Pin `langchain-azure-storage` `deepagents` dependency ceiling to `0.7.0`

### DIFF
--- a/libs/azure-storage/pyproject.toml
+++ b/libs/azure-storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-azure-storage"
-version = "1.1.0"
+version = "1.1.1"
 description = "LangChain integrations for Azure Storage"
 authors = [
     {name="Microsoft Corporation", email="ascl@microsoft.com"},

--- a/libs/azure-storage/pyproject.toml
+++ b/libs/azure-storage/pyproject.toml
@@ -36,8 +36,11 @@ dependencies = [
 # 3.11+.
 # TODO(#815): drop the python_version marker when the package minimum moves to
 # 3.11 — revisit at Python 3.10 EOL (Oct 2026) or when langchain core drops 3.10.
+#
+# TODO(#878): Add support for deepagents 0.7+. It is locked to versions < 0.7.0
+# due to backwards incompatible changes in interface in 0.7.0
 deepagents = [
-    "deepagents>=0.6.12,<1; python_version>='3.11'",
+    "deepagents>=0.6.12,<0.7.0; python_version>='3.11'",
     "wcmatch>=10.1; python_version>='3.11'",
 ]
 

--- a/libs/azure-storage/uv.lock
+++ b/libs/azure-storage/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "langchain-azure-storage"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },

--- a/libs/azure-storage/uv.lock
+++ b/libs/azure-storage/uv.lock
@@ -1084,7 +1084,7 @@ requires-dist = [
     { name = "azure-core", specifier = ">=1.38.0" },
     { name = "azure-identity", specifier = "~=1.25" },
     { name = "azure-storage-blob", extras = ["aio"], specifier = "~=12.26" },
-    { name = "deepagents", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=0.6.12,<1" },
+    { name = "deepagents", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=0.6.12,<0.7.0" },
     { name = "langchain-core", specifier = ">=1.2.5,<2.0" },
     { name = "wcmatch", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=10.1" },
 ]


### PR DESCRIPTION
There were incompatible changes to interfaces introduced in 0.7.0 that need to be accounted for in the Azure Storage Deep Agents backend. The pin prevents automatic upgrades to 0.7.0 while proper support is added.

The PR also bumps the `langchain-azure-storage` version to `1.1.1` to make this update available in a patch release.