### PR TITLE
feat(azure-storage): add AzureTableStorageSaver LangGraph checkpointer

### DIFF
--- a/libs/azure-storage/README.md
+++ b/libs/azure-storage/README.md
@@ -3,6 +3,7 @@
 This package contains the LangChain integrations for [Azure Storage](https://learn.microsoft.com/en-us/azure/storage/common/storage-introduction). Currently, it includes:
 - [Document loader support for Azure Blob Storage](#azure-blob-storage-document-loader-usage)
 - [Deep Agents filesystem backend backed by Azure Blob Storage](#deep-agents-azure-blob-storage-backend-usage)
+- [LangGraph checkpointer backed by Azure Table Storage](#azure-table-storage-langgraph-checkpointer-usage)
 
 > [!NOTE]
 > This package is in Public Preview. For more information, see [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/).
@@ -278,5 +279,53 @@ async with AzureBlobBackend(account_url="...", container_name="agent-workspace")
 ```
 
 The **sync** client releases its resources on garbage collection, so closing it is optional; you can still use `with` (or call `close()`) to release it promptly.
+
+## Azure Table Storage LangGraph Checkpointer Usage
+
+[LangGraph checkpointers](https://langchain-ai.github.io/langgraph/concepts/persistence/) persist a graph's state across invocations, enabling multi-turn conversations, human-in-the-loop workflows, and time travel. This package provides `AzureTableStorageSaver`, a checkpointer backed by [Azure Table Storage](https://learn.microsoft.com/en-us/azure/storage/tables/table-storage-overview).
+
+```python
+from langchain_azure_storage.checkpoint import AzureTableStorageSaver
+
+saver = AzureTableStorageSaver(
+    endpoint="https://<my-storage-account-name>.table.core.windows.net",
+    table_name="checkpoints",
+)
+
+graph = builder.compile(checkpointer=saver)
+config = {"configurable": {"thread_id": "thread-1"}}
+graph.invoke({"messages": [...]}, config)
+```
+
+The table is created automatically on first use if it doesn't already exist. `AzureTableStorageSaver` exposes both sync methods (`get_tuple`, `list`, `put`, `put_writes`) and their `a`-prefixed async counterparts, each backed by its own lazily-created client — use whichever fits your call site.
+
+Like the document loader, it defaults to [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication/credential-chains?tabs=dac#defaultazurecredential-overview) and accepts a `credential` override:
+
+```python
+from azure.identity import ManagedIdentityCredential
+
+saver = AzureTableStorageSaver(
+    endpoint="https://<account>.table.core.windows.net",
+    table_name="checkpoints",
+    credential=ManagedIdentityCredential(),
+)
+```
+
+For local development against the [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) emulator, use `from_connection_string` instead of `endpoint` + `credential`:
+
+```python
+saver = AzureTableStorageSaver.from_connection_string(
+    "<connection-string>",
+    table_name="checkpoints",
+)
+```
+
+### Resource lifecycle
+
+`AzureTableStorageSaver` creates its underlying Azure SDK clients (and, unless you pass a `credential`, a `DefaultAzureCredential`) lazily on first use and reuses them across calls. Call `close()`/`aclose()` (or use the saver as a sync/async context manager) to release them once you're done.
+
+### Checkpoint size
+
+Azure Table Storage caps each entity property at 64 KiB and each entity at 1 MiB. `AzureTableStorageSaver` transparently splits large serialized checkpoints, metadata, and writes across multiple properties to work around the per-property limit; if a single checkpoint's total serialized size still exceeds the 1 MiB entity limit, the underlying Azure SDK raises an error.
 
 ## Changelog

--- a/libs/azure-storage/langchain_azure_storage/checkpoint.py
+++ b/libs/azure-storage/langchain_azure_storage/checkpoint.py
@@ -1,0 +1,919 @@
+"""Azure Table Storage implementation of a LangGraph checkpointer."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import threading
+from collections.abc import AsyncIterator, Iterator, Sequence
+from typing import Any, Optional, Union
+
+import azure.core.credentials
+import azure.core.credentials_async
+import azure.identity
+import azure.identity.aio
+from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
+from azure.data.tables import TableClient, UpdateMode
+from azure.data.tables.aio import TableClient as AsyncTableClient
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    WRITES_IDX_MAP,
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    get_checkpoint_id,
+)
+from langgraph.checkpoint.serde.base import SerializerProtocol
+
+from langchain_azure_storage._user_agent import USER_AGENT
+
+_KEY_SEPARATOR = "$"
+# Azure Table Storage forbids these characters in PartitionKey/RowKey, on top
+# of the separator we use to join key parts.
+_CONTROL_CHARS = "".join(chr(c) for c in (*range(0x00, 0x20), *range(0x7F, 0xA0)))
+_FORBIDDEN_KEY_CHARS = re.compile("[" + re.escape("/\\#?" + _CONTROL_CHARS) + "]")
+# Table Storage caps String/Binary properties at 64 KiB each; stay safely
+# under that so large checkpoints/writes can be split across properties.
+_MAX_CHUNK_SIZE = 63 * 1024
+
+# Credential types accepted by the saver.
+_SDK_CREDENTIAL_TYPE = Optional[
+    Union[
+        azure.core.credentials.AzureSasCredential,
+        azure.core.credentials.AzureNamedKeyCredential,
+        azure.core.credentials.TokenCredential,
+        azure.core.credentials_async.AsyncTokenCredential,
+    ]
+]
+# Narrower views of the above, matching what the sync/async TableClient
+# constructors actually accept, once `_resolve_*_credential` has ruled out
+# the other mode's credential type.
+_SYNC_CREDENTIAL_TYPE = Optional[
+    Union[
+        azure.core.credentials.AzureSasCredential,
+        azure.core.credentials.AzureNamedKeyCredential,
+        azure.core.credentials.TokenCredential,
+    ]
+]
+_ASYNC_CREDENTIAL_TYPE = Optional[
+    Union[
+        azure.core.credentials.AzureSasCredential,
+        azure.core.credentials.AzureNamedKeyCredential,
+        azure.core.credentials_async.AsyncTokenCredential,
+    ]
+]
+
+
+def _validate_key_part(value: str, name: str) -> None:
+    """Raise ValueError if *value* is unsafe to use in a Table Storage key."""
+    if _KEY_SEPARATOR in value:
+        raise ValueError(
+            f"'{name}' must not contain the separator '{_KEY_SEPARATOR}': got {value!r}"
+        )
+    if _FORBIDDEN_KEY_CHARS.search(value):
+        raise ValueError(
+            f"'{name}' must not contain '/', '\\', '#', '?', or control "
+            f"characters (Azure Table Storage key restrictions): got {value!r}"
+        )
+
+
+def _partition_key(thread_id: str, checkpoint_ns: str) -> str:
+    """Build the shared PartitionKey for a thread_id/checkpoint_ns pair."""
+    return f"{thread_id}{_KEY_SEPARATOR}{checkpoint_ns}"
+
+
+def _checkpoint_row_key(checkpoint_id: str) -> str:
+    """Build the RowKey for a checkpoint entity."""
+    return f"checkpoint{_KEY_SEPARATOR}{checkpoint_id}"
+
+
+def _writes_row_key(checkpoint_id: str, task_id: str, idx: Any) -> str:
+    """Build the RowKey for a pending-writes entity."""
+    if idx is None:
+        return f"writes{_KEY_SEPARATOR}{checkpoint_id}{_KEY_SEPARATOR}{task_id}"
+    return (
+        f"writes{_KEY_SEPARATOR}{checkpoint_id}{_KEY_SEPARATOR}{task_id}"
+        f"{_KEY_SEPARATOR}{idx}"
+    )
+
+
+def _parse_checkpoint_row_key(row_key: str) -> str:
+    """Parse a checkpoint entity's RowKey, returning its checkpoint_id."""
+    prefix, sep, checkpoint_id = row_key.partition(_KEY_SEPARATOR)
+    if prefix != "checkpoint" or not sep:
+        raise ValueError(f"Invalid checkpoint row key: {row_key!r}")
+    return checkpoint_id
+
+
+def _parse_writes_row_key(row_key: str) -> tuple[str, str, str]:
+    """Parse a writes entity's RowKey into (checkpoint_id, task_id, idx)."""
+    parts = row_key.split(_KEY_SEPARATOR)
+    if len(parts) != 4 or parts[0] != "writes":
+        raise ValueError(f"Invalid writes row key: {row_key!r}")
+    _, checkpoint_id, task_id, idx = parts
+    return checkpoint_id, task_id, idx
+
+
+def _put_chunked(entity: dict[str, Any], prefix: str, type_: str, data: bytes) -> None:
+    """Split *data* across ``{prefix}_0``, ``{prefix}_1``, ... properties.
+
+    Table Storage caps each String/Binary property at 64 KiB and each entity
+    at 1 MiB. Splitting large payloads across multiple binary properties
+    keeps individual properties under that per-property cap; the service
+    itself will raise a clear error if the total entity size (all chunks
+    combined) exceeds the 1 MiB entity cap.
+    """
+    chunks = (
+        [data[i : i + _MAX_CHUNK_SIZE] for i in range(0, len(data), _MAX_CHUNK_SIZE)]
+        if data
+        else [b""]
+    )
+    entity[f"{prefix}_type"] = type_
+    entity[f"{prefix}_n"] = len(chunks)
+    for i, chunk in enumerate(chunks):
+        entity[f"{prefix}_{i}"] = chunk
+
+
+def _get_chunked(entity: dict[str, Any], prefix: str) -> tuple[str, bytes]:
+    """Reassemble a value previously stored with `_put_chunked`."""
+    type_ = entity[f"{prefix}_type"]
+    n = entity[f"{prefix}_n"]
+    data = b"".join(entity[f"{prefix}_{i}"] for i in range(n))
+    return type_, data
+
+
+def _checkpoint_tuple_from_entity(
+    serde: SerializerProtocol,
+    thread_id: str,
+    checkpoint_ns: str,
+    entity: dict[str, Any],
+    pending_writes: list[tuple[str, str, Any]] | None,
+) -> CheckpointTuple:
+    """Build a CheckpointTuple from a checkpoint entity."""
+    checkpoint_id = _parse_checkpoint_row_key(entity["RowKey"])
+    checkpoint = serde.loads_typed(_get_chunked(entity, "checkpoint"))
+    metadata = serde.loads_typed(_get_chunked(entity, "metadata"))
+    parent_checkpoint_id = entity.get("parent_checkpoint_id") or ""
+
+    config: RunnableConfig = {
+        "configurable": {
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+        }
+    }
+    parent_config: RunnableConfig | None = (
+        {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": parent_checkpoint_id,
+            }
+        }
+        if parent_checkpoint_id
+        else None
+    )
+    return CheckpointTuple(
+        config=config,
+        checkpoint=checkpoint,
+        metadata=metadata,
+        parent_config=parent_config,
+        pending_writes=pending_writes,
+    )
+
+
+def _checkpoint_entity(
+    serde: SerializerProtocol,
+    partition_key: str,
+    thread_id: str,
+    checkpoint_ns: str,
+    checkpoint: Checkpoint,
+    metadata: CheckpointMetadata,
+    parent_checkpoint_id: str | None,
+) -> dict[str, Any]:
+    """Build the Table Storage entity for a checkpoint `put`."""
+    entity: dict[str, Any] = {
+        "PartitionKey": partition_key,
+        "RowKey": _checkpoint_row_key(checkpoint["id"]),
+        "thread_id": thread_id,
+        "checkpoint_ns": checkpoint_ns,
+        "parent_checkpoint_id": parent_checkpoint_id or "",
+    }
+    checkpoint_type, checkpoint_data = serde.dumps_typed(checkpoint)
+    _put_chunked(entity, "checkpoint", checkpoint_type, checkpoint_data)
+    metadata_type, metadata_data = serde.dumps_typed(metadata)
+    _put_chunked(entity, "metadata", metadata_type, metadata_data)
+    return entity
+
+
+def _write_entity(
+    serde: SerializerProtocol,
+    partition_key: str,
+    checkpoint_id: str,
+    task_id: str,
+    write_idx: int,
+    channel: str,
+    value: Any,
+) -> dict[str, Any]:
+    """Build the Table Storage entity for a single pending write."""
+    entity: dict[str, Any] = {
+        "PartitionKey": partition_key,
+        "RowKey": _writes_row_key(checkpoint_id, task_id, write_idx),
+        "channel": channel,
+    }
+    type_, data = serde.dumps_typed(value)
+    _put_chunked(entity, "value", type_, data)
+    return entity
+
+
+def _checkpoints_query(partition_key: str, before_id: str | None) -> tuple[str, dict]:
+    """Build the OData filter selecting all checkpoint entities in a partition."""
+    query_filter = "PartitionKey eq @pk and RowKey ge @lo and RowKey lt @hi"
+    parameters = {
+        "pk": partition_key,
+        "lo": f"checkpoint{_KEY_SEPARATOR}",
+        "hi": f"checkpoint{_KEY_SEPARATOR}~",
+    }
+    if before_id:
+        query_filter += " and RowKey lt @before"
+        parameters["before"] = _checkpoint_row_key(before_id)
+    return query_filter, parameters
+
+
+def _writes_query(partition_key: str, checkpoint_id: str) -> tuple[str, dict]:
+    """Build the OData filter selecting all writes for one checkpoint."""
+    query_filter = "PartitionKey eq @pk and RowKey ge @lo and RowKey lt @hi"
+    parameters = {
+        "pk": partition_key,
+        "lo": f"writes{_KEY_SEPARATOR}{checkpoint_id}{_KEY_SEPARATOR}",
+        "hi": f"writes{_KEY_SEPARATOR}{checkpoint_id}{_KEY_SEPARATOR}~",
+    }
+    return query_filter, parameters
+
+
+def _sort_writes(entities: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort write entities by their numeric idx (RowKey order is lexical)."""
+    return sorted(entities, key=lambda e: int(_parse_writes_row_key(e["RowKey"])[2]))
+
+
+def _writes_from_entities(
+    serde: SerializerProtocol, entities: Sequence[dict[str, Any]]
+) -> list[tuple[str, str, Any]]:
+    """Convert sorted write entities into (task_id, channel, value) tuples."""
+    result = []
+    for entity in _sort_writes(entities):
+        task_id = _parse_writes_row_key(entity["RowKey"])[1]
+        value = serde.loads_typed(_get_chunked(entity, "value"))
+        result.append((task_id, entity["channel"], value))
+    return result
+
+
+class AzureTableStorageSaver(BaseCheckpointSaver):
+    """LangGraph checkpoint saver backed by Azure Table Storage.
+
+    Stores both checkpoints and pending writes as entities in a single Azure
+    Table, partitioned by ``thread_id``/``checkpoint_ns``. Large checkpoint,
+    metadata, and write payloads are transparently split across multiple
+    entity properties to work around Table Storage's 64 KiB per-property
+    limit; the (rarely hit) 1 MiB per-entity limit is enforced by the
+    service itself.
+
+    The underlying Azure SDK clients are created lazily on first use and
+    cached; call :meth:`close`/:meth:`aclose` (or use the saver as a context
+    manager) to release them.
+
+    Example:
+        >>> from langchain_azure_storage.checkpoint import AzureTableStorageSaver
+        >>> saver = AzureTableStorageSaver(
+        ...     endpoint="https://<account>.table.core.windows.net",
+        ...     table_name="checkpoints",
+        ... )
+        >>> config = {"configurable": {"thread_id": "thread-1"}}
+        >>> checkpoint_tuple = saver.get_tuple(config)
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        table_name: str,
+        *,
+        credential: _SDK_CREDENTIAL_TYPE = None,
+        serde: SerializerProtocol | None = None,
+    ) -> None:
+        """Create a new saver authenticating via endpoint + credential.
+
+        Use :meth:`from_connection_string` instead to authenticate with a
+        connection string (e.g. for the Azurite emulator).
+
+        Args:
+            endpoint: Table service endpoint, e.g.
+                ``https://<account>.table.core.windows.net``.
+            table_name: Name of the table to store checkpoints in. Created
+                automatically on first use if it doesn't already exist.
+            credential: Credential to authenticate with. If ``None``,
+                ``DefaultAzureCredential`` is used.
+            serde: Optional custom serializer.
+        """
+        super().__init__(serde=serde)
+        self._endpoint = endpoint
+        self._table_name = table_name
+        self._credential = credential
+        self._connection_string: str | None = None
+        self._sync_table_client: TableClient | None = None
+        self._async_table_client: AsyncTableClient | None = None
+        self._sync_owned_credential: Any | None = None
+        self._async_owned_credential: Any | None = None
+        self._sync_lock = threading.Lock()
+        self._async_lock = asyncio.Lock()
+
+    @classmethod
+    def from_connection_string(
+        cls,
+        connection_string: str,
+        table_name: str,
+        *,
+        serde: SerializerProtocol | None = None,
+    ) -> "AzureTableStorageSaver":
+        """Create a new saver authenticating via a connection string.
+
+        Intended for the `Azurite <https://learn.microsoft.com/azure/storage/common/storage-use-azurite>`_
+        emulator, or any account where a connection string is more
+        convenient than ``endpoint`` + ``credential``.
+
+        Args:
+            connection_string: Full connection string (e.g. from the Azure
+                portal, or for the Azurite emulator).
+            table_name: Name of the table to store checkpoints in.
+            serde: Optional custom serializer.
+
+        Returns:
+            A new ``AzureTableStorageSaver`` authenticating via
+            *connection_string*.
+        """
+        saver = cls("", table_name, serde=serde)
+        saver._connection_string = connection_string
+        return saver
+
+    # ------------------------------------------------------------------ #
+    # Resource lifecycle                                                  #
+    # ------------------------------------------------------------------ #
+
+    def _resolve_sync_credential(
+        self, provided_credential: _SDK_CREDENTIAL_TYPE
+    ) -> _SYNC_CREDENTIAL_TYPE:
+        if provided_credential is None:
+            credential = azure.identity.DefaultAzureCredential()
+            self._sync_owned_credential = credential
+            return credential
+        if isinstance(
+            provided_credential, azure.core.credentials_async.AsyncTokenCredential
+        ):
+            raise ValueError(
+                "Cannot use synchronous methods when AzureTableStorageSaver is "
+                "instantiated with an AsyncTokenCredential. Use the async "
+                "methods instead, or supply a synchronous credential."
+            )
+        return provided_credential
+
+    async def _resolve_async_credential(
+        self, provided_credential: _SDK_CREDENTIAL_TYPE
+    ) -> _ASYNC_CREDENTIAL_TYPE:
+        if provided_credential is None:
+            credential = azure.identity.aio.DefaultAzureCredential()
+            self._async_owned_credential = credential
+            return credential
+        if not isinstance(
+            provided_credential,
+            (
+                azure.core.credentials_async.AsyncTokenCredential,
+                azure.core.credentials.AzureSasCredential,
+                azure.core.credentials.AzureNamedKeyCredential,
+            ),
+        ):
+            raise ValueError(
+                "Cannot use asynchronous methods when AzureTableStorageSaver is "
+                "instantiated with a synchronous TokenCredential. Use the sync "
+                "methods instead, or supply an AsyncTokenCredential."
+            )
+        return provided_credential
+
+    def _get_sync_table(self) -> TableClient:
+        """Return the cached sync table client, creating it on first use."""
+        if self._sync_table_client is not None:
+            return self._sync_table_client
+        with self._sync_lock:
+            if self._sync_table_client is not None:
+                return self._sync_table_client
+            if self._connection_string:
+                client = TableClient.from_connection_string(
+                    self._connection_string,
+                    self._table_name,
+                    user_agent=USER_AGENT,
+                )
+            else:
+                credential = self._resolve_sync_credential(self._credential)
+                client = TableClient(
+                    self._endpoint,
+                    self._table_name,
+                    credential=credential,
+                    user_agent=USER_AGENT,
+                )
+            try:
+                client.create_table()
+            except ResourceExistsError:
+                pass
+            self._sync_table_client = client
+            return client
+
+    async def _get_async_table(self) -> AsyncTableClient:
+        """Return the cached async table client, creating it on first use."""
+        if self._async_table_client is not None:
+            return self._async_table_client
+        async with self._async_lock:
+            if self._async_table_client is not None:
+                return self._async_table_client
+            if self._connection_string:
+                client = AsyncTableClient.from_connection_string(
+                    self._connection_string,
+                    self._table_name,
+                    user_agent=USER_AGENT,
+                )
+            else:
+                credential = await self._resolve_async_credential(self._credential)
+                client = AsyncTableClient(
+                    self._endpoint,
+                    self._table_name,
+                    credential=credential,
+                    user_agent=USER_AGENT,
+                )
+            try:
+                await client.create_table()
+            except ResourceExistsError:
+                pass
+            self._async_table_client = client
+            return client
+
+    def close(self) -> None:
+        """Close the cached sync table client and any credential it owns."""
+        if self._sync_table_client is not None:
+            self._sync_table_client.close()
+            self._sync_table_client = None
+        if self._sync_owned_credential is not None:
+            self._sync_owned_credential.close()
+            self._sync_owned_credential = None
+
+    async def aclose(self) -> None:
+        """Close the cached async table client and any credential it owns."""
+        if self._async_table_client is not None:
+            await self._async_table_client.close()
+            self._async_table_client = None
+        if self._async_owned_credential is not None:
+            await self._async_owned_credential.close()
+            self._async_owned_credential = None
+
+    def __enter__(self) -> "AzureTableStorageSaver":
+        """Enter the context manager, returning this saver."""
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        """Exit the context manager, calling `close()`."""
+        self.close()
+
+    async def __aenter__(self) -> "AzureTableStorageSaver":
+        """Enter the async context manager, returning this saver."""
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        """Exit the async context manager, calling `aclose()`."""
+        await self.aclose()
+
+    # ------------------------------------------------------------------ #
+    # Sync methods                                                        #
+    # ------------------------------------------------------------------ #
+
+    def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        """Fetch a checkpoint tuple from Azure Table Storage.
+
+        Args:
+            config: Configuration specifying which checkpoint to retrieve.
+
+        Returns:
+            The requested checkpoint tuple, or None if not found.
+        """
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
+        checkpoint_id = get_checkpoint_id(config)
+        _validate_key_part(thread_id, "thread_id")
+        _validate_key_part(checkpoint_ns, "checkpoint_ns")
+
+        partition_key = _partition_key(thread_id, checkpoint_ns)
+        table = self._get_sync_table()
+
+        if checkpoint_id:
+            try:
+                entity = table.get_entity(
+                    partition_key, _checkpoint_row_key(checkpoint_id)
+                )
+            except ResourceNotFoundError:
+                return None
+        else:
+            query_filter, parameters = _checkpoints_query(partition_key, None)
+            row_keys = [
+                e["RowKey"]
+                for e in table.query_entities(
+                    query_filter,
+                    parameters=parameters,
+                    select=["PartitionKey", "RowKey"],
+                )
+            ]
+            if not row_keys:
+                return None
+            entity = table.get_entity(partition_key, max(row_keys))
+            checkpoint_id = _parse_checkpoint_row_key(entity["RowKey"])
+
+        write_filter, write_parameters = _writes_query(partition_key, checkpoint_id)
+        pending_writes = _writes_from_entities(
+            self.serde,
+            list(table.query_entities(write_filter, parameters=write_parameters)),
+        )
+        return _checkpoint_tuple_from_entity(
+            self.serde, thread_id, checkpoint_ns, entity, pending_writes
+        )
+
+    def list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> Iterator[CheckpointTuple]:
+        """List checkpoints from Azure Table Storage.
+
+        Args:
+            config: Base configuration for filtering checkpoints.
+            filter: Additional filtering criteria.
+            before: List checkpoints created before this configuration.
+            limit: Maximum number of checkpoints to return.
+
+        Yields:
+            Matching checkpoint tuples, most recent first.
+        """
+        if not config:
+            return
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
+        _validate_key_part(thread_id, "thread_id")
+        _validate_key_part(checkpoint_ns, "checkpoint_ns")
+        if limit is not None and limit < 1:
+            raise ValueError("limit must be a positive integer")
+
+        partition_key = _partition_key(thread_id, checkpoint_ns)
+        before_id = get_checkpoint_id(before) if before else None
+        table = self._get_sync_table()
+
+        query_filter, parameters = _checkpoints_query(partition_key, before_id)
+        entities = list(table.query_entities(query_filter, parameters=parameters))
+        # ponytail: Table Storage has no server-side ORDER BY, so results are
+        # sorted client-side. Fine for typical per-thread history sizes; add
+        # a secondary index (or server-side paging) if a thread ever
+        # accumulates enough checkpoints for this to matter.
+        entities.sort(key=lambda e: e["RowKey"], reverse=True)
+
+        count = 0
+        for entity in entities:
+            checkpoint_tuple = _checkpoint_tuple_from_entity(
+                self.serde, thread_id, checkpoint_ns, entity, pending_writes=None
+            )
+            if filter:
+                metadata = checkpoint_tuple.metadata or {}
+                if not all(metadata.get(k) == v for k, v in filter.items()):
+                    continue
+
+            checkpoint_id = _parse_checkpoint_row_key(entity["RowKey"])
+            write_filter, write_parameters = _writes_query(partition_key, checkpoint_id)
+            pending_writes = _writes_from_entities(
+                self.serde,
+                list(table.query_entities(write_filter, parameters=write_parameters)),
+            )
+            yield CheckpointTuple(
+                config=checkpoint_tuple.config,
+                checkpoint=checkpoint_tuple.checkpoint,
+                metadata=checkpoint_tuple.metadata,
+                parent_config=checkpoint_tuple.parent_config,
+                pending_writes=pending_writes,
+            )
+            count += 1
+            if limit is not None and count >= limit:
+                return
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Save a checkpoint to Azure Table Storage.
+
+        Args:
+            config: Configuration for the checkpoint.
+            checkpoint: The checkpoint to store.
+            metadata: Additional metadata for the checkpoint.
+            new_versions: New channel versions as of this write.
+
+        Returns:
+            Updated configuration after storing the checkpoint.
+        """
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"]["checkpoint_ns"]
+        _validate_key_part(thread_id, "thread_id")
+        _validate_key_part(checkpoint_ns, "checkpoint_ns")
+        _validate_key_part(checkpoint["id"], "checkpoint_id")
+
+        partition_key = _partition_key(thread_id, checkpoint_ns)
+        entity = _checkpoint_entity(
+            self.serde,
+            partition_key,
+            thread_id,
+            checkpoint_ns,
+            checkpoint,
+            metadata,
+            config["configurable"].get("checkpoint_id"),
+        )
+        table = self._get_sync_table()
+        table.upsert_entity(entity, mode=UpdateMode.REPLACE)
+
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Store intermediate writes linked to a checkpoint.
+
+        Args:
+            config: Configuration of the related checkpoint.
+            writes: List of writes to store.
+            task_id: Identifier for the task creating the writes.
+            task_path: Path of the task creating the writes (not persisted).
+        """
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"]["checkpoint_ns"]
+        checkpoint_id = config["configurable"]["checkpoint_id"]
+        _validate_key_part(thread_id, "thread_id")
+        _validate_key_part(checkpoint_ns, "checkpoint_ns")
+        _validate_key_part(checkpoint_id, "checkpoint_id")
+        _validate_key_part(task_id, "task_id")
+
+        partition_key = _partition_key(thread_id, checkpoint_ns)
+        is_upsert = all(w[0] in WRITES_IDX_MAP for w in writes)
+        table = self._get_sync_table()
+
+        for idx, (channel, value) in enumerate(writes):
+            write_idx = WRITES_IDX_MAP.get(channel, idx)
+            entity = _write_entity(
+                self.serde,
+                partition_key,
+                checkpoint_id,
+                task_id,
+                write_idx,
+                channel,
+                value,
+            )
+            if is_upsert:
+                table.upsert_entity(entity, mode=UpdateMode.REPLACE)
+            else:
+                try:
+                    table.create_entity(entity)
+                except ResourceExistsError:
+                    pass
+
+    # ------------------------------------------------------------------ #
+    # Async methods                                                       #
+    # ------------------------------------------------------------------ #
+
+    async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        """Fetch a checkpoint tuple from Azure Table Storage asynchronously.
+
+        Args:
+            config: Configuration specifying which checkpoint to retrieve.
+
+        Returns:
+            The requested checkpoint tuple, or None if not found.
+        """
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
+        checkpoint_id = get_checkpoint_id(config)
+        _validate_key_part(thread_id, "thread_id")
+        _validate_key_part(checkpoint_ns, "checkpoint_ns")
+
+        partition_key = _partition_key(thread_id, checkpoint_ns)
+        table = await self._get_async_table()
+
+        if checkpoint_id:
+            try:
+                entity = await table.get_entity(
+                    partition_key, _checkpoint_row_key(checkpoint_id)
+                )
+            except ResourceNotFoundError:
+                return None
+        else:
+            query_filter, parameters = _checkpoints_query(partition_key, None)
+            row_keys = [
+                e["RowKey"]
+                async for e in table.query_entities(
+                    query_filter,
+                    parameters=parameters,
+                    select=["PartitionKey", "RowKey"],
+                )
+            ]
+            if not row_keys:
+                return None
+            entity = await table.get_entity(partition_key, max(row_keys))
+            checkpoint_id = _parse_checkpoint_row_key(entity["RowKey"])
+
+        write_filter, write_parameters = _writes_query(partition_key, checkpoint_id)
+        write_entities = [
+            e
+            async for e in table.query_entities(
+                write_filter, parameters=write_parameters
+            )
+        ]
+        pending_writes = _writes_from_entities(self.serde, write_entities)
+        return _checkpoint_tuple_from_entity(
+            self.serde, thread_id, checkpoint_ns, entity, pending_writes
+        )
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        """List checkpoints from Azure Table Storage asynchronously.
+
+        Args:
+            config: Base configuration for filtering checkpoints.
+            filter: Additional filtering criteria.
+            before: List checkpoints created before this configuration.
+            limit: Maximum number of checkpoints to return.
+
+        Yields:
+            Matching checkpoint tuples, most recent first.
+        """
+        if not config:
+            return
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
+        _validate_key_part(thread_id, "thread_id")
+        _validate_key_part(checkpoint_ns, "checkpoint_ns")
+        if limit is not None and limit < 1:
+            raise ValueError("limit must be a positive integer")
+
+        partition_key = _partition_key(thread_id, checkpoint_ns)
+        before_id = get_checkpoint_id(before) if before else None
+        table = await self._get_async_table()
+
+        query_filter, parameters = _checkpoints_query(partition_key, before_id)
+        entities = [
+            e async for e in table.query_entities(query_filter, parameters=parameters)
+        ]
+        entities.sort(key=lambda e: e["RowKey"], reverse=True)
+
+        count = 0
+        for entity in entities:
+            checkpoint_tuple = _checkpoint_tuple_from_entity(
+                self.serde, thread_id, checkpoint_ns, entity, pending_writes=None
+            )
+            if filter:
+                metadata = checkpoint_tuple.metadata or {}
+                if not all(metadata.get(k) == v for k, v in filter.items()):
+                    continue
+
+            checkpoint_id = _parse_checkpoint_row_key(entity["RowKey"])
+            write_filter, write_parameters = _writes_query(partition_key, checkpoint_id)
+            write_entities = [
+                e
+                async for e in table.query_entities(
+                    write_filter, parameters=write_parameters
+                )
+            ]
+            pending_writes = _writes_from_entities(self.serde, write_entities)
+            yield CheckpointTuple(
+                config=checkpoint_tuple.config,
+                checkpoint=checkpoint_tuple.checkpoint,
+                metadata=checkpoint_tuple.metadata,
+                parent_config=checkpoint_tuple.parent_config,
+                pending_writes=pending_writes,
+            )
+            count += 1
+            if limit is not None and count >= limit:
+                return
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Save a checkpoint to Azure Table Storage asynchronously.
+
+        Args:
+            config: Configuration for the checkpoint.
+            checkpoint: The checkpoint to store.
+            metadata: Additional metadata for the checkpoint.
+            new_versions: New channel versions as of this write.
+
+        Returns:
+            Updated configuration after storing the checkpoint.
+        """
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"]["checkpoint_ns"]
+        _validate_key_part(thread_id, "thread_id")
+        _validate_key_part(checkpoint_ns, "checkpoint_ns")
+        _validate_key_part(checkpoint["id"], "checkpoint_id")
+
+        partition_key = _partition_key(thread_id, checkpoint_ns)
+        entity = _checkpoint_entity(
+            self.serde,
+            partition_key,
+            thread_id,
+            checkpoint_ns,
+            checkpoint,
+            metadata,
+            config["configurable"].get("checkpoint_id"),
+        )
+        table = await self._get_async_table()
+        await table.upsert_entity(entity, mode=UpdateMode.REPLACE)
+
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint["id"],
+            }
+        }
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Store intermediate writes linked to a checkpoint asynchronously.
+
+        Args:
+            config: Configuration of the related checkpoint.
+            writes: List of writes to store.
+            task_id: Identifier for the task creating the writes.
+            task_path: Path of the task creating the writes (not persisted).
+        """
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"]["checkpoint_ns"]
+        checkpoint_id = config["configurable"]["checkpoint_id"]
+        _validate_key_part(thread_id, "thread_id")
+        _validate_key_part(checkpoint_ns, "checkpoint_ns")
+        _validate_key_part(checkpoint_id, "checkpoint_id")
+        _validate_key_part(task_id, "task_id")
+
+        partition_key = _partition_key(thread_id, checkpoint_ns)
+        is_upsert = all(w[0] in WRITES_IDX_MAP for w in writes)
+        table = await self._get_async_table()
+
+        for idx, (channel, value) in enumerate(writes):
+            write_idx = WRITES_IDX_MAP.get(channel, idx)
+            entity = _write_entity(
+                self.serde,
+                partition_key,
+                checkpoint_id,
+                task_id,
+                write_idx,
+                channel,
+                value,
+            )
+            if is_upsert:
+                await table.upsert_entity(entity, mode=UpdateMode.REPLACE)
+            else:
+                try:
+                    await table.create_entity(entity)
+                except ResourceExistsError:
+                    pass
+
+
+__all__ = ["AzureTableStorageSaver"]

--- a/libs/azure-storage/pyproject.toml
+++ b/libs/azure-storage/pyproject.toml
@@ -22,10 +22,13 @@ classifiers = [
 ]
 
 dependencies = [
+    "aiohttp>=3.14.1",
     "azure-core>=1.38.0",
+    "azure-data-tables>=12.7.0,<13.0",
     "azure-identity~=1.25",
     "azure-storage-blob[aio]~=12.26",
     "langchain-core>=1.2.5,<2.0",
+    "langgraph-checkpoint>=2.1.2,<5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/libs/azure-storage/tests/integration_tests/conftest.py
+++ b/libs/azure-storage/tests/integration_tests/conftest.py
@@ -11,6 +11,13 @@ emulator such as Azurite:
 When both are set, the account URL takes precedence. The document loader tests
 require ``AZURE_STORAGE_ACCOUNT_URL`` (the document loaders do not support
 connection strings).
+
+The Azure Table Storage checkpointer tests additionally accept
+``AZURE_STORAGE_TABLE_ENDPOINT`` (e.g.
+``https://<account>.table.core.windows.net``) for the live-account path, since
+the table service endpoint isn't derivable from ``AZURE_STORAGE_ACCOUNT_URL``
+(a blob endpoint). They fall back to ``AZURE_STORAGE_CONNECTION_STRING`` for
+Azurite, which is account-wide and already covers the table service.
 """
 
 from __future__ import annotations
@@ -37,6 +44,11 @@ def account_url() -> Optional[str]:
 @pytest.fixture(scope="session")
 def connection_string() -> Optional[str]:
     return os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+
+
+@pytest.fixture(scope="session")
+def table_endpoint() -> Optional[str]:
+    return os.environ.get("AZURE_STORAGE_TABLE_ENDPOINT")
 
 
 @pytest.fixture(scope="session")

--- a/libs/azure-storage/tests/integration_tests/test_checkpoint.py
+++ b/libs/azure-storage/tests/integration_tests/test_checkpoint.py
@@ -1,0 +1,226 @@
+# type: ignore
+"""Integration tests for the Azure Table Storage LangGraph checkpointer.
+
+These run against a live storage account or the Azurite emulator; see
+``conftest.py`` for the environment variables that select the target.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Optional
+
+import pytest
+from azure.data.tables import TableServiceClient
+from azure.data.tables.aio import TableServiceClient as AsyncTableServiceClient
+from azure.identity import DefaultAzureCredential
+
+from langchain_azure_storage.checkpoint import AzureTableStorageSaver
+
+pytestmark = pytest.mark.skipif(
+    not (
+        os.environ.get("AZURE_STORAGE_TABLE_ENDPOINT")
+        or os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+    ),
+    reason=(
+        "Set AZURE_STORAGE_TABLE_ENDPOINT (live account) or "
+        "AZURE_STORAGE_CONNECTION_STRING (e.g. Azurite) to run these tests."
+    ),
+)
+
+
+def _table_name() -> str:
+    return f"testcp{uuid.uuid4().hex[:20]}"
+
+
+@pytest.fixture
+def sync_saver(
+    table_endpoint: Optional[str], connection_string: Optional[str]
+) -> Iterator[AzureTableStorageSaver]:
+    table_name = _table_name()
+    if table_endpoint:
+        saver = AzureTableStorageSaver(
+            table_endpoint, table_name, credential=DefaultAzureCredential()
+        )
+    else:
+        assert connection_string is not None
+        saver = AzureTableStorageSaver.from_connection_string(
+            connection_string, table_name
+        )
+    yield saver
+    saver.close()
+    _delete_table_sync(table_name, table_endpoint, connection_string)
+
+
+@pytest.fixture
+async def async_saver(
+    table_endpoint: Optional[str], connection_string: Optional[str]
+) -> AsyncIterator[AzureTableStorageSaver]:
+    table_name = _table_name()
+    if table_endpoint:
+        from azure.identity.aio import (
+            DefaultAzureCredential as AsyncDefaultAzureCredential,
+        )
+
+        saver = AzureTableStorageSaver(
+            table_endpoint, table_name, credential=AsyncDefaultAzureCredential()
+        )
+    else:
+        assert connection_string is not None
+        saver = AzureTableStorageSaver.from_connection_string(
+            connection_string, table_name
+        )
+    yield saver
+    await saver.aclose()
+    await _delete_table_async(table_name, table_endpoint, connection_string)
+
+
+def _delete_table_sync(
+    table_name: str, table_endpoint: Optional[str], connection_string: Optional[str]
+) -> None:
+    if table_endpoint:
+        client = TableServiceClient(table_endpoint, credential=DefaultAzureCredential())
+    else:
+        assert connection_string is not None
+        client = TableServiceClient.from_connection_string(connection_string)
+    with client:
+        client.delete_table(table_name)
+
+
+async def _delete_table_async(
+    table_name: str, table_endpoint: Optional[str], connection_string: Optional[str]
+) -> None:
+    if table_endpoint:
+        from azure.identity.aio import (
+            DefaultAzureCredential as AsyncDefaultAzureCredential,
+        )
+
+        client = AsyncTableServiceClient(
+            table_endpoint, credential=AsyncDefaultAzureCredential()
+        )
+    else:
+        assert connection_string is not None
+        client = AsyncTableServiceClient.from_connection_string(connection_string)
+    async with client:
+        await client.delete_table(table_name)
+
+
+def _checkpoint(cp_id: str, **channel_values: object) -> dict:
+    return {
+        "v": 1,
+        "id": cp_id,
+        "ts": "2024-01-01T00:00:00.000000+00:00",
+        "channel_values": channel_values,
+        "channel_versions": dict.fromkeys(channel_values, 1),
+        "versions_seen": {},
+        "updated_channels": None,
+    }
+
+
+def test_sync_put_and_get_tuple(sync_saver: AzureTableStorageSaver) -> None:
+    tid = f"sync_{uuid.uuid4().hex[:8]}"
+    cpid = f"cp_{uuid.uuid4().hex[:8]}"
+    config = {
+        "configurable": {"thread_id": tid, "checkpoint_ns": "", "checkpoint_id": cpid}
+    }
+
+    result_config = sync_saver.put(
+        config, _checkpoint(cpid, test_key="test_value"), {"source": "input"}, {}
+    )
+    assert result_config["configurable"]["thread_id"] == tid
+
+    retrieved = sync_saver.get_tuple(config)
+    assert retrieved is not None
+    assert retrieved.checkpoint["id"] == cpid
+    assert retrieved.checkpoint["channel_values"] == {"test_key": "test_value"}
+    assert retrieved.metadata["source"] == "input"
+
+
+def test_sync_list_orders_most_recent_first(sync_saver: AzureTableStorageSaver) -> None:
+    tid = f"sync_list_{uuid.uuid4().hex[:8]}"
+    cp_ids = [f"cp_{i:03d}_{uuid.uuid4().hex[:8]}" for i in range(3)]
+    for cp_id in cp_ids:
+        config = {"configurable": {"thread_id": tid, "checkpoint_ns": ""}}
+        sync_saver.put(config, _checkpoint(cp_id), {}, {})
+
+    list_config = {"configurable": {"thread_id": tid, "checkpoint_ns": ""}}
+    checkpoints = list(sync_saver.list(list_config))
+    assert [c.checkpoint["id"] for c in checkpoints] == list(reversed(cp_ids))
+
+
+def test_sync_put_writes_and_get_tuple(sync_saver: AzureTableStorageSaver) -> None:
+    tid = f"sync_writes_{uuid.uuid4().hex[:8]}"
+    cpid = f"cp_{uuid.uuid4().hex[:8]}"
+    config = {
+        "configurable": {"thread_id": tid, "checkpoint_ns": "", "checkpoint_id": cpid}
+    }
+    sync_saver.put(config, _checkpoint(cpid), {}, {})
+    sync_saver.put_writes(config, [("channel_a", "value_a")], "task-1")
+
+    retrieved = sync_saver.get_tuple(config)
+    assert retrieved is not None
+    assert retrieved.pending_writes == [("task-1", "channel_a", "value_a")]
+
+
+def test_sync_large_checkpoint_round_trips(sync_saver: AzureTableStorageSaver) -> None:
+    tid = f"sync_large_{uuid.uuid4().hex[:8]}"
+    cpid = f"cp_{uuid.uuid4().hex[:8]}"
+    config = {
+        "configurable": {"thread_id": tid, "checkpoint_ns": "", "checkpoint_id": cpid}
+    }
+    big_value = "z" * (150 * 1024)  # forces multi-chunk storage
+
+    sync_saver.put(config, _checkpoint(cpid, data=big_value), {}, {})
+    retrieved = sync_saver.get_tuple(config)
+    assert retrieved is not None
+    assert retrieved.checkpoint["channel_values"]["data"] == big_value
+
+
+async def test_async_put_and_get_tuple(async_saver: AzureTableStorageSaver) -> None:
+    tid = f"async_{uuid.uuid4().hex[:8]}"
+    cpid = f"cp_{uuid.uuid4().hex[:8]}"
+    config = {
+        "configurable": {"thread_id": tid, "checkpoint_ns": "", "checkpoint_id": cpid}
+    }
+
+    result_config = await async_saver.aput(
+        config, _checkpoint(cpid, test_key="async_value"), {"source": "input"}, {}
+    )
+    assert result_config["configurable"]["thread_id"] == tid
+
+    retrieved = await async_saver.aget_tuple(config)
+    assert retrieved is not None
+    assert retrieved.checkpoint["id"] == cpid
+    assert retrieved.checkpoint["channel_values"] == {"test_key": "async_value"}
+
+
+async def test_async_list_orders_most_recent_first(
+    async_saver: AzureTableStorageSaver,
+) -> None:
+    tid = f"async_list_{uuid.uuid4().hex[:8]}"
+    cp_ids = [f"cp_{i:03d}_{uuid.uuid4().hex[:8]}" for i in range(2)]
+    for cp_id in cp_ids:
+        config = {"configurable": {"thread_id": tid, "checkpoint_ns": ""}}
+        await async_saver.aput(config, _checkpoint(cp_id), {}, {})
+
+    list_config = {"configurable": {"thread_id": tid, "checkpoint_ns": ""}}
+    checkpoints = [c async for c in async_saver.alist(list_config)]
+    assert [c.checkpoint["id"] for c in checkpoints] == list(reversed(cp_ids))
+
+
+async def test_async_put_writes_and_get_tuple(
+    async_saver: AzureTableStorageSaver,
+) -> None:
+    tid = f"async_writes_{uuid.uuid4().hex[:8]}"
+    cpid = f"cp_{uuid.uuid4().hex[:8]}"
+    config = {
+        "configurable": {"thread_id": tid, "checkpoint_ns": "", "checkpoint_id": cpid}
+    }
+    await async_saver.aput(config, _checkpoint(cpid), {}, {})
+    await async_saver.aput_writes(config, [("channel_a", "value_a")], "task-1")
+
+    retrieved = await async_saver.aget_tuple(config)
+    assert retrieved is not None
+    assert retrieved.pending_writes == [("task-1", "channel_a", "value_a")]

--- a/libs/azure-storage/tests/unit_tests/test_checkpoint.py
+++ b/libs/azure-storage/tests/unit_tests/test_checkpoint.py
@@ -1,0 +1,747 @@
+"""Unit tests for the Azure Table Storage LangGraph checkpointer."""
+
+from __future__ import annotations
+
+from typing import Any, Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from azure.core.credentials import AzureNamedKeyCredential, AzureSasCredential
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
+from azure.identity import DefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential as AsyncDefaultAzureCredential
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import Checkpoint
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+from langchain_azure_storage.checkpoint import (
+    AzureTableStorageSaver,
+    _checkpoint_row_key,
+    _checkpoints_query,
+    _get_chunked,
+    _parse_checkpoint_row_key,
+    _parse_writes_row_key,
+    _partition_key,
+    _put_chunked,
+    _sort_writes,
+    _validate_key_part,
+    _writes_from_entities,
+    _writes_query,
+    _writes_row_key,
+)
+
+# ---------------------------------------------------------------------------
+# Pure helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestValidateKeyPart:
+    def test_allows_normal_string(self) -> None:
+        _validate_key_part("thread-123", "thread_id")  # no raise
+
+    def test_allows_empty_string(self) -> None:
+        _validate_key_part("", "checkpoint_ns")  # no raise
+
+    def test_rejects_separator(self) -> None:
+        with pytest.raises(ValueError, match="separator"):
+            _validate_key_part("a$b", "thread_id")
+
+    @pytest.mark.parametrize("bad_char", ["/", "\\", "#", "?"])
+    def test_rejects_table_storage_forbidden_chars(self, bad_char: str) -> None:
+        with pytest.raises(ValueError, match="Table Storage key restrictions"):
+            _validate_key_part(f"a{bad_char}b", "thread_id")
+
+    def test_rejects_control_characters(self) -> None:
+        with pytest.raises(ValueError, match="Table Storage key restrictions"):
+            _validate_key_part("a\tb", "thread_id")
+
+
+class TestKeyBuilders:
+    def test_partition_key(self) -> None:
+        assert _partition_key("t1", "ns1") == "t1$ns1"
+
+    def test_partition_key_empty_ns(self) -> None:
+        assert _partition_key("t1", "") == "t1$"
+
+    def test_checkpoint_row_key_round_trip(self) -> None:
+        row_key = _checkpoint_row_key("cp1")
+        assert row_key == "checkpoint$cp1"
+        assert _parse_checkpoint_row_key(row_key) == "cp1"
+
+    def test_parse_checkpoint_row_key_invalid(self) -> None:
+        with pytest.raises(ValueError, match="Invalid checkpoint row key"):
+            _parse_checkpoint_row_key("writes$cp1")
+
+    def test_writes_row_key_with_idx_round_trip(self) -> None:
+        row_key = _writes_row_key("cp1", "task1", 0)
+        assert row_key == "writes$cp1$task1$0"
+        assert _parse_writes_row_key(row_key) == ("cp1", "task1", "0")
+
+    def test_writes_row_key_negative_idx(self) -> None:
+        row_key = _writes_row_key("cp1", "task1", -1)
+        assert row_key == "writes$cp1$task1$-1"
+        assert _parse_writes_row_key(row_key) == ("cp1", "task1", "-1")
+
+    def test_writes_row_key_without_idx(self) -> None:
+        assert _writes_row_key("cp1", "task1", None) == "writes$cp1$task1"
+
+    def test_parse_writes_row_key_invalid(self) -> None:
+        with pytest.raises(ValueError, match="Invalid writes row key"):
+            _parse_writes_row_key("checkpoint$cp1$task1$0")
+
+
+class TestChunking:
+    def test_round_trip_empty_bytes(self) -> None:
+        entity: dict[str, Any] = {}
+        _put_chunked(entity, "checkpoint", "json", b"")
+        assert entity["checkpoint_n"] == 1
+        assert _get_chunked(entity, "checkpoint") == ("json", b"")
+
+    def test_round_trip_small_value(self) -> None:
+        entity: dict[str, Any] = {}
+        _put_chunked(entity, "checkpoint", "json", b"hello world")
+        assert entity["checkpoint_n"] == 1
+        assert _get_chunked(entity, "checkpoint") == ("json", b"hello world")
+
+    def test_round_trip_multi_chunk_value(self) -> None:
+        # Larger than the 63 KiB per-chunk size, so this must split.
+        data = b"x" * (63 * 1024 + 100)
+        entity: dict[str, Any] = {}
+        _put_chunked(entity, "checkpoint", "bytes", data)
+        assert entity["checkpoint_n"] == 2
+        assert _get_chunked(entity, "checkpoint") == ("bytes", data)
+
+    def test_round_trip_exact_chunk_boundary(self) -> None:
+        data = b"y" * (63 * 1024)
+        entity: dict[str, Any] = {}
+        _put_chunked(entity, "value", "bytes", data)
+        assert entity["value_n"] == 1
+        assert _get_chunked(entity, "value") == ("bytes", data)
+
+
+class TestQueryBuilders:
+    def test_checkpoints_query_without_before(self) -> None:
+        query_filter, parameters = _checkpoints_query("t1$ns1", None)
+        assert "before" not in parameters
+        assert parameters["pk"] == "t1$ns1"
+        assert parameters["lo"] == "checkpoint$"
+        assert parameters["hi"] == "checkpoint$~"
+
+    def test_checkpoints_query_with_before(self) -> None:
+        query_filter, parameters = _checkpoints_query("t1$ns1", "cp5")
+        assert "RowKey lt @before" in query_filter
+        assert parameters["before"] == "checkpoint$cp5"
+
+    def test_writes_query(self) -> None:
+        query_filter, parameters = _writes_query("t1$ns1", "cp1")
+        assert parameters["pk"] == "t1$ns1"
+        assert parameters["lo"] == "writes$cp1$"
+        assert parameters["hi"] == "writes$cp1$~"
+
+
+class TestSortWrites:
+    def test_sorts_numerically_not_lexically(self) -> None:
+        entities = [
+            {"RowKey": _writes_row_key("cp1", "task1", 10)},
+            {"RowKey": _writes_row_key("cp1", "task1", 2)},
+        ]
+        sorted_entities = _sort_writes(entities)
+        idxs = [_parse_writes_row_key(e["RowKey"])[2] for e in sorted_entities]
+        assert idxs == ["2", "10"]
+
+    def test_sorts_negative_special_channel_idx_first(self) -> None:
+        entities = [
+            {"RowKey": _writes_row_key("cp1", "task1", 0)},
+            {"RowKey": _writes_row_key("cp1", "task1", -1)},
+        ]
+        sorted_entities = _sort_writes(entities)
+        idxs = [_parse_writes_row_key(e["RowKey"])[2] for e in sorted_entities]
+        assert idxs == ["-1", "0"]
+
+
+def _serde() -> JsonPlusSerializer:
+    return JsonPlusSerializer()
+
+
+class TestWritesFromEntities:
+    def test_converts_and_orders(self) -> None:
+        serde = _serde()
+        entities = []
+        for idx, channel in [(1, "chan1"), (0, "chan0")]:
+            entity: dict[str, Any] = {
+                "RowKey": _writes_row_key("cp1", "task1", idx),
+                "channel": channel,
+            }
+            type_, data = serde.dumps_typed(f"value-{idx}")
+            _put_chunked(entity, "value", type_, data)
+            entities.append(entity)
+
+        result = _writes_from_entities(serde, entities)
+        assert result == [
+            ("task1", "chan0", "value-0"),
+            ("task1", "chan1", "value-1"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# In-memory fake TableClient/AsyncTableClient
+#
+# Understands exactly the query/entity shapes this module generates -- not a
+# general OData engine -- so tests exercise the saver's real logic
+# (chunking, key building, filtering, sorting) without a live account or the
+# Azurite emulator.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSyncTable:
+    def __init__(self) -> None:
+        self.entities: dict[tuple[str, str], dict[str, Any]] = {}
+        self.closed = False
+
+    def create_table(self) -> None:
+        pass
+
+    def upsert_entity(self, entity: dict[str, Any], mode: Any = None) -> dict[str, Any]:
+        self.entities[(entity["PartitionKey"], entity["RowKey"])] = dict(entity)
+        return {}
+
+    def create_entity(self, entity: dict[str, Any]) -> dict[str, Any]:
+        key = (entity["PartitionKey"], entity["RowKey"])
+        if key in self.entities:
+            raise ResourceExistsError("entity already exists")
+        self.entities[key] = dict(entity)
+        return {}
+
+    def get_entity(
+        self, partition_key: str, row_key: str, *, select: Any = None
+    ) -> dict[str, Any]:
+        key = (partition_key, row_key)
+        if key not in self.entities:
+            raise ResourceNotFoundError("entity not found")
+        return self._project(self.entities[key], select)
+
+    def query_entities(
+        self,
+        query_filter: str,
+        *,
+        parameters: dict[str, Any] | None = None,
+        select: Any = None,
+        results_per_page: Any = None,
+    ) -> Iterator[dict[str, Any]]:
+        parameters = parameters or {}
+        pk = parameters["pk"]
+        lo = parameters.get("lo")
+        hi = parameters.get("hi")
+        before = parameters.get("before")
+        results = []
+        for (p, r), entity in self.entities.items():
+            if p != pk:
+                continue
+            if lo is not None and not r >= lo:
+                continue
+            if hi is not None and not r < hi:
+                continue
+            if before is not None and not r < before:
+                continue
+            results.append(self._project(entity, select))
+        return iter(results)
+
+    def close(self) -> None:
+        self.closed = True
+
+    @staticmethod
+    def _project(entity: dict[str, Any], select: Any) -> dict[str, Any]:
+        if not select:
+            return dict(entity)
+        return {k: entity[k] for k in select if k in entity}
+
+
+class _FakeAsyncTable:
+    """Async adapter over `_FakeSyncTable`, sharing its backing store."""
+
+    def __init__(self, fake: _FakeSyncTable) -> None:
+        self._fake = fake
+
+    async def create_table(self) -> None:
+        self._fake.create_table()
+
+    async def upsert_entity(self, entity: dict[str, Any], mode: Any = None) -> Any:
+        return self._fake.upsert_entity(entity, mode=mode)
+
+    async def create_entity(self, entity: dict[str, Any]) -> Any:
+        return self._fake.create_entity(entity)
+
+    async def get_entity(
+        self, partition_key: str, row_key: str, *, select: Any = None
+    ) -> dict[str, Any]:
+        return self._fake.get_entity(partition_key, row_key, select=select)
+
+    def query_entities(self, query_filter: str, **kwargs: Any) -> Any:
+        items = list(self._fake.query_entities(query_filter, **kwargs))
+
+        async def _agen() -> Any:
+            for item in items:
+                yield item
+
+        return _agen()
+
+    async def close(self) -> None:
+        self._fake.close()
+
+
+def _make_sync_saver() -> tuple[AzureTableStorageSaver, _FakeSyncTable]:
+    saver = AzureTableStorageSaver("https://fake.table.core.windows.net", "checkpoints")
+    fake = _FakeSyncTable()
+    saver._sync_table_client = fake  # type: ignore[assignment]
+    return saver, fake
+
+
+def _make_async_saver() -> tuple[AzureTableStorageSaver, _FakeSyncTable]:
+    saver = AzureTableStorageSaver("https://fake.table.core.windows.net", "checkpoints")
+    fake = _FakeSyncTable()
+    saver._async_table_client = _FakeAsyncTable(fake)  # type: ignore[assignment]
+    return saver, fake
+
+
+def _checkpoint(cp_id: str, **channel_values: Any) -> Checkpoint:
+    channel_versions: dict[str, str | int | float] = dict.fromkeys(channel_values, 1)
+    return {
+        "v": 1,
+        "id": cp_id,
+        "ts": "2024-01-01T00:00:00.000000+00:00",
+        "channel_values": channel_values,
+        "channel_versions": channel_versions,
+        "versions_seen": {},
+        "updated_channels": None,
+    }
+
+
+def _config(
+    thread_id: str, checkpoint_ns: str = "", checkpoint_id: str | None = None
+) -> RunnableConfig:
+    configurable: dict[str, Any] = {
+        "thread_id": thread_id,
+        "checkpoint_ns": checkpoint_ns,
+    }
+    if checkpoint_id is not None:
+        configurable["checkpoint_id"] = checkpoint_id
+    return {"configurable": configurable}
+
+
+# ---------------------------------------------------------------------------
+# Sync: put / get_tuple / list / put_writes
+# ---------------------------------------------------------------------------
+
+
+class TestPut:
+    def test_put_stores_entity_and_returns_config(self) -> None:
+        saver, fake = _make_sync_saver()
+        config = _config("t1", "ns1")
+        result = saver.put(config, _checkpoint("cp1", step=1), {"source": "input"}, {})
+
+        assert result["configurable"] == {
+            "thread_id": "t1",
+            "checkpoint_ns": "ns1",
+            "checkpoint_id": "cp1",
+        }
+        entity = fake.entities[("t1$ns1", "checkpoint$cp1")]
+        assert entity["parent_checkpoint_id"] == ""
+
+    def test_put_records_parent_checkpoint_id(self) -> None:
+        saver, fake = _make_sync_saver()
+        config = _config("t1", "", "cp1")
+        saver.put(config, _checkpoint("cp2", step=2), {}, {})
+        entity = fake.entities[("t1$", "checkpoint$cp2")]
+        assert entity["parent_checkpoint_id"] == "cp1"
+
+    def test_put_rejects_forbidden_thread_id(self) -> None:
+        saver, _ = _make_sync_saver()
+        config = _config("t/1")
+        with pytest.raises(ValueError, match="Table Storage key restrictions"):
+            saver.put(config, _checkpoint("cp1"), {}, {})
+
+    def test_large_checkpoint_is_chunked(self) -> None:
+        saver, fake = _make_sync_saver()
+        config = _config("t1")
+        big_value = "x" * (200 * 1024)
+        saver.put(config, _checkpoint("cp1", data=big_value), {}, {})
+        entity = fake.entities[("t1$", "checkpoint$cp1")]
+        assert entity["checkpoint_n"] > 1
+
+
+class TestGetTuple:
+    def test_returns_none_when_missing(self) -> None:
+        saver, _ = _make_sync_saver()
+        assert saver.get_tuple(_config("unknown-thread")) is None
+
+    def test_round_trip_with_explicit_checkpoint_id(self) -> None:
+        saver, _ = _make_sync_saver()
+        config = _config("t1")
+        saver.put(config, _checkpoint("cp1", step=1), {"source": "input"}, {})
+
+        result = saver.get_tuple(_config("t1", "", "cp1"))
+        assert result is not None
+        assert result.checkpoint["id"] == "cp1"
+        assert result.checkpoint["channel_values"] == {"step": 1}
+        assert result.metadata["source"] == "input"
+        assert result.parent_config is None
+
+    def test_round_trip_records_parent_config(self) -> None:
+        saver, _ = _make_sync_saver()
+        saver.put(_config("t1"), _checkpoint("cp1"), {}, {})
+        saver.put(_config("t1", "", "cp1"), _checkpoint("cp2"), {}, {})
+
+        result = saver.get_tuple(_config("t1", "", "cp2"))
+        assert result is not None
+        assert result.parent_config is not None
+        assert result.parent_config["configurable"]["checkpoint_id"] == "cp1"
+
+    def test_without_checkpoint_id_returns_latest(self) -> None:
+        saver, _ = _make_sync_saver()
+        for cp_id in ["00001", "00003", "00002"]:
+            saver.put(_config("t1"), _checkpoint(cp_id), {}, {})
+
+        result = saver.get_tuple(_config("t1"))
+        assert result is not None
+        assert result.checkpoint["id"] == "00003"
+
+    def test_without_checkpoint_id_returns_none_when_empty(self) -> None:
+        saver, _ = _make_sync_saver()
+        assert saver.get_tuple(_config("t1")) is None
+
+    def test_includes_pending_writes(self) -> None:
+        saver, _ = _make_sync_saver()
+        config = saver.put(_config("t1"), _checkpoint("cp1"), {}, {})
+        saver.put_writes(config, [("chan0", "val0")], "task1")
+
+        result = saver.get_tuple(_config("t1", "", "cp1"))
+        assert result is not None
+        assert result.pending_writes == [("task1", "chan0", "val0")]
+
+
+class TestList:
+    def test_returns_empty_for_no_config(self) -> None:
+        saver, _ = _make_sync_saver()
+        assert list(saver.list(None)) == []
+
+    def test_negative_limit_raises(self) -> None:
+        saver, _ = _make_sync_saver()
+        with pytest.raises(ValueError, match="positive"):
+            list(saver.list(_config("t1"), limit=-1))
+
+    def test_zero_limit_raises(self) -> None:
+        saver, _ = _make_sync_saver()
+        with pytest.raises(ValueError, match="positive"):
+            list(saver.list(_config("t1"), limit=0))
+
+    def test_lists_most_recent_first(self) -> None:
+        saver, _ = _make_sync_saver()
+        for cp_id in ["00001", "00002", "00003"]:
+            saver.put(_config("t1"), _checkpoint(cp_id), {}, {})
+
+        results = list(saver.list(_config("t1")))
+        assert [r.checkpoint["id"] for r in results] == ["00003", "00002", "00001"]
+
+    def test_respects_limit(self) -> None:
+        saver, _ = _make_sync_saver()
+        for cp_id in ["00001", "00002", "00003"]:
+            saver.put(_config("t1"), _checkpoint(cp_id), {}, {})
+
+        results = list(saver.list(_config("t1"), limit=2))
+        assert [r.checkpoint["id"] for r in results] == ["00003", "00002"]
+
+    def test_respects_before(self) -> None:
+        saver, _ = _make_sync_saver()
+        for cp_id in ["00001", "00002", "00003"]:
+            saver.put(_config("t1"), _checkpoint(cp_id), {}, {})
+
+        before = _config("t1", "", "00003")
+        results = list(saver.list(_config("t1"), before=before))
+        assert [r.checkpoint["id"] for r in results] == ["00002", "00001"]
+
+    def test_applies_metadata_filter(self) -> None:
+        saver, _ = _make_sync_saver()
+        saver.put(_config("t1"), _checkpoint("00001"), {"step": 1}, {})
+        saver.put(_config("t1"), _checkpoint("00002"), {"step": 2}, {})
+
+        results = list(saver.list(_config("t1"), filter={"step": 2}))
+        assert [r.checkpoint["id"] for r in results] == ["00002"]
+
+    def test_isolates_by_checkpoint_ns(self) -> None:
+        saver, _ = _make_sync_saver()
+        saver.put(_config("t1", "ns-a"), _checkpoint("00001"), {}, {})
+        saver.put(_config("t1", "ns-b"), _checkpoint("00002"), {}, {})
+
+        results = list(saver.list(_config("t1", "ns-a")))
+        assert [r.checkpoint["id"] for r in results] == ["00001"]
+
+
+class TestPutWrites:
+    def test_upserts_special_channel_writes(self) -> None:
+        saver, fake = _make_sync_saver()
+        saver.put(_config("t1"), _checkpoint("cp1"), {}, {})
+        config = _config("t1", "", "cp1")
+        saver.put_writes(config, [("__error__", "boom")], "task1")
+        saver.put_writes(config, [("__error__", "boom-again")], "task1")
+
+        result = saver.get_tuple(config)
+        assert result is not None
+        # Second put_writes call overwrote the first (upsert semantics).
+        assert result.pending_writes == [("task1", "__error__", "boom-again")]
+
+    def test_normal_channel_writes_are_create_only(self) -> None:
+        saver, fake = _make_sync_saver()
+        saver.put(_config("t1"), _checkpoint("cp1"), {}, {})
+        config = _config("t1", "", "cp1")
+        saver.put_writes(config, [("chan0", "first")], "task1")
+        # A second put_writes for the same (task_id, idx) must not overwrite.
+        saver.put_writes(config, [("chan0", "second")], "task1")
+
+        result = saver.get_tuple(config)
+        assert result is not None
+        assert result.pending_writes == [("task1", "chan0", "first")]
+
+    def test_multiple_writes_ordered_by_idx(self) -> None:
+        saver, _ = _make_sync_saver()
+        saver.put(_config("t1"), _checkpoint("cp1"), {}, {})
+        config = _config("t1", "", "cp1")
+        saver.put_writes(config, [("chan0", "v0"), ("chan1", "v1")], "task1")
+
+        result = saver.get_tuple(config)
+        assert result is not None
+        assert result.pending_writes == [
+            ("task1", "chan0", "v0"),
+            ("task1", "chan1", "v1"),
+        ]
+
+    def test_rejects_forbidden_task_id(self) -> None:
+        saver, _ = _make_sync_saver()
+        config = _config("t1", "", "cp1")
+        with pytest.raises(ValueError, match="Table Storage key restrictions"):
+            saver.put_writes(config, [("chan0", "v0")], "task/1")
+
+
+# ---------------------------------------------------------------------------
+# Async: aput / aget_tuple / alist / aput_writes
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRoundTrip:
+    async def test_aput_and_aget_tuple(self) -> None:
+        saver, _ = _make_async_saver()
+        config = _config("t1")
+        result_config = await saver.aput(
+            config, _checkpoint("cp1", step=1), {"source": "input"}, {}
+        )
+        assert result_config["configurable"]["checkpoint_id"] == "cp1"
+
+        result = await saver.aget_tuple(_config("t1", "", "cp1"))
+        assert result is not None
+        assert result.checkpoint["channel_values"] == {"step": 1}
+        assert result.metadata["source"] == "input"
+
+    async def test_aget_tuple_returns_none_when_missing(self) -> None:
+        saver, _ = _make_async_saver()
+        assert await saver.aget_tuple(_config("unknown")) is None
+
+    async def test_aget_tuple_without_id_returns_latest(self) -> None:
+        saver, _ = _make_async_saver()
+        for cp_id in ["00001", "00003", "00002"]:
+            await saver.aput(_config("t1"), _checkpoint(cp_id), {}, {})
+
+        result = await saver.aget_tuple(_config("t1"))
+        assert result is not None
+        assert result.checkpoint["id"] == "00003"
+
+    async def test_alist_orders_descending_and_respects_limit(self) -> None:
+        saver, _ = _make_async_saver()
+        for cp_id in ["00001", "00002", "00003"]:
+            await saver.aput(_config("t1"), _checkpoint(cp_id), {}, {})
+
+        results = [r async for r in saver.alist(_config("t1"), limit=2)]
+        assert [r.checkpoint["id"] for r in results] == ["00003", "00002"]
+
+    async def test_alist_negative_limit_raises(self) -> None:
+        saver, _ = _make_async_saver()
+        with pytest.raises(ValueError, match="positive"):
+            async for _ in saver.alist(_config("t1"), limit=-1):
+                pass
+
+    async def test_aput_writes_then_aget_tuple_includes_pending_writes(self) -> None:
+        saver, _ = _make_async_saver()
+        config = await saver.aput(_config("t1"), _checkpoint("cp1"), {}, {})
+        await saver.aput_writes(config, [("chan0", "val0")], "task1")
+
+        result = await saver.aget_tuple(_config("t1", "", "cp1"))
+        assert result is not None
+        assert result.pending_writes == [("task1", "chan0", "val0")]
+
+    async def test_aput_writes_upsert_for_special_channels(self) -> None:
+        saver, _ = _make_async_saver()
+        await saver.aput(_config("t1"), _checkpoint("cp1"), {}, {})
+        config = _config("t1", "", "cp1")
+        await saver.aput_writes(config, [("__error__", "first")], "task1")
+        await saver.aput_writes(config, [("__error__", "second")], "task1")
+
+        result = await saver.aget_tuple(config)
+        assert result is not None
+        assert result.pending_writes == [("task1", "__error__", "second")]
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: lazy client creation, close/aclose, context managers
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_close_closes_client_and_owned_credential(self) -> None:
+        saver, fake = _make_sync_saver()
+        owned_credential = MagicMock()
+        saver._sync_owned_credential = owned_credential
+
+        saver.close()
+
+        assert fake.closed is True
+        owned_credential.close.assert_called_once()
+        assert saver._sync_table_client is None
+        assert saver._sync_owned_credential is None
+
+    def test_close_is_a_no_op_when_unused(self) -> None:
+        saver = AzureTableStorageSaver(
+            "https://fake.table.core.windows.net", "checkpoints"
+        )
+        saver.close()  # must not raise
+
+    def test_context_manager_calls_close(self) -> None:
+        saver, fake = _make_sync_saver()
+        with saver as entered:
+            assert entered is saver
+        assert fake.closed is True
+
+    async def test_aclose_closes_client_and_owned_credential(self) -> None:
+        saver, fake = _make_async_saver()
+        owned_credential = AsyncMock()
+        saver._async_owned_credential = owned_credential
+
+        await saver.aclose()
+
+        assert fake.closed is True
+        owned_credential.close.assert_awaited_once()
+        assert saver._async_table_client is None
+        assert saver._async_owned_credential is None
+
+    async def test_async_context_manager_calls_aclose(self) -> None:
+        saver, fake = _make_async_saver()
+        async with saver as entered:
+            assert entered is saver
+        assert fake.closed is True
+
+
+class TestCredentialResolution:
+    def test_sync_resolves_default_azure_credential_when_none(self) -> None:
+        saver = AzureTableStorageSaver(
+            "https://fake.table.core.windows.net", "checkpoints"
+        )
+        with patch(
+            "langchain_azure_storage.checkpoint.azure.identity.DefaultAzureCredential"
+        ) as mock_cls:
+            mock_cls.return_value = MagicMock(spec=DefaultAzureCredential)
+            credential = saver._resolve_sync_credential(None)
+            mock_cls.assert_called_once()
+            assert credential is mock_cls.return_value
+            assert saver._sync_owned_credential is credential
+
+    def test_sync_rejects_async_token_credential(self) -> None:
+        saver = AzureTableStorageSaver(
+            "https://fake.table.core.windows.net", "checkpoints"
+        )
+        async_credential = MagicMock(spec=AsyncTokenCredential)
+        with pytest.raises(ValueError, match="AsyncTokenCredential"):
+            saver._resolve_sync_credential(async_credential)
+
+    def test_sync_passes_through_sas_credential(self) -> None:
+        saver = AzureTableStorageSaver(
+            "https://fake.table.core.windows.net", "checkpoints"
+        )
+        sas = AzureSasCredential("sig")
+        assert saver._resolve_sync_credential(sas) is sas
+
+    async def test_async_resolves_default_azure_credential_when_none(self) -> None:
+        saver = AzureTableStorageSaver(
+            "https://fake.table.core.windows.net", "checkpoints"
+        )
+        with patch(
+            "langchain_azure_storage.checkpoint.azure.identity.aio.DefaultAzureCredential"
+        ) as mock_cls:
+            mock_cls.return_value = MagicMock(spec=AsyncDefaultAzureCredential)
+            credential = await saver._resolve_async_credential(None)
+            mock_cls.assert_called_once()
+            assert credential is mock_cls.return_value
+            assert saver._async_owned_credential is credential
+
+    async def test_async_rejects_sync_token_credential(self) -> None:
+        saver = AzureTableStorageSaver(
+            "https://fake.table.core.windows.net", "checkpoints"
+        )
+        sync_credential = MagicMock(spec=DefaultAzureCredential)
+        with pytest.raises(ValueError, match="synchronous TokenCredential"):
+            await saver._resolve_async_credential(sync_credential)
+
+    async def test_async_passes_through_named_key_credential(self) -> None:
+        saver = AzureTableStorageSaver(
+            "https://fake.table.core.windows.net", "checkpoints"
+        )
+        named_key = AzureNamedKeyCredential("account", "a" * 10)
+        assert await saver._resolve_async_credential(named_key) is named_key
+
+
+class TestLazyTableCreation:
+    def test_get_sync_table_creates_table_and_caches(self) -> None:
+        saver = AzureTableStorageSaver(
+            "https://fake.table.core.windows.net",
+            "checkpoints",
+            credential=AzureSasCredential("sig"),
+        )
+        with patch("langchain_azure_storage.checkpoint.TableClient") as mock_cls:
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+
+            first = saver._get_sync_table()
+            second = saver._get_sync_table()
+
+            assert first is mock_client
+            assert second is mock_client
+            mock_cls.assert_called_once()
+            mock_client.create_table.assert_called_once()
+
+    def test_get_sync_table_ignores_already_exists(self) -> None:
+        saver = AzureTableStorageSaver(
+            "https://fake.table.core.windows.net",
+            "checkpoints",
+            credential=AzureSasCredential("sig"),
+        )
+        with patch("langchain_azure_storage.checkpoint.TableClient") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.create_table.side_effect = ResourceExistsError("exists")
+            mock_cls.return_value = mock_client
+
+            table = saver._get_sync_table()
+            assert table is mock_client
+
+    def test_get_sync_table_uses_connection_string(self) -> None:
+        from langchain_azure_storage._user_agent import USER_AGENT
+
+        saver = AzureTableStorageSaver.from_connection_string(
+            "fake-conn-str", "checkpoints"
+        )
+        with patch("langchain_azure_storage.checkpoint.TableClient") as mock_cls:
+            mock_client = MagicMock()
+            mock_cls.from_connection_string.return_value = mock_client
+
+            table = saver._get_sync_table()
+
+            mock_cls.from_connection_string.assert_called_once_with(
+                "fake-conn-str", "checkpoints", user_agent=USER_AGENT
+            )
+            assert table is mock_client

--- a/libs/azure-storage/uv.lock
+++ b/libs/azure-storage/uv.lock
@@ -295,6 +295,21 @@ aio = [
 ]
 
 [[package]]
+name = "azure-data-tables"
+version = "12.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/b8/e76cfa7f5f847722664c6f8108c391deadcb9d9aad579650c128affd4669/azure_data_tables-12.7.0.tar.gz", hash = "sha256:b14fc94a3223a2835ff5688e17d8e107b27c7cd7c4114138f2ac81373723705d", size = 258650, upload-time = "2025-05-06T17:51:06.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/3e/2b8da274b49402659cd732def2ae217f2e86312278feb56b55ccbffbbc26/azure_data_tables-12.7.0-py3-none-any.whl", hash = "sha256:24ed9b5690aa46c213182e32bb1b39a68dd9f526d84f447c287e3a401b437c10", size = 133178, upload-time = "2025-05-06T17:51:07.65Z" },
+]
+
+[[package]]
 name = "azure-identity"
 version = "1.25.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1040,11 +1055,14 @@ name = "langchain-azure-storage"
 version = "1.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "aiohttp" },
     { name = "azure-core" },
+    { name = "azure-data-tables" },
     { name = "azure-identity" },
     { name = "azure-storage-blob", extra = ["aio"] },
     { name = "langchain-core", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "langgraph-checkpoint" },
 ]
 
 [package.optional-dependencies]
@@ -1078,11 +1096,14 @@ typing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "azure-core", specifier = ">=1.38.0" },
+    { name = "azure-data-tables", specifier = ">=12.7.0,<13.0" },
     { name = "azure-identity", specifier = "~=1.25" },
     { name = "azure-storage-blob", extras = ["aio"], specifier = "~=12.26" },
     { name = "deepagents", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=0.6.12,<0.7.0" },
     { name = "langchain-core", specifier = ">=1.2.5,<2.0" },
+    { name = "langgraph-checkpoint", specifier = ">=2.1.2,<5.0.0" },
     { name = "wcmatch", marker = "python_full_version >= '3.11' and extra == 'deepagents'", specifier = ">=10.1" },
 ]
 provides-extras = ["deepagents"]
@@ -1216,8 +1237,9 @@ name = "langgraph-checkpoint"
 version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "langchain-core", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "langchain-core", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "ormsgpack", marker = "python_full_version >= '3.11'" },
+    { name = "ormsgpack" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Adds `AzureTableStorageSaver`, a LangGraph checkpoint saver backed by Azure Table Storage, in `libs/azure-storage/langchain_azure_storage/checkpoint.py`.
- Stores checkpoints and pending writes as entities partitioned by `thread_id`/`checkpoint_ns`, using the same `checkpoint$...` / `writes$...` row-key scheme as the existing CosmosDB checkpointer for consistency across the repo.
- Serialized checkpoint/metadata/write payloads are transparently split across multiple entity properties to work around Table Storage's 64 KiB per-property limit (the 1 MiB per-entity limit is left to the service to enforce).
- Exposes a single class with both sync and async methods (`get_tuple`/`aget_tuple`, `list`/`alist`, `put`/`aput`, `put_writes`/`aput_writes`), each backed by its own lazily-created `TableClient`/async `TableClient` — following the same credential-resolution, lifecycle (`close`/`aclose`, context managers), and `from_connection_string` (Azurite) pattern as `AzureBlobBackend` already in this package.
- Adds `azure-data-tables` and `langgraph-checkpoint` as direct dependencies; `aiohttp` is added explicitly for the async Table Storage transport (previously only pulled in transitively via `azure-storage-blob[aio]`).
- Documents usage in the package README.

Closes #406.

## Testing
- 69 new unit tests in `tests/unit_tests/test_checkpoint.py`: pure key-building/chunking/query-builder logic, plus an in-memory fake `TableClient` double that exercises real put/get/list/put_writes round trips (including chunking of large checkpoints, metadata filtering, `before`/`limit` pagination, and special-channel upsert-vs-create-only write semantics) without needing a live account.
- 7 new integration tests in `tests/integration_tests/test_checkpoint.py`, gated behind `AZURE_STORAGE_TABLE_ENDPOINT`/`AZURE_STORAGE_CONNECTION_STRING` env vars (same convention as the existing document-loader/Deep Agents integration tests) — verified locally against the real Azurite Table Storage emulator (all 7 passing).
- Manually ran a real `langgraph.graph.StateGraph` end-to-end against Azurite with `AzureTableStorageSaver` as its checkpointer: multi-turn `invoke`, `get_state`, and `get_state_history` (time travel) all behaved correctly.
- `ruff check`, `ruff format --diff`, and `mypy` all clean on both Python 3.10 and 3.12; full unit test suite (261 tests) passes on both versions.
- `uv lock --check` passes.