### PR TITLE
chore(dynamic-sessions): deprecate in favour of langchain-azure-compute

### DIFF
--- a/libs/azure-dynamic-sessions/README.md
+++ b/libs/azure-dynamic-sessions/README.md
@@ -1,5 +1,33 @@
 # langchain-azure-dynamic-sessions
 
+> [!WARNING]
+> **This package is deprecated and will not receive further fixes.** It has
+> been superseded by
+> [`langchain-azure-compute`](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-compute),
+> which carries the dynamic sessions integrations forward under the wider
+> Azure Container Apps umbrella — and additionally covers Azure Container Apps
+> sandboxes, the stateful counterpart to dynamic sessions.
+>
+> ```bash
+> pip install "langchain-azure-compute[dynamic-sessions]"
+> ```
+>
+> Then update imports:
+>
+> ```diff
+> - from langchain_azure_dynamic_sessions import SessionsPythonREPLTool
+> + from langchain_azure_compute.dynamic_sessions import SessionsPythonREPLTool
+> - from langchain_azure_dynamic_sessions import SessionsBashTool
+> + from langchain_azure_compute.dynamic_sessions import SessionsBashTool
+> - from langchain_azure_dynamic_sessions.backends import SessionsBashBackend
+> + from langchain_azure_compute.dynamic_sessions.backends import SessionsBashBackend
+> ```
+>
+> Migrating also fixes `SessionsBashBackend` on **deepagents >= 0.7**, where it
+> is broken here: its file-operation overrides are silently ignored and
+> `read()` returns the wrong type. Neither failure raises, so an affected agent
+> degrades quietly rather than erroring.
+
 This package contains the LangChain integration for Azure Container Apps dynamic sessions. You can use it to add a secure and scalable code interpreter to your agents.
 
 ## Installation

--- a/libs/azure-dynamic-sessions/README.md
+++ b/libs/azure-dynamic-sessions/README.md
@@ -1,5 +1,33 @@
 # langchain-azure-dynamic-sessions
 
+> [!WARNING]
+> **This package is deprecated and will not receive further fixes.** It has
+> been superseded by
+> [`langchain-azure-container-apps`](https://github.com/langchain-ai/langchain-azure/tree/main/libs/azure-container-apps),
+> which carries the dynamic sessions integrations forward under the wider
+> Azure Container Apps umbrella — and additionally covers Azure Container Apps
+> sandboxes, the stateful counterpart to dynamic sessions.
+>
+> ```bash
+> pip install "langchain-azure-container-apps[dynamic-sessions]"
+> ```
+>
+> Then update imports:
+>
+> ```diff
+> - from langchain_azure_dynamic_sessions import SessionsPythonREPLTool
+> + from langchain_azure_container_apps.dynamic_sessions import SessionsPythonREPLTool
+> - from langchain_azure_dynamic_sessions import SessionsBashTool
+> + from langchain_azure_container_apps.dynamic_sessions import SessionsBashTool
+> - from langchain_azure_dynamic_sessions.backends import SessionsBashBackend
+> + from langchain_azure_container_apps.dynamic_sessions.backends import SessionsBashBackend
+> ```
+>
+> Migrating also fixes `SessionsBashBackend` on **deepagents >= 0.7**, where it
+> is broken here: its file-operation overrides are silently ignored and
+> `read()` returns the wrong type. Neither failure raises, so an affected agent
+> degrades quietly rather than erroring.
+
 This package contains the LangChain integration for Azure Container Apps dynamic sessions. You can use it to add a secure and scalable code interpreter to your agents.
 
 ## Installation
@@ -36,7 +64,16 @@ from langchain_azure_dynamic_sessions.tools import SessionsPythonREPLTool
 tool = SessionsPythonREPLTool(pool_management_endpoint=POOL_MANAGEMENT_ENDPOINT)
 
 agent = create_agent(model=llm, tools=[tool])
-result = agent.invoke({"messages": [{"role": "user", "content": "What is the current time in Vancouver, Canada?"}]})
+result = agent.invoke(
+    {
+        "messages": [
+            {
+                "role": "user",
+                "content": "What is the current time in Vancouver, Canada?",
+            }
+        ]
+    }
+)
 ```
 
 When you're done with a session, call `close()` (or `delete_session()`) to release
@@ -59,7 +96,13 @@ from langchain_azure_dynamic_sessions.tools import SessionsBashTool
 tool = SessionsBashTool(pool_management_endpoint=POOL_MANAGEMENT_ENDPOINT)
 
 agent = create_agent(model=llm, tools=[tool])
-result = agent.invoke({"messages": [{"role": "user", "content": "List the files in the current directory."}]})
+result = agent.invoke(
+    {
+        "messages": [
+            {"role": "user", "content": "List the files in the current directory."}
+        ]
+    }
+)
 ```
 
 You can also execute bash commands directly:
@@ -81,13 +124,17 @@ The tool supports file operations as well:
 tool = SessionsBashTool(pool_management_endpoint=POOL_MANAGEMENT_ENDPOINT)
 
 # upload a file to the session
-tool.upload_file(local_file_path="./local_script.sh", remote_file_path="/mnt/user/script.sh")
+tool.upload_file(
+    local_file_path="./local_script.sh", remote_file_path="/mnt/user/script.sh"
+)
 
 # list files in the session
 files = tool.list_files()
 
 # download a file from the session
-tool.download_file(remote_file_path="/mnt/user/output.txt", local_file_path="./output.txt")
+tool.download_file(
+    remote_file_path="/mnt/user/output.txt", local_file_path="./output.txt"
+)
 ```
 
 Both tools also support context-manager usage so sessions are deleted

--- a/libs/azure-dynamic-sessions/langchain_azure_dynamic_sessions/__init__.py
+++ b/libs/azure-dynamic-sessions/langchain_azure_dynamic_sessions/__init__.py
@@ -1,8 +1,26 @@
-"""This package provides tools for managing dynamic sessions in Azure."""
+"""This package provides tools for managing dynamic sessions in Azure.
+
+.. deprecated::
+    Superseded by ``langchain-azure-container-apps``, which carries the
+    dynamic sessions integrations forward and additionally covers Azure
+    Container Apps sandboxes.
+"""
+
+import warnings
 
 from langchain_azure_dynamic_sessions.tools.sessions import (
     SessionsBashTool,
     SessionsPythonREPLTool,
+)
+
+warnings.warn(
+    "langchain-azure-dynamic-sessions is deprecated and will not receive "
+    "further fixes. Use langchain-azure-container-apps instead: "
+    "pip install 'langchain-azure-container-apps[dynamic-sessions]', then "
+    "import from langchain_azure_container_apps.dynamic_sessions. Migrating "
+    "also fixes SessionsBashBackend on deepagents >= 0.7, which is broken here.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [

--- a/libs/azure-dynamic-sessions/langchain_azure_dynamic_sessions/__init__.py
+++ b/libs/azure-dynamic-sessions/langchain_azure_dynamic_sessions/__init__.py
@@ -1,8 +1,26 @@
-"""This package provides tools for managing dynamic sessions in Azure."""
+"""This package provides tools for managing dynamic sessions in Azure.
+
+.. deprecated::
+    Superseded by ``langchain-azure-compute``, which carries the
+    dynamic sessions integrations forward and additionally covers Azure
+    Container Apps sandboxes.
+"""
+
+import warnings
 
 from langchain_azure_dynamic_sessions.tools.sessions import (
     SessionsBashTool,
     SessionsPythonREPLTool,
+)
+
+warnings.warn(
+    "langchain-azure-dynamic-sessions is deprecated and will not receive "
+    "further fixes. Use langchain-azure-compute instead: "
+    "pip install 'langchain-azure-compute[dynamic-sessions]', then "
+    "import from langchain_azure_compute.dynamic_sessions. Migrating "
+    "also fixes SessionsBashBackend on deepagents >= 0.7, which is broken here.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [

--- a/libs/azure-dynamic-sessions/langchain_azure_dynamic_sessions/backends/sessions.py
+++ b/libs/azure-dynamic-sessions/langchain_azure_dynamic_sessions/backends/sessions.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import re
 import shlex
 import urllib.parse
+import warnings
 from io import BytesIO
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -30,6 +32,7 @@ except ImportError as e:
         "azure-dynamic-sessions requires 'deepagents' to use SessionsBashBackend. "
         "Install with: pip install deepagents"
     ) from e
+
 
 from deepagents.backends.protocol import (
     EditResult,
@@ -53,6 +56,44 @@ from langchain_azure_dynamic_sessions.tools.sessions import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 120
+
+
+def _warn_if_deepagents_incompatible() -> None:
+    """Warn when the installed deepagents is newer than this backend supports.
+
+    This backend targets the deepagents 0.6 surface. On 0.7 the `ls_info` and
+    `glob_info` overrides are dead code (renamed to `ls`/`glob`) and `read`
+    returns the wrong type. None of that raises, so the failure is silent
+    without this warning. The fix ships in langchain-azure-container-apps.
+    """
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        installed = version("deepagents")
+    except PackageNotFoundError:
+        return
+    # Match the leading release numbers only. `int(part)` over a dot-split
+    # raised on any prerelease ("0.7rc1") and skipped the warning for exactly
+    # the versions most likely to hit this. Comparing the release tuple rather
+    # than PEP 440 order is deliberate: `Version("0.7rc1") < Version("0.7")`,
+    # so an ordering comparison would also let 0.7 prereleases through.
+    release = re.match(r"(\d+)\.(\d+)", installed)
+    if release is None:
+        return
+    major, minor = int(release.group(1)), int(release.group(2))
+    if (major, minor) >= (0, 7):
+        warnings.warn(
+            f"SessionsBashBackend does not support deepagents {installed}: its "
+            "file-operation overrides are silently ignored on 0.7+ and read() "
+            "returns the wrong type. Use langchain-azure-container-apps "
+            "instead: pip install "
+            "'langchain-azure-container-apps[dynamic-sessions]'.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+_warn_if_deepagents_incompatible()
 
 
 @experimental()

--- a/libs/azure-dynamic-sessions/langchain_azure_dynamic_sessions/backends/sessions.py
+++ b/libs/azure-dynamic-sessions/langchain_azure_dynamic_sessions/backends/sessions.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import re
 import shlex
 import urllib.parse
+import warnings
 from io import BytesIO
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -30,6 +32,7 @@ except ImportError as e:
         "azure-dynamic-sessions requires 'deepagents' to use SessionsBashBackend. "
         "Install with: pip install deepagents"
     ) from e
+
 
 from deepagents.backends.protocol import (
     EditResult,
@@ -53,6 +56,44 @@ from langchain_azure_dynamic_sessions.tools.sessions import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 120
+
+
+def _warn_if_deepagents_incompatible() -> None:
+    """Warn when the installed deepagents is newer than this backend supports.
+
+    This backend targets the deepagents 0.6 surface. On 0.7 the `ls_info` and
+    `glob_info` overrides are dead code (renamed to `ls`/`glob`) and `read`
+    returns the wrong type. None of that raises, so the failure is silent
+    without this warning. The fix ships in langchain-azure-compute.
+    """
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        installed = version("deepagents")
+    except PackageNotFoundError:
+        return
+    # Match the leading release numbers only. `int(part)` over a dot-split
+    # raised on any prerelease ("0.7rc1") and skipped the warning for exactly
+    # the versions most likely to hit this. Comparing the release tuple rather
+    # than PEP 440 order is deliberate: `Version("0.7rc1") < Version("0.7")`,
+    # so an ordering comparison would also let 0.7 prereleases through.
+    release = re.match(r"(\d+)\.(\d+)", installed)
+    if release is None:
+        return
+    major, minor = int(release.group(1)), int(release.group(2))
+    if (major, minor) >= (0, 7):
+        warnings.warn(
+            f"SessionsBashBackend does not support deepagents {installed}: its "
+            "file-operation overrides are silently ignored on 0.7+ and read() "
+            "returns the wrong type. Use langchain-azure-compute "
+            "instead: pip install "
+            "'langchain-azure-compute[dynamic-sessions]'.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+_warn_if_deepagents_incompatible()
 
 
 @experimental()

--- a/libs/azure-dynamic-sessions/pyproject.toml
+++ b/libs/azure-dynamic-sessions/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "langchain-azure-dynamic-sessions"
 version = "1.0.3"
-description = "An integration package connecting Azure Container Apps dynamic sessions and LangChain"
+description = "Deprecated: use langchain-azure-compute. Connects Azure Container Apps dynamic sessions and LangChain"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10,<4.0"

--- a/libs/azure-dynamic-sessions/pyproject.toml
+++ b/libs/azure-dynamic-sessions/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "langchain-azure-dynamic-sessions"
-version = "1.0.3"
-description = "An integration package connecting Azure Container Apps dynamic sessions and LangChain"
+version = "1.1.0"
+description = "Deprecated: use langchain-azure-container-apps. Connects Azure Container Apps dynamic sessions and LangChain"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10,<4.0"

--- a/libs/azure-dynamic-sessions/tests/unit_tests/test_deprecation.py
+++ b/libs/azure-dynamic-sessions/tests/unit_tests/test_deprecation.py
@@ -1,0 +1,176 @@
+"""Tests for the deprecation layer of langchain-azure-dynamic-sessions.
+
+Covers the module-level DeprecationWarning on ``import
+langchain_azure_dynamic_sessions`` and the RuntimeWarning emitted by
+``_warn_if_deepagents_incompatible`` in ``backends.sessions`` when an
+incompatible deepagents version (>= 0.7) is installed.
+
+deepagents is not installed in the test environment, so minimal stand-in
+modules are injected into ``sys.modules`` to let ``backends.sessions``
+import; ``importlib.metadata.version`` is patched to simulate installed
+deepagents versions. The shipped code path is exercised directly (the
+version-parsing logic is never reimplemented here).
+"""
+
+import importlib
+import importlib.metadata
+import sys
+import types
+import warnings
+from importlib.metadata import PackageNotFoundError
+from typing import Generator, Optional
+
+import pytest
+
+_BACKEND_MODULE = "langchain_azure_dynamic_sessions.backends.sessions"
+
+# Names backends.sessions imports from deepagents at runtime.
+_PROTOCOL_NAMES = (
+    "EditResult",
+    "ExecuteResponse",
+    "FileDownloadResponse",
+    "FileUploadResponse",
+    "WriteResult",
+)
+
+
+def _install_fake_deepagents(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inject minimal deepagents stand-ins so backends.sessions can import."""
+    deepagents = types.ModuleType("deepagents")
+    backends = types.ModuleType("deepagents.backends")
+    sandbox = types.ModuleType("deepagents.backends.sandbox")
+    protocol = types.ModuleType("deepagents.backends.protocol")
+
+    setattr(sandbox, "BaseSandbox", type("BaseSandbox", (), {}))
+    for name in _PROTOCOL_NAMES:
+        setattr(protocol, name, type(name, (), {}))
+
+    setattr(deepagents, "backends", backends)
+    setattr(backends, "sandbox", sandbox)
+    setattr(backends, "protocol", protocol)
+
+    monkeypatch.setitem(sys.modules, "deepagents", deepagents)
+    monkeypatch.setitem(sys.modules, "deepagents.backends", backends)
+    monkeypatch.setitem(sys.modules, "deepagents.backends.sandbox", sandbox)
+    monkeypatch.setitem(sys.modules, "deepagents.backends.protocol", protocol)
+
+
+def _patch_deepagents_version(
+    monkeypatch: pytest.MonkeyPatch, installed: Optional[str]
+) -> None:
+    """Make importlib.metadata report *installed* for deepagents.
+
+    ``None`` simulates deepagents not being installed (PackageNotFoundError).
+    Other distributions resolve through the real lookup.
+    """
+    real_version = importlib.metadata.version
+
+    def fake_version(distribution_name: str) -> str:
+        if distribution_name == "deepagents":
+            if installed is None:
+                raise PackageNotFoundError(distribution_name)
+            return installed
+        return real_version(distribution_name)
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+
+
+@pytest.fixture
+def evict_backend_modules() -> Generator[None, None, None]:
+    """Evict cached backends modules before and after the test."""
+
+    def evict() -> None:
+        for key in list(sys.modules):
+            if "langchain_azure_dynamic_sessions.backends" in key:
+                del sys.modules[key]
+
+    evict()
+    yield
+    evict()
+
+
+@pytest.fixture
+def sessions_module(
+    monkeypatch: pytest.MonkeyPatch,
+    evict_backend_modules: None,
+) -> types.ModuleType:
+    """Import the real backends.sessions module under fake deepagents."""
+    _install_fake_deepagents(monkeypatch)
+    # Import quietly: simulate deepagents metadata being absent so the
+    # module-level compatibility check does not fire during import.
+    _patch_deepagents_version(monkeypatch, None)
+    return importlib.import_module(_BACKEND_MODULE)
+
+
+def test_package_import_emits_deprecation_warning() -> None:
+    """Importing the package must warn and point at the replacement package."""
+    import langchain_azure_dynamic_sessions as pkg
+
+    # Re-execute the module body to re-trigger the module-level warning.
+    # reload() reuses the same module object, so no state needs restoring.
+    with pytest.warns(DeprecationWarning, match="langchain-azure-container-apps"):
+        importlib.reload(pkg)
+
+
+@pytest.mark.parametrize(
+    ("installed", "should_warn"),
+    [
+        pytest.param("0.6.12", False, id="0.6.12-compatible"),
+        pytest.param("0.7.0", True, id="0.7.0"),
+        pytest.param("0.7rc1", True, id="0.7rc1-prerelease"),
+        pytest.param("0.7.0.dev0", True, id="0.7.0.dev0-prerelease"),
+        pytest.param("0.8.1", True, id="0.8.1"),
+        pytest.param("1.0.0", True, id="1.0.0"),
+        pytest.param("not-a-version", False, id="non-version-string"),
+        pytest.param(None, False, id="not-installed"),
+    ],
+)
+def test_warn_if_deepagents_incompatible(
+    sessions_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    installed: Optional[str],
+    should_warn: bool,
+) -> None:
+    """RuntimeWarning fires iff the deepagents release tuple is >= (0, 7)."""
+    _patch_deepagents_version(monkeypatch, installed)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sessions_module._warn_if_deepagents_incompatible()
+
+    runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    if should_warn:
+        assert len(runtime_warnings) == 1
+        message = str(runtime_warnings[0].message)
+        assert installed is not None
+        assert installed in message
+        assert "langchain-azure-container-apps" in message
+    else:
+        assert runtime_warnings == []
+
+
+def test_backend_import_warns_on_incompatible_deepagents(
+    monkeypatch: pytest.MonkeyPatch,
+    evict_backend_modules: None,
+) -> None:
+    """The compatibility check runs at import time of backends.sessions."""
+    _install_fake_deepagents(monkeypatch)
+    _patch_deepagents_version(monkeypatch, "0.7.0")
+
+    with pytest.warns(RuntimeWarning, match="deepagents 0.7.0"):
+        importlib.import_module(_BACKEND_MODULE)
+
+
+def test_backend_import_quiet_on_compatible_deepagents(
+    monkeypatch: pytest.MonkeyPatch,
+    evict_backend_modules: None,
+) -> None:
+    """No RuntimeWarning when a compatible deepagents (< 0.7) is installed."""
+    _install_fake_deepagents(monkeypatch)
+    _patch_deepagents_version(monkeypatch, "0.6.12")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.import_module(_BACKEND_MODULE)
+
+    assert not [w for w in caught if issubclass(w.category, RuntimeWarning)]

--- a/libs/azure-dynamic-sessions/tests/unit_tests/test_deprecation.py
+++ b/libs/azure-dynamic-sessions/tests/unit_tests/test_deprecation.py
@@ -1,0 +1,176 @@
+"""Tests for the deprecation layer of langchain-azure-dynamic-sessions.
+
+Covers the module-level DeprecationWarning on ``import
+langchain_azure_dynamic_sessions`` and the RuntimeWarning emitted by
+``_warn_if_deepagents_incompatible`` in ``backends.sessions`` when an
+incompatible deepagents version (>= 0.7) is installed.
+
+deepagents is not installed in the test environment, so minimal stand-in
+modules are injected into ``sys.modules`` to let ``backends.sessions``
+import; ``importlib.metadata.version`` is patched to simulate installed
+deepagents versions. The shipped code path is exercised directly (the
+version-parsing logic is never reimplemented here).
+"""
+
+import importlib
+import importlib.metadata
+import sys
+import types
+import warnings
+from importlib.metadata import PackageNotFoundError
+from typing import Generator, Optional
+
+import pytest
+
+_BACKEND_MODULE = "langchain_azure_dynamic_sessions.backends.sessions"
+
+# Names backends.sessions imports from deepagents at runtime.
+_PROTOCOL_NAMES = (
+    "EditResult",
+    "ExecuteResponse",
+    "FileDownloadResponse",
+    "FileUploadResponse",
+    "WriteResult",
+)
+
+
+def _install_fake_deepagents(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inject minimal deepagents stand-ins so backends.sessions can import."""
+    deepagents = types.ModuleType("deepagents")
+    backends = types.ModuleType("deepagents.backends")
+    sandbox = types.ModuleType("deepagents.backends.sandbox")
+    protocol = types.ModuleType("deepagents.backends.protocol")
+
+    setattr(sandbox, "BaseSandbox", type("BaseSandbox", (), {}))
+    for name in _PROTOCOL_NAMES:
+        setattr(protocol, name, type(name, (), {}))
+
+    setattr(deepagents, "backends", backends)
+    setattr(backends, "sandbox", sandbox)
+    setattr(backends, "protocol", protocol)
+
+    monkeypatch.setitem(sys.modules, "deepagents", deepagents)
+    monkeypatch.setitem(sys.modules, "deepagents.backends", backends)
+    monkeypatch.setitem(sys.modules, "deepagents.backends.sandbox", sandbox)
+    monkeypatch.setitem(sys.modules, "deepagents.backends.protocol", protocol)
+
+
+def _patch_deepagents_version(
+    monkeypatch: pytest.MonkeyPatch, installed: Optional[str]
+) -> None:
+    """Make importlib.metadata report *installed* for deepagents.
+
+    ``None`` simulates deepagents not being installed (PackageNotFoundError).
+    Other distributions resolve through the real lookup.
+    """
+    real_version = importlib.metadata.version
+
+    def fake_version(distribution_name: str) -> str:
+        if distribution_name == "deepagents":
+            if installed is None:
+                raise PackageNotFoundError(distribution_name)
+            return installed
+        return real_version(distribution_name)
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+
+
+@pytest.fixture
+def evict_backend_modules() -> Generator[None, None, None]:
+    """Evict cached backends modules before and after the test."""
+
+    def evict() -> None:
+        for key in list(sys.modules):
+            if "langchain_azure_dynamic_sessions.backends" in key:
+                del sys.modules[key]
+
+    evict()
+    yield
+    evict()
+
+
+@pytest.fixture
+def sessions_module(
+    monkeypatch: pytest.MonkeyPatch,
+    evict_backend_modules: None,
+) -> types.ModuleType:
+    """Import the real backends.sessions module under fake deepagents."""
+    _install_fake_deepagents(monkeypatch)
+    # Import quietly: simulate deepagents metadata being absent so the
+    # module-level compatibility check does not fire during import.
+    _patch_deepagents_version(monkeypatch, None)
+    return importlib.import_module(_BACKEND_MODULE)
+
+
+def test_package_import_emits_deprecation_warning() -> None:
+    """Importing the package must warn and point at the replacement package."""
+    import langchain_azure_dynamic_sessions as pkg
+
+    # Re-execute the module body to re-trigger the module-level warning.
+    # reload() reuses the same module object, so no state needs restoring.
+    with pytest.warns(DeprecationWarning, match="langchain-azure-compute"):
+        importlib.reload(pkg)
+
+
+@pytest.mark.parametrize(
+    ("installed", "should_warn"),
+    [
+        pytest.param("0.6.12", False, id="0.6.12-compatible"),
+        pytest.param("0.7.0", True, id="0.7.0"),
+        pytest.param("0.7rc1", True, id="0.7rc1-prerelease"),
+        pytest.param("0.7.0.dev0", True, id="0.7.0.dev0-prerelease"),
+        pytest.param("0.8.1", True, id="0.8.1"),
+        pytest.param("1.0.0", True, id="1.0.0"),
+        pytest.param("not-a-version", False, id="non-version-string"),
+        pytest.param(None, False, id="not-installed"),
+    ],
+)
+def test_warn_if_deepagents_incompatible(
+    sessions_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    installed: Optional[str],
+    should_warn: bool,
+) -> None:
+    """RuntimeWarning fires iff the deepagents release tuple is >= (0, 7)."""
+    _patch_deepagents_version(monkeypatch, installed)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sessions_module._warn_if_deepagents_incompatible()
+
+    runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    if should_warn:
+        assert len(runtime_warnings) == 1
+        message = str(runtime_warnings[0].message)
+        assert installed is not None
+        assert installed in message
+        assert "langchain-azure-compute" in message
+    else:
+        assert runtime_warnings == []
+
+
+def test_backend_import_warns_on_incompatible_deepagents(
+    monkeypatch: pytest.MonkeyPatch,
+    evict_backend_modules: None,
+) -> None:
+    """The compatibility check runs at import time of backends.sessions."""
+    _install_fake_deepagents(monkeypatch)
+    _patch_deepagents_version(monkeypatch, "0.7.0")
+
+    with pytest.warns(RuntimeWarning, match="deepagents 0.7.0"):
+        importlib.import_module(_BACKEND_MODULE)
+
+
+def test_backend_import_quiet_on_compatible_deepagents(
+    monkeypatch: pytest.MonkeyPatch,
+    evict_backend_modules: None,
+) -> None:
+    """No RuntimeWarning when a compatible deepagents (< 0.7) is installed."""
+    _install_fake_deepagents(monkeypatch)
+    _patch_deepagents_version(monkeypatch, "0.6.12")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.import_module(_BACKEND_MODULE)
+
+    assert not [w for w in caught if issubclass(w.category, RuntimeWarning)]

--- a/libs/azure-dynamic-sessions/uv.lock
+++ b/libs/azure-dynamic-sessions/uv.lock
@@ -447,7 +447,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -563,17 +563,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -589,17 +589,17 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.15'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/80/406f9e3bde1c1fd9bf5a0be9d090f8ae623e401b7670d8f6fdf2ab679891/ipython-9.4.0.tar.gz", hash = "sha256:c033c6d4e7914c3d9768aabe76bbe87ba1dc66a92a05db6bfa1125d81f2ee270", size = 4385338, upload-time = "2025-07-01T11:11:30.606Z" }
 wheels = [
@@ -611,7 +611,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "langchain-azure-dynamic-sessions"
-version = "1.0.3"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },


### PR DESCRIPTION
# Deprecate `langchain-azure-dynamic-sessions`

Part of the stack for #906 · **6 of 6** · base: *Run the shared sandbox standard suite against `ACASandbox`* · top of stack

Points users at `langchain-azure-compute`. Placed **last** in the stack so the whole replacement package exists first: the warning and the README can then describe what users are actually moving to — both integrations, not a package still being assembled.

**Touches `libs/azure-dynamic-sessions` only.** No changes to the new package.

## What it does

- Importing the package emits a `DeprecationWarning` naming the replacement and the import rewrite.
- The README leads with the migration, using an absolute GitHub URL — a repo-relative link does not resolve in the rendered PyPI description. The diff maps all three public names.
- The `description` now leads with "Deprecated: use langchain-azure-compute". The **version bump and its `## Changelog` entry are deliberately deferred** to a separate release PR, per review — this PR carries the deprecation only, so `pyproject.toml` stays at 1.0.3 and `uv.lock` is untouched.
- A separate `RuntimeWarning` when the installed deepagents is >= 0.7, where this package's backend is silently broken: its file-operation overrides are ignored and `read()` returns the wrong type. Neither raises, so an affected agent degrades quietly.

Warning rather than raising, so an upgrade whose only purpose is to deprecate does not break working setups.

## Worth a close look

The version check matches leading `major.minor` digits rather than splitting on dots and calling `int()`. The old form raised on any prerelease and so skipped the warning for exactly the versions most likely to hit this.

Comparing release numbers rather than PEP 440 order is deliberate: `Version("0.7rc1")` sorts *below* `Version("0.7")`, so an ordering comparison would also let 0.7 prereleases through. `tests/unit_tests/test_deprecation.py` enforces this across `0.6.12`, `0.7.0`, `0.7rc1`, `0.7.0.dev0`, `0.8.1`, `1.0.0`, a non-version string and a missing distribution — deepagents stand-ins are injected into `sys.modules`, since this package deliberately does not depend on it — and asserts the `DeprecationWarning` on a fresh import.

One visibility note: `DeprecationWarning` is hidden by Python's default filters outside `__main__` and test runners. That is the convention for library deprecations and is chosen deliberately over a louder `UserWarning`.

## Deliberately not fixed

The underlying 0.7 bugs. The fix ships in the new package and this one is going away.

## Validation

- 49 unit tests for the old package (11 new for the warnings), ruff and mypy clean — run on **both** CI matrix legs, Python 3.10 and 3.14
- `uv lock --check` passes under CI's pinned uv 0.12.3; `uv.lock` is byte-identical to `main`

## Notes

Rebased onto current `main`, which moved the CI matrix from Python 3.12 to 3.14 and uv from 0.11.2 to 0.12.3; both legs verified locally. `uv.lock` is no longer modified by this PR at all.

No later PR in this stack modifies behaviour introduced here.


