### PR TITLE
feat: support foundry checkpointer

### DIFF
--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -168,6 +168,26 @@ The Responses host uses one conversation-state source per graph. The policy depe
 
 The Responses transcript provider is selected by the underlying `azure-ai-agentserver-responses` runtime. Local runs and tests use an in-memory provider by default. Foundry-hosted containers use the Foundry-backed storage provider when the platform environment variables are present. This transcript store is separate from the LangGraph checkpointer, which stores graph runtime state.
 
+Use `FoundryCheckpointSaver` to keep LangGraph runtime state in Foundry's
+durable state store:
+
+```python
+from langchain_azure_ai.agents.hosting import (
+  FoundryCheckpointSaver,
+  ResponsesHostServer,
+)
+
+
+async def main() -> None:
+  async with FoundryCheckpointSaver() as checkpointer:
+    graph = builder.compile(checkpointer=checkpointer)
+    await ResponsesHostServer(graph).run_async()
+```
+
+`FoundryCheckpointSaver` is intended for a Foundry-hosted agent using container
+protocol `2.0.0`, which supplies the request context required by the state-store
+API. Use an in-memory or database-backed LangGraph saver for local development.
+
 
 ### Auto tracing to Azure Application Insights
 

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -254,6 +254,9 @@ if TYPE_CHECKING:
         ResponsesServerOptions,
     )
 
+    from langchain_azure_ai.agents.hosting._foundry_checkpoint_saver import (
+        FoundryCheckpointSaver,
+    )
     from langchain_azure_ai.agents.hosting._invoke_host import (
         InvocationsHostServer,
     )
@@ -264,6 +267,7 @@ if TYPE_CHECKING:
 __all__ = [
     "HOSTING_USER_AGENT",
     "CreateResponse",
+    "FoundryCheckpointSaver",
     "InvocationsHostServer",
     "InvocationAgentServerHost",
     "ResponseContext",
@@ -278,6 +282,9 @@ __all__ = [
 
 _module_lookup = {
     "CreateResponse": "azure.ai.agentserver.responses",
+    "FoundryCheckpointSaver": (
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver"
+    ),
     "InvocationsHostServer": "langchain_azure_ai.agents.hosting._invoke_host",
     "InvocationAgentServerHost": "azure.ai.agentserver.invocations",
     "ResponseContext": "azure.ai.agentserver.responses",

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_foundry_checkpoint_saver.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_foundry_checkpoint_saver.py
@@ -76,13 +76,24 @@ class _PendingWriteItemValue(TypedDict):
     value: _SerializedValue
 
 
-class _CheckpointItemTags(TypedDict):
-    """Foundry tags attached to checkpoint items."""
+class _CheckpointTags(TypedDict):
+    """Foundry checkpoint tag vocabulary."""
 
     kind: Literal["checkpoint"]
-    ns: str
     source: NotRequired[str]
     step: NotRequired[str]
+
+
+class _CheckpointItemTags(_CheckpointTags):
+    """Foundry tags attached to checkpoint items."""
+
+    ns: str
+
+
+class _CheckpointQueryTags(_CheckpointTags):
+    """Foundry tags used to query checkpoint items."""
+
+    ns: NotRequired[str]
 
 
 class _PendingWriteItemTags(TypedDict):
@@ -165,8 +176,12 @@ class FoundryCheckpointSaver(BaseCheckpointSaver):
             else:
                 # Foundry orders keys by creation time. Descending order with
                 # limit=1 selects the newest checkpoint in this namespace.
+                tags: _CheckpointItemTags = {
+                    "kind": "checkpoint",
+                    "ns": checkpoint_ns,
+                }
                 page = await store.list_keys(
-                    tags={"kind": "checkpoint", "ns": checkpoint_ns},
+                    tags=cast(Mapping[str, str], tags),
                     limit=1,
                     order="desc",
                 )
@@ -205,7 +220,7 @@ class FoundryCheckpointSaver(BaseCheckpointSaver):
 
         checkpoint_id = get_checkpoint_id(config)
         before_id = get_checkpoint_id(before) if before else None
-        tags = {"kind": "checkpoint"}
+        tags: _CheckpointQueryTags = {"kind": "checkpoint"}
         if namespace_is_set:
             tags["ns"] = checkpoint_ns
         if filter:
@@ -216,10 +231,24 @@ class FoundryCheckpointSaver(BaseCheckpointSaver):
         store = await self._get_or_create_store(thread_id)
         try:
             after: str | None = None
+            if before_id and before is not None:
+                before_configurable = before.get("configurable") or {}
+                before_ns = before_configurable.get("checkpoint_ns", checkpoint_ns)
+                if not isinstance(before_ns, str):
+                    raise ValueError("checkpoint_ns must be a string")
+                before_item = await store.get_item(
+                    self._checkpoint_key(before_ns, before_id)
+                )
+                if before_item is None:
+                    return
+                # Foundry store cursors are relative to the requested order. With
+                # descending order, items after this cursor are older.
+                after = before_item.id
+
             yielded = 0
             while True:
                 page = await store.list_keys(
-                    tags=tags,
+                    tags=cast(Mapping[str, str], tags),
                     limit=_PAGE_SIZE,
                     order="desc",
                     after=after,
@@ -236,8 +265,6 @@ class FoundryCheckpointSaver(BaseCheckpointSaver):
                     if namespace_is_set and item_ns != checkpoint_ns:
                         continue
                     if checkpoint_id and item_id != checkpoint_id:
-                        continue
-                    if before_id and item_id >= before_id:
                         continue
 
                     checkpoint_tuple = await self._checkpoint_tuple(
@@ -473,13 +500,14 @@ class FoundryCheckpointSaver(BaseCheckpointSaver):
     ) -> list[tuple[str, str, Any]]:
         records: list[_PendingWriteItemValue] = []
         after: str | None = None
+        tags: _PendingWriteItemTags = {
+            "kind": "write",
+            "ns": checkpoint_ns,
+            "ckpt": checkpoint_id,
+        }
         while True:
             page = await store.list_keys(
-                tags={
-                    "kind": "write",
-                    "ns": checkpoint_ns,
-                    "ckpt": checkpoint_id,
-                },
+                tags=cast(Mapping[str, str], tags),
                 limit=_PAGE_SIZE,
                 order="asc",
                 after=after,

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_foundry_checkpoint_saver.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_foundry_checkpoint_saver.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import Any, Literal, cast
 
 from azure.ai.agentserver.core.storage import (
@@ -174,7 +174,11 @@ class FoundryCheckpointSaver(BaseCheckpointSaver):
 
             if item is None:
                 return None
-            return await self._checkpoint_tuple(store, thread_id, item.value)
+            return await self._checkpoint_tuple(
+                store,
+                thread_id,
+                cast(_CheckpointItemValue, item.value),
+            )
         finally:
             await store.aclose()
 
@@ -293,7 +297,7 @@ class FoundryCheckpointSaver(BaseCheckpointSaver):
             await store.set_item(
                 self._checkpoint_key(checkpoint_ns, checkpoint_id),
                 cast(JSONObject, value),
-                tags=tags,
+                tags=cast(Mapping[str, str], tags),
             )
         finally:
             await store.aclose()
@@ -347,14 +351,14 @@ class FoundryCheckpointSaver(BaseCheckpointSaver):
                     await store.set_item(
                         key,
                         cast(JSONObject, item_value),
-                        tags=tags,
+                        tags=cast(Mapping[str, str], tags),
                     )
                 else:
                     try:
                         await store.create_item(
                             key,
                             cast(JSONObject, item_value),
-                            tags=tags,
+                            tags=cast(Mapping[str, str], tags),
                         )
                     except FoundryStorageConflictError:
                         pass

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_foundry_checkpoint_saver.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_foundry_checkpoint_saver.py
@@ -1,0 +1,564 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""LangGraph checkpoint persistence backed by Foundry state stores."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from collections.abc import AsyncIterator, Sequence
+from typing import Any, Literal, cast
+
+from azure.ai.agentserver.core.storage import (
+    FoundryStateStore,
+    FoundryStorageConflictError,
+    FoundryStorageEndpoint,
+    FoundryStorageNotFoundError,
+    JSONObject,
+)
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.identity.aio import DefaultAzureCredential
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    WRITES_IDX_MAP,
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    get_checkpoint_id,
+    get_checkpoint_metadata,
+)
+from langgraph.checkpoint.serde.base import SerializerProtocol
+from typing_extensions import NotRequired, TypedDict
+
+from langchain_azure_ai._user_agent import get_user_agent
+
+DEFAULT_STORE_NAME_PREFIX = "langchain_azure_ai.agents.hosting.FoundryCheckpointSaver"
+DEFAULT_ITEM_TTL_SECONDS = 30 * 24 * 60 * 60
+_PAGE_SIZE = 100
+_MAX_STORE_NAME_LENGTH = 128
+
+
+class _SerializedValue(TypedDict):
+    """LangGraph typed-serializer output represented as Foundry JSON."""
+
+    type: str
+    data: str
+
+
+class _CheckpointItemValue(TypedDict):
+    """JSON value stored for one LangGraph checkpoint item."""
+
+    checkpoint_id: str
+    checkpoint_ns: str
+    checkpoint: _SerializedValue
+    metadata: _SerializedValue
+    parent_checkpoint_id: str
+
+
+class _PendingWriteItemValue(TypedDict):
+    """JSON value stored for one LangGraph pending-write item.
+
+    Pending writes preserve successful task outputs before the next full
+    checkpoint commits. LangGraph can reuse them when sibling tasks fail,
+    avoiding repeated model/tool work and duplicate non-idempotent side
+    effects. They also carry error, interrupt, resume, and scheduling state.
+    """
+
+    checkpoint_id: str
+    checkpoint_ns: str
+    task_id: str
+    task_path: str
+    index: int
+    channel: str
+    value: _SerializedValue
+
+
+class _CheckpointItemTags(TypedDict):
+    """Foundry tags attached to checkpoint items."""
+
+    kind: Literal["checkpoint"]
+    ns: str
+    source: NotRequired[str]
+    step: NotRequired[str]
+
+
+class _PendingWriteItemTags(TypedDict):
+    """Foundry tags attached to pending-write items."""
+
+    kind: Literal["write"]
+    ns: str
+    ckpt: str
+
+
+class FoundryCheckpointSaver(BaseCheckpointSaver):
+    """Persist LangGraph checkpoints in Microsoft Foundry state stores.
+
+    Each LangGraph ``thread_id`` maps to one state store named
+    ``{store_name_prefix}/{thread_id}``. Checkpoint namespaces and IDs are
+    encoded in item keys within that store. The saver is async-only; use it
+    with ``graph.ainvoke`` or ``graph.astream``.
+
+    Args:
+        credential: Optional async Azure credential. Omit to use
+            ``DefaultAzureCredential``.
+        endpoint: Foundry project or storage endpoint. When omitted, the SDK
+            resolves ``FOUNDRY_PROJECT_ENDPOINT``.
+        store_name_prefix: Prefix used for per-thread store names.
+        user_isolation: Partition items by the hosted request's end user.
+        item_ttl_seconds: Sliding item TTL configured when a thread store is
+            first created. ``-1`` disables expiration.
+        api_version: Foundry storage API version.
+        serde: Optional LangGraph serializer.
+    """
+
+    def __init__(
+        self,
+        credential: AsyncTokenCredential | None = None,
+        endpoint: FoundryStorageEndpoint | str | None = None,
+        *,
+        store_name_prefix: str = DEFAULT_STORE_NAME_PREFIX,
+        user_isolation: bool = True,
+        item_ttl_seconds: int = DEFAULT_ITEM_TTL_SECONDS,
+        api_version: str = "v1",
+        serde: SerializerProtocol | None = None,
+    ) -> None:
+        super().__init__(serde=serde)
+        if not store_name_prefix:
+            raise ValueError("store_name_prefix must be a non-empty string")
+
+        self._owns_credential = credential is None
+        self._credential = (
+            credential if credential is not None else DefaultAzureCredential()
+        )
+        self._endpoint = endpoint
+        self._store_name_prefix = store_name_prefix.rstrip("/")
+        self._user_isolation = user_isolation
+        self._item_ttl_seconds = item_ttl_seconds
+        self._api_version = api_version
+
+    async def __aenter__(self) -> FoundryCheckpointSaver:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the saver-owned credential, if any."""
+        if self._owns_credential:
+            await self._credential.close()
+            self._owns_credential = False
+
+    async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        """Fetch an exact checkpoint or the latest checkpoint in a namespace."""
+        thread_id, checkpoint_ns = self._thread_and_namespace(config)
+        store = await self._get_or_create_store(thread_id)
+        try:
+            checkpoint_id = get_checkpoint_id(config)
+
+            if checkpoint_id:
+                item = await store.get_item(
+                    self._checkpoint_key(checkpoint_ns, checkpoint_id)
+                )
+            else:
+                # Foundry orders keys by creation time. Descending order with
+                # limit=1 selects the newest checkpoint in this namespace.
+                page = await store.list_keys(
+                    tags={"kind": "checkpoint", "ns": checkpoint_ns},
+                    limit=1,
+                    order="desc",
+                )
+                item = await store.get_item(page.keys[0].key) if page.keys else None
+
+            if item is None:
+                return None
+            return await self._checkpoint_tuple(store, thread_id, item.value)
+        finally:
+            await store.aclose()
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        """List checkpoints newest-first for one known thread."""
+        if config is None:
+            raise ValueError("config with a thread_id is required")
+        if limit is not None and limit < 1:
+            raise ValueError("limit must be a positive integer")
+
+        thread_id = self._thread_id(config)
+        configurable = config.get("configurable") or {}
+        namespace_is_set = "checkpoint_ns" in configurable
+        checkpoint_ns = configurable.get("checkpoint_ns", "")
+        if not isinstance(checkpoint_ns, str):
+            raise ValueError("checkpoint_ns must be a string")
+
+        checkpoint_id = get_checkpoint_id(config)
+        before_id = get_checkpoint_id(before) if before else None
+        tags = {"kind": "checkpoint"}
+        if namespace_is_set:
+            tags["ns"] = checkpoint_ns
+        if filter:
+            for field in ("source", "step"):
+                if field in filter:
+                    tags[field] = str(filter[field])
+
+        store = await self._get_or_create_store(thread_id)
+        try:
+            after: str | None = None
+            yielded = 0
+            while True:
+                page = await store.list_keys(
+                    tags=tags,
+                    limit=_PAGE_SIZE,
+                    order="desc",
+                    after=after,
+                )
+                for key in page.keys:
+                    item = await store.get_item(key.key)
+                    if item is None:
+                        continue
+                    value = cast(_CheckpointItemValue, item.value)
+                    item_ns = value.get("checkpoint_ns", "")
+                    item_id = value.get("checkpoint_id")
+                    if not isinstance(item_id, str):
+                        continue
+                    if namespace_is_set and item_ns != checkpoint_ns:
+                        continue
+                    if checkpoint_id and item_id != checkpoint_id:
+                        continue
+                    if before_id and item_id >= before_id:
+                        continue
+
+                    checkpoint_tuple = await self._checkpoint_tuple(
+                        store, thread_id, value
+                    )
+                    if filter and not all(
+                        checkpoint_tuple.metadata.get(name) == expected
+                        for name, expected in filter.items()
+                    ):
+                        continue
+
+                    yield checkpoint_tuple
+                    yielded += 1
+                    if limit is not None and yielded >= limit:
+                        return
+
+                if not page.has_more or page.last_id is None:
+                    return
+                after = page.last_id
+        finally:
+            await store.aclose()
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Persist one append-only LangGraph checkpoint."""
+        del new_versions
+        thread_id, checkpoint_ns = self._thread_and_namespace(config)
+        checkpoint_id = checkpoint["id"]
+        parent_checkpoint_id = get_checkpoint_id(config)
+        checkpoint_metadata = get_checkpoint_metadata(config, metadata)
+
+        value: _CheckpointItemValue = {
+            "checkpoint_id": checkpoint_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint": self._serialize(checkpoint),
+            "metadata": self._serialize(checkpoint_metadata),
+            "parent_checkpoint_id": parent_checkpoint_id or "",
+        }
+        tags: _CheckpointItemTags = {
+            "kind": "checkpoint",
+            "ns": checkpoint_ns,
+        }
+        source = checkpoint_metadata.get("source")
+        step = checkpoint_metadata.get("step")
+        if source is not None:
+            tags["source"] = str(source)
+        if step is not None:
+            tags["step"] = str(step)
+
+        store = await self._get_or_create_store(thread_id)
+        try:
+            await store.set_item(
+                self._checkpoint_key(checkpoint_ns, checkpoint_id),
+                cast(JSONObject, value),
+                tags=tags,
+            )
+        finally:
+            await store.aclose()
+        return self._config(thread_id, checkpoint_ns, checkpoint_id)
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Persist task outputs needed for correct and efficient recovery.
+
+        Without these writes, LangGraph may rerun already-successful sibling
+        tasks after a failure and can lose special error, interrupt, resume,
+        or scheduling state.
+        """
+        thread_id, checkpoint_ns = self._thread_and_namespace(config)
+        checkpoint_id = get_checkpoint_id(config)
+        if not checkpoint_id:
+            raise ValueError("checkpoint_id is required to store pending writes")
+        if not task_id:
+            raise ValueError("task_id must be a non-empty string")
+
+        store = await self._get_or_create_store(thread_id)
+        try:
+            for ordinal, (channel, value) in enumerate(writes):
+                index = WRITES_IDX_MAP.get(channel, ordinal)
+                item_value: _PendingWriteItemValue = {
+                    "checkpoint_id": checkpoint_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "task_id": task_id,
+                    "task_path": task_path,
+                    "index": index,
+                    "channel": channel,
+                    "value": self._serialize(value),
+                }
+                key = self._write_key(
+                    checkpoint_ns,
+                    checkpoint_id,
+                    task_id,
+                    index,
+                )
+                tags: _PendingWriteItemTags = {
+                    "kind": "write",
+                    "ns": checkpoint_ns,
+                    "ckpt": checkpoint_id,
+                }
+                if channel in WRITES_IDX_MAP:
+                    await store.set_item(
+                        key,
+                        cast(JSONObject, item_value),
+                        tags=tags,
+                    )
+                else:
+                    try:
+                        await store.create_item(
+                            key,
+                            cast(JSONObject, item_value),
+                            tags=tags,
+                        )
+                    except FoundryStorageConflictError:
+                        pass
+        finally:
+            await store.aclose()
+
+    async def adelete_thread(self, thread_id: str) -> None:
+        """Delete a thread's store and every checkpoint item in it."""
+        if not thread_id:
+            raise ValueError("thread_id must be a non-empty string")
+        store = self._bound_store(thread_id)
+        try:
+            if self._user_isolation:
+                keys: list[str] = []
+                after: str | None = None
+                while True:
+                    page = await store.list_keys(
+                        limit=_PAGE_SIZE,
+                        order="asc",
+                        after=after,
+                    )
+                    keys.extend(key.key for key in page.keys)
+                    if not page.has_more or page.last_id is None:
+                        break
+                    after = page.last_id
+                for key in keys:
+                    await store.delete_item(key)
+            else:
+                await store.delete()
+        except FoundryStorageNotFoundError:
+            pass
+        finally:
+            await store.aclose()
+
+    async def _get_or_create_store(self, thread_id: str) -> FoundryStateStore:
+        store = await FoundryStateStore.get_or_create(
+            self._store_name(thread_id),
+            self._credential,
+            self._endpoint,
+            user_isolation=self._user_isolation,
+            item_ttl_seconds=self._item_ttl_seconds,
+            description="LangGraph checkpoints",
+            api_version=self._api_version,
+            # AgentServer uses this callback to build the outbound User-Agent
+            # header. Keep it lazy so registered prefixes and the telemetry
+            # opt-out are evaluated per request.
+            get_server_version=get_user_agent,
+        )
+        try:
+            properties = await store.get()
+            if properties.user_isolation != self._user_isolation:
+                raise ValueError(
+                    f"State store {store.name!r} already exists with "
+                    f"user_isolation={properties.user_isolation}; expected "
+                    f"{self._user_isolation}"
+                )
+            if properties.item_ttl_seconds != self._item_ttl_seconds:
+                raise ValueError(
+                    f"State store {store.name!r} already exists with "
+                    f"item_ttl_seconds={properties.item_ttl_seconds}; expected "
+                    f"{self._item_ttl_seconds}"
+                )
+        except BaseException:
+            await store.aclose()
+            raise
+        return store
+
+    def _bound_store(self, thread_id: str) -> FoundryStateStore:
+        return FoundryStateStore(
+            self._store_name(thread_id),
+            self._credential,
+            self._endpoint,
+            user_isolation=self._user_isolation,
+            item_ttl_seconds=self._item_ttl_seconds,
+            api_version=self._api_version,
+            # AgentServer uses this callback to build the outbound User-Agent
+            # header; lazy evaluation keeps prefixes and opt-out state current.
+            get_server_version=get_user_agent,
+        )
+
+    async def _checkpoint_tuple(
+        self,
+        store: FoundryStateStore,
+        thread_id: str,
+        value: _CheckpointItemValue,
+    ) -> CheckpointTuple:
+        checkpoint_id = value["checkpoint_id"]
+        checkpoint_ns = value.get("checkpoint_ns", "")
+        parent_checkpoint_id = value.get("parent_checkpoint_id", "")
+        pending_writes = await self._pending_writes(
+            store,
+            checkpoint_ns,
+            checkpoint_id,
+        )
+        return CheckpointTuple(
+            config=self._config(thread_id, checkpoint_ns, checkpoint_id),
+            checkpoint=cast(Checkpoint, self._deserialize(value["checkpoint"])),
+            metadata=cast(CheckpointMetadata, self._deserialize(value["metadata"])),
+            parent_config=(
+                self._config(thread_id, checkpoint_ns, parent_checkpoint_id)
+                if parent_checkpoint_id
+                else None
+            ),
+            pending_writes=pending_writes,
+        )
+
+    async def _pending_writes(
+        self,
+        store: FoundryStateStore,
+        checkpoint_ns: str,
+        checkpoint_id: str,
+    ) -> list[tuple[str, str, Any]]:
+        records: list[_PendingWriteItemValue] = []
+        after: str | None = None
+        while True:
+            page = await store.list_keys(
+                tags={
+                    "kind": "write",
+                    "ns": checkpoint_ns,
+                    "ckpt": checkpoint_id,
+                },
+                limit=_PAGE_SIZE,
+                order="asc",
+                after=after,
+            )
+            for key in page.keys:
+                item = await store.get_item(key.key)
+                if item is not None:
+                    records.append(cast(_PendingWriteItemValue, item.value))
+            if not page.has_more or page.last_id is None:
+                break
+            after = page.last_id
+
+        records.sort(key=lambda item: (item["task_id"], item["index"]))
+        return [
+            (
+                item["task_id"],
+                item["channel"],
+                self._deserialize(item["value"]),
+            )
+            for item in records
+        ]
+
+    def _serialize(self, value: Any) -> _SerializedValue:
+        type_name, data = self.serde.dumps_typed(value)
+        return {
+            "type": type_name,
+            "data": base64.b64encode(data).decode("ascii"),
+        }
+
+    def _deserialize(self, value: _SerializedValue) -> Any:
+        return self.serde.loads_typed(
+            (
+                value["type"],
+                base64.b64decode(value["data"].encode("ascii")),
+            )
+        )
+
+    def _store_name(self, thread_id: str) -> str:
+        name = f"{self._store_name_prefix}/{thread_id}"
+        if len(name) <= _MAX_STORE_NAME_LENGTH:
+            return name
+        digest = hashlib.sha256(name.encode("utf-8")).hexdigest()
+        prefix_length = _MAX_STORE_NAME_LENGTH - len(digest) - 1
+        return f"{self._store_name_prefix[:prefix_length]}/{digest}"
+
+    @staticmethod
+    def _checkpoint_key(checkpoint_ns: str, checkpoint_id: str) -> str:
+        return f"{checkpoint_ns}/{checkpoint_id}"
+
+    @staticmethod
+    def _write_key(
+        checkpoint_ns: str,
+        checkpoint_id: str,
+        task_id: str,
+        index: int,
+    ) -> str:
+        return f"{checkpoint_ns}/writes/{checkpoint_id}/{task_id}/{index}"
+
+    @staticmethod
+    def _thread_id(config: RunnableConfig) -> str:
+        thread_id = (config.get("configurable") or {}).get("thread_id")
+        if not isinstance(thread_id, str) or not thread_id:
+            raise ValueError("thread_id must be a non-empty string")
+        return thread_id
+
+    @classmethod
+    def _thread_and_namespace(cls, config: RunnableConfig) -> tuple[str, str]:
+        thread_id = cls._thread_id(config)
+        checkpoint_ns = (config.get("configurable") or {}).get("checkpoint_ns", "")
+        if not isinstance(checkpoint_ns, str):
+            raise ValueError("checkpoint_ns must be a string")
+        return thread_id, checkpoint_ns
+
+    @staticmethod
+    def _config(
+        thread_id: str,
+        checkpoint_ns: str,
+        checkpoint_id: str,
+    ) -> RunnableConfig:
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            }
+        }

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_foundry_checkpoint_saver.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_foundry_checkpoint_saver.py
@@ -1,0 +1,346 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Unit tests for the Foundry-backed LangGraph checkpoint saver."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from azure.core.credentials_async import AsyncTokenCredential
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+from langchain_azure_ai._user_agent import get_user_agent
+from langchain_azure_ai.agents.hosting import FoundryCheckpointSaver
+from langchain_azure_ai.agents.hosting._foundry_checkpoint_saver import (
+    DEFAULT_STORE_NAME_PREFIX,
+)
+
+
+class _GraphState(TypedDict):
+    value: int
+
+
+def _credential() -> AsyncTokenCredential:
+    return cast(AsyncTokenCredential, object())
+
+
+class _FakeStateStore:
+    def __init__(self) -> None:
+        self.name = "langGraphCheckpoints/thread-1"
+        self.user_isolation = True
+        self.item_ttl_seconds = 30 * 24 * 60 * 60
+        self.items: dict[str, Any] = {}
+        self.tags: dict[str, dict[str, str]] = {}
+        self.order: list[str] = []
+        self.closed = False
+        self.deleted = False
+
+    async def get(self) -> Any:
+        return SimpleNamespace(
+            user_isolation=self.user_isolation,
+            item_ttl_seconds=self.item_ttl_seconds,
+        )
+
+    async def set_item(
+        self,
+        key: str,
+        value: dict[str, Any],
+        *,
+        tags: dict[str, str],
+    ) -> None:
+        if key not in self.items:
+            self.order.append(key)
+        self.items[key] = SimpleNamespace(value=value)
+        self.tags[key] = tags
+
+    async def create_item(
+        self,
+        key: str,
+        value: dict[str, Any],
+        *,
+        tags: dict[str, str],
+    ) -> None:
+        assert key not in self.items
+        await self.set_item(key, value, tags=tags)
+
+    async def get_item(self, key: str) -> Any | None:
+        return self.items.get(key)
+
+    async def list_keys(
+        self,
+        *,
+        tags: dict[str, str] | None = None,
+        limit: int,
+        order: str,
+        after: str | None = None,
+    ) -> Any:
+        del after
+        keys = [
+            key
+            for key in self.order
+            if tags is None
+            or all(self.tags[key].get(name) == value for name, value in tags.items())
+        ]
+        if order == "desc":
+            keys.reverse()
+        keys = keys[:limit]
+        return SimpleNamespace(
+            keys=[SimpleNamespace(key=key) for key in keys],
+            has_more=False,
+            last_id=None,
+        )
+
+    async def delete(self) -> None:
+        self.deleted = True
+
+    async def delete_item(self, key: str) -> None:
+        self.items.pop(key, None)
+        self.tags.pop(key, None)
+        if key in self.order:
+            self.order.remove(key)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _config(
+    checkpoint_id: str | None = None,
+    *,
+    checkpoint_ns: str = "",
+) -> RunnableConfig:
+    configurable = {
+        "thread_id": "thread-1",
+        "checkpoint_ns": checkpoint_ns,
+    }
+    if checkpoint_id is not None:
+        configurable["checkpoint_id"] = checkpoint_id
+    return cast(RunnableConfig, {"configurable": configurable})
+
+
+def _checkpoint(checkpoint_id: str, value: str) -> Checkpoint:
+    return cast(
+        Checkpoint,
+        {
+            "v": 2,
+            "id": checkpoint_id,
+            "ts": "2026-08-05T00:00:00+00:00",
+            "channel_values": {"messages": [value]},
+            "channel_versions": {"messages": 1},
+            "versions_seen": {},
+            "updated_channels": ["messages"],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_put_stamps_state_store_user_agent() -> None:
+    store = _FakeStateStore()
+    credential = _credential()
+
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
+        "FoundryStateStore.get_or_create",
+        new=AsyncMock(return_value=store),
+    ) as get_or_create:
+        saver = FoundryCheckpointSaver(
+            credential,
+            "https://example.services.ai.azure.com/api/projects/project",
+        )
+        result = await saver.aput(
+            _config(),
+            _checkpoint("checkpoint-1", "first"),
+            cast(CheckpointMetadata, {"source": "input", "step": -1}),
+            {},
+        )
+
+    assert result == _config("checkpoint-1")
+    get_or_create.assert_awaited_once()
+    assert get_or_create.call_args.args[0] == f"{DEFAULT_STORE_NAME_PREFIX}/thread-1"
+    callback = get_or_create.call_args.kwargs["get_server_version"]
+    assert callback is get_user_agent
+    assert callback() == get_user_agent()
+    assert store.tags["/checkpoint-1"] == {
+        "kind": "checkpoint",
+        "ns": "",
+        "source": "input",
+        "step": "-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_rejects_incompatible_existing_store() -> None:
+    store = _FakeStateStore()
+    store.user_isolation = False
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
+        "FoundryStateStore.get_or_create",
+        new=AsyncMock(return_value=store),
+    ):
+        saver = FoundryCheckpointSaver(_credential(), user_isolation=True)
+        with pytest.raises(ValueError, match="user_isolation=False"):
+            await saver.aget_tuple(_config())
+
+    assert store.closed is True
+
+
+@pytest.mark.asyncio
+async def test_overlong_thread_id_uses_bounded_stable_store_name() -> None:
+    store = _FakeStateStore()
+    get_or_create = AsyncMock(return_value=store)
+    long_config = cast(
+        RunnableConfig,
+        {"configurable": {"thread_id": "thread-" + "x" * 200}},
+    )
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
+        "FoundryStateStore.get_or_create",
+        new=get_or_create,
+    ):
+        saver = FoundryCheckpointSaver(_credential())
+        await saver.aget_tuple(long_config)
+
+    store_name = get_or_create.call_args.args[0]
+    assert len(store_name) <= 128
+    assert store_name.startswith(f"{DEFAULT_STORE_NAME_PREFIX}/")
+    assert store_name == saver._store_name(long_config["configurable"]["thread_id"])
+
+
+@pytest.mark.asyncio
+async def test_round_trip_latest_history_and_pending_writes() -> None:
+    store = _FakeStateStore()
+    get_or_create = AsyncMock(return_value=store)
+
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
+        "FoundryStateStore.get_or_create",
+        new=get_or_create,
+    ):
+        saver = FoundryCheckpointSaver(_credential())
+        first_config = await saver.aput(
+            _config(),
+            _checkpoint("checkpoint-1", "first"),
+            cast(CheckpointMetadata, {"source": "input", "step": -1}),
+            {},
+        )
+        await saver.aput_writes(
+            first_config,
+            [("messages", {"content": "pending"})],
+            "task-1",
+        )
+        second_config = await saver.aput(
+            first_config,
+            _checkpoint("checkpoint-2", "second"),
+            cast(CheckpointMetadata, {"source": "loop", "step": 0}),
+            {},
+        )
+
+        latest = await saver.aget_tuple(_config())
+        exact = await saver.aget_tuple(first_config)
+        history = [item async for item in saver.alist(_config())]
+        before = [item async for item in saver.alist(_config(), before=second_config)]
+        filtered = [
+            item
+            async for item in saver.alist(
+                _config(),
+                filter={"source": "input"},
+            )
+        ]
+
+    assert latest is not None
+    assert latest.config == second_config
+    assert latest.checkpoint["channel_values"] == {"messages": ["second"]}
+    assert latest.parent_config == first_config
+    assert exact is not None
+    assert exact.pending_writes == [("task-1", "messages", {"content": "pending"})]
+    assert [item.config for item in history] == [second_config, first_config]
+    assert [item.config for item in before] == [first_config]
+    assert [item.config for item in filtered] == [first_config]
+    assert get_or_create.await_count == 8
+
+
+@pytest.mark.asyncio
+async def test_delete_user_isolated_thread_deletes_items() -> None:
+    store = _FakeStateStore()
+    await store.set_item(
+        "/checkpoint-1",
+        {"checkpoint_id": "checkpoint-1"},
+        tags={"kind": "checkpoint", "ns": ""},
+    )
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver.FoundryStateStore",
+        return_value=store,
+    ):
+        saver = FoundryCheckpointSaver(_credential())
+        await saver.adelete_thread("thread-1")
+
+    assert store.deleted is False
+    assert store.items == {}
+    assert store.closed is True
+
+
+@pytest.mark.asyncio
+async def test_delete_thread_stamps_user_agent() -> None:
+    store = SimpleNamespace(delete=AsyncMock(), aclose=AsyncMock())
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
+        "FoundryStateStore",
+        return_value=store,
+    ) as state_store:
+        saver = FoundryCheckpointSaver(_credential(), user_isolation=False)
+        await saver.adelete_thread("thread-1")
+
+    assert state_store.call_args.kwargs["get_server_version"] is get_user_agent
+    store.delete.assert_awaited_once()
+    store.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_saver_runs_with_real_langgraph() -> None:
+    store = _FakeStateStore()
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
+        "FoundryStateStore.get_or_create",
+        new=AsyncMock(return_value=store),
+    ):
+        saver = FoundryCheckpointSaver(_credential())
+
+        async def increment(state: _GraphState) -> _GraphState:
+            return {"value": state["value"] + 1}
+
+        builder = StateGraph(_GraphState)
+        builder.add_node("increment", increment)
+        builder.add_edge(START, "increment")
+        builder.add_edge("increment", END)
+        graph = builder.compile(checkpointer=saver)
+        config = cast(
+            RunnableConfig,
+            {"configurable": {"thread_id": "thread-1"}},
+        )
+
+        result = await graph.ainvoke({"value": 1}, config)
+        snapshot = await graph.aget_state(config)
+
+    assert result == {"value": 2}
+    assert snapshot.values == {"value": 2}
+    assert snapshot.config["configurable"]["checkpoint_id"]
+
+
+@pytest.mark.asyncio
+async def test_close_closes_owned_default_credential() -> None:
+    credential = SimpleNamespace(close=AsyncMock())
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
+        "DefaultAzureCredential",
+        return_value=credential,
+    ):
+        saver = FoundryCheckpointSaver()
+        await saver.aclose()
+
+    credential.close.assert_awaited_once()

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_foundry_checkpoint_saver.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_foundry_checkpoint_saver.py
@@ -289,8 +289,7 @@ async def test_delete_user_isolated_thread_deletes_items() -> None:
 async def test_delete_thread_stamps_user_agent() -> None:
     store = SimpleNamespace(delete=AsyncMock(), aclose=AsyncMock())
     with patch(
-        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
-        "FoundryStateStore",
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver.FoundryStateStore",
         return_value=store,
     ) as state_store:
         saver = FoundryCheckpointSaver(_credential(), user_isolation=False)

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_foundry_checkpoint_saver.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_foundry_checkpoint_saver.py
@@ -39,6 +39,7 @@ class _FakeStateStore:
         self.items: dict[str, Any] = {}
         self.tags: dict[str, dict[str, str]] = {}
         self.order: list[str] = []
+        self.list_keys_calls: list[dict[str, Any]] = []
         self.closed = False
         self.deleted = False
 
@@ -57,7 +58,10 @@ class _FakeStateStore:
     ) -> None:
         if key not in self.items:
             self.order.append(key)
-        self.items[key] = SimpleNamespace(value=value)
+            item_id = f"item-{len(self.order)}"
+        else:
+            item_id = self.items[key].id
+        self.items[key] = SimpleNamespace(id=item_id, value=value)
         self.tags[key] = tags
 
     async def create_item(
@@ -80,21 +84,40 @@ class _FakeStateStore:
         limit: int,
         order: str,
         after: str | None = None,
+        before: str | None = None,
     ) -> Any:
-        del after
-        keys = [
+        assert after is None or before is None
+        self.list_keys_calls.append(
+            {"tags": tags, "order": order, "after": after, "before": before}
+        )
+        ordered_keys = list(self.order)
+        if order == "desc":
+            ordered_keys.reverse()
+        if after is not None:
+            cursor_index = next(
+                index
+                for index, key in enumerate(ordered_keys)
+                if self.items[key].id == after
+            )
+            ordered_keys = ordered_keys[cursor_index + 1 :]
+        if before is not None:
+            cursor_index = next(
+                index
+                for index, key in enumerate(ordered_keys)
+                if self.items[key].id == before
+            )
+            ordered_keys = ordered_keys[:cursor_index]
+        matching_keys = [
             key
-            for key in self.order
+            for key in ordered_keys
             if tags is None
             or all(self.tags[key].get(name) == value for name, value in tags.items())
         ]
-        if order == "desc":
-            keys.reverse()
-        keys = keys[:limit]
+        keys = matching_keys[:limit]
         return SimpleNamespace(
-            keys=[SimpleNamespace(key=key) for key in keys],
-            has_more=False,
-            last_id=None,
+            keys=[SimpleNamespace(id=self.items[key].id, key=key) for key in keys],
+            has_more=len(matching_keys) > limit,
+            last_id=self.items[keys[-1]].id if keys else None,
         )
 
     async def delete(self) -> None:
@@ -263,6 +286,52 @@ async def test_round_trip_latest_history_and_pending_writes() -> None:
     assert [item.config for item in before] == [first_config]
     assert [item.config for item in filtered] == [first_config]
     assert get_or_create.await_count == 8
+
+
+@pytest.mark.asyncio
+async def test_list_before_uses_creation_order_not_checkpoint_id_order() -> None:
+    store = _FakeStateStore()
+
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
+        "FoundryStateStore.get_or_create",
+        new=AsyncMock(return_value=store),
+    ):
+        saver = FoundryCheckpointSaver(_credential())
+        older_config = await saver.aput(
+            _config(),
+            _checkpoint("z-older", "older"),
+            cast(CheckpointMetadata, {"source": "input", "step": -1}),
+            {},
+        )
+        before_config = await saver.aput(
+            older_config,
+            _checkpoint("a-before", "before"),
+            cast(CheckpointMetadata, {"source": "loop", "step": 0}),
+            {},
+        )
+        await saver.aput(
+            before_config,
+            _checkpoint("m-newer", "newer"),
+            cast(CheckpointMetadata, {"source": "loop", "step": 1}),
+            {},
+        )
+
+        checkpoints = [
+            item
+            async for item in saver.alist(
+                _config(),
+                before=before_config,
+                filter={"source": "input"},
+            )
+        ]
+
+    assert [item.config for item in checkpoints] == [older_config]
+    assert any(
+        call["tags"]["kind"] == "checkpoint"
+        and call["after"] == store.items["/a-before"].id
+        for call in store.list_keys_calls
+    )
 
 
 @pytest.mark.asyncio

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_types.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_types.py
@@ -13,6 +13,7 @@ pytest.importorskip("azure.ai.agentserver.responses")
 from langchain_azure_ai.agents import hosting  # noqa: E402
 from langchain_azure_ai.agents.hosting import (  # noqa: E402
     CreateResponse,
+    FoundryCheckpointSaver,
     InvocationAgentServerHost,
     ResponseContext,
     ResponseEventStream,
@@ -25,6 +26,7 @@ from langchain_azure_ai.agents.hosting import (  # noqa: E402
 def test_hosting_reexports_sdk_types() -> None:
     exported_types = [
         CreateResponse,
+        FoundryCheckpointSaver,
         InvocationAgentServerHost,
         ResponseContext,
         ResponseEventStream,
@@ -39,8 +41,11 @@ def test_hosting_reexports_sdk_types() -> None:
     assert InvocationAgentServerHost.__module__.startswith(
         "azure.ai.agentserver.invocations"
     )
+    assert FoundryCheckpointSaver.__module__.startswith(
+        "langchain_azure_ai.agents.hosting"
+    )
     assert all(
         exported_type.__module__.startswith("azure.ai.agentserver.responses")
         for exported_type in exported_types
-        if exported_type is not InvocationAgentServerHost
+        if exported_type not in {FoundryCheckpointSaver, InvocationAgentServerHost}
     )

--- a/samples/hosting/langgraph-hosted-agents/responses/01_basic/agent.manifest.yaml
+++ b/samples/hosting/langgraph-hosted-agents/responses/01_basic/agent.manifest.yaml
@@ -14,11 +14,11 @@ template:
   kind: hosted
   protocols:
     - protocol: responses
-      version: 1.0.0
+      version: 2.0.0
   environment_variables:
     - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
       value: "{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}"
 resources:
   - kind: model
-    id: gpt-4.1-mini
+    id: gpt-4.1
     name: AZURE_AI_MODEL_DEPLOYMENT_NAME

--- a/samples/hosting/langgraph-hosted-agents/responses/01_basic/agent.yaml
+++ b/samples/hosting/langgraph-hosted-agents/responses/01_basic/agent.yaml
@@ -3,7 +3,7 @@ kind: hosted
 name: langchain-azure-agent-basic-responses
 protocols:
   - protocol: responses
-    version: 1.0.0
+    version: 2.0.0
 resources:
   cpu: '0.25'
   memory: '0.5Gi'

--- a/samples/hosting/langgraph-hosted-agents/responses/01_basic/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/01_basic/main.py
@@ -21,8 +21,12 @@ Then in another terminal:
 """
 from __future__ import annotations
 
+import logging
 import os
+from typing import Any, Optional
 
+from azure.ai.agentserver.core.storage import FoundryStateStore
+from azure.ai.agentserver.responses import CreateResponse, ResponseContext
 from azure.ai.projects import AIProjectClient
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
@@ -41,6 +45,29 @@ load_dotenv()
 
 
 _AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+_STATE_STORE_NAME = "samples/responses-01-basic/get-or-create"
+logger = logging.getLogger(__name__)
+
+
+class StateStoreProbeResponsesHostServer(ResponsesHostServer):
+    """Call the Foundry state-store API once before each graph run."""
+
+    async def build_input(
+        self,
+        request: CreateResponse,
+        context: ResponseContext,
+        *,
+        skip_call_ids: Optional[frozenset[str]] = None,
+    ) -> dict[str, Any]:
+        store = await FoundryStateStore.get_or_create(_STATE_STORE_NAME)
+        async with store:
+            logger.info("Foundry state store is ready: %s", store.name)
+
+        return await super().build_input(
+            request,
+            context,
+            skip_call_ids=skip_call_ids,
+        )
 
 
 def _build_chat_model() -> ChatOpenAI:
@@ -76,7 +103,7 @@ def main() -> None:
     graph = create_agent(_build_chat_model(), tools=[])
     port = int(os.environ.get("PORT", "8088"))
 
-    ResponsesHostServer(graph).run(port=port)
+    StateStoreProbeResponsesHostServer(graph).run(port=port)
 
 
 if __name__ == "__main__":

--- a/samples/hosting/langgraph-hosted-agents/responses/05_workflows/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/05_workflows/README.md
@@ -28,8 +28,9 @@ The graph is a hand-built `StateGraph` with three nodes:
 - **tools** — a standard `ToolNode` executes any requested tool calls.
 - **synthesize** — the LLM produces the final assistant message.
 
-A `MemorySaver` checkpointer keeps state across turns when the client
-reuses the same `conversation.id`.
+The checkpointer keeps state across turns when the client reuses the same
+`conversation.id`. Local runs use `MemorySaver`; Foundry-hosted runs use
+`FoundryCheckpointSaver` so checkpoints survive container replacement.
 
 ### Responses hosting
 
@@ -37,7 +38,7 @@ reuses the same `conversation.id`.
 compiled graph through the Responses protocol:
 
 ```python
-ResponsesHostServer(graph).run(host=..., port=...)
+await ResponsesHostServer(graph).run_async(host=..., port=...)
 ```
 
 Hitting `/responses` returns the full trace as Responses-protocol output
@@ -82,4 +83,5 @@ Foundry](../../README.md#deploying-the-agent-to-foundry) section of
 the README in the parent directory.
 
 The shipped [agent.manifest.yaml](agent.manifest.yaml) declares the
-Responses protocol for deployment routing.
+Responses protocol `2.0.0` for deployment routing and Foundry state-store
+request context.

--- a/samples/hosting/langgraph-hosted-agents/responses/05_workflows/agent.manifest.yaml
+++ b/samples/hosting/langgraph-hosted-agents/responses/05_workflows/agent.manifest.yaml
@@ -18,7 +18,7 @@ template:
   kind: hosted
   protocols:
     - protocol: responses
-      version: 1.0.0
+      version: 2.0.0
   environment_variables:
     - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
       value: "{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}"

--- a/samples/hosting/langgraph-hosted-agents/responses/05_workflows/agent.yaml
+++ b/samples/hosting/langgraph-hosted-agents/responses/05_workflows/agent.yaml
@@ -3,7 +3,7 @@ kind: hosted
 name: langchain-azure-workflows-responses
 protocols:
   - protocol: responses
-    version: 1.0.0
+    version: 2.0.0
 resources:
   cpu: '0.25'
   memory: '0.5Gi'

--- a/samples/hosting/langgraph-hosted-agents/responses/05_workflows/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/05_workflows/main.py
@@ -178,7 +178,7 @@ async def main() -> None:
         enable_auto_tracing(auto_configure_azure_monitor=True)
 
     if AgentConfig.from_env().is_hosted:
-        checkpointer = FoundryCheckpointSaver()
+        checkpointer = FoundryCheckpointSaver(user_isolation=False)
     else:
         checkpointer = MemorySaver()
     async with checkpointer:

--- a/samples/hosting/langgraph-hosted-agents/responses/05_workflows/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/05_workflows/main.py
@@ -39,18 +39,22 @@ Then in another terminal:
     # Responses API - tool round-trip with full trace
     curl -X POST http://127.0.0.1:8088/responses -H 'Content-Type: application/json' -d '{"input":"What is the weather in Seattle?","model":"gpt-4o"}'
 """
+
 from __future__ import annotations
 
+import asyncio
 import os
 from random import randint
-from typing import Annotated
+from typing import Annotated, Any
 
+from azure.ai.agentserver.core import AgentConfig
 from azure.ai.projects import AIProjectClient
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import BaseMessage, SystemMessage
 from langchain_core.tools import tool
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import add_messages
@@ -62,7 +66,10 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from langchain_azure_ai.agents.hosting import ResponsesHostServer
+from langchain_azure_ai.agents.hosting import (
+    FoundryCheckpointSaver,
+    ResponsesHostServer,
+)
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
 
 load_dotenv()
@@ -120,7 +127,7 @@ def _build_chat_model() -> ChatOpenAI:
     )
 
 
-def _build_graph():
+def _build_graph(checkpointer: BaseCheckpointSaver[Any]):
     base_model = _build_chat_model()
     planner = base_model.bind_tools(_TOOLS)
 
@@ -154,16 +161,14 @@ def _build_graph():
     # tools_condition routes to "tools" when the planner emitted
     # tool_calls, otherwise to END. We feed the tool results back
     # through synthesize.
-    builder.add_conditional_edges(
-        "plan", tools_condition, {"tools": "tools", END: END}
-    )
+    builder.add_conditional_edges("plan", tools_condition, {"tools": "tools", END: END})
     builder.add_edge("tools", "synthesize")
     builder.add_edge("synthesize", END)
 
-    return builder.compile(checkpointer=MemorySaver())
+    return builder.compile(checkpointer=checkpointer)
 
 
-def main() -> None:
+async def main() -> None:
     if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
         provider = TracerProvider()
         provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
@@ -172,10 +177,16 @@ def main() -> None:
     else:
         enable_auto_tracing(auto_configure_azure_monitor=True)
 
-    port = int(os.environ.get("PORT", "8088"))
-    graph = _build_graph()
-    ResponsesHostServer(graph).run(port=port)
+    if AgentConfig.from_env().is_hosted:
+        checkpointer = FoundryCheckpointSaver()
+    else:
+        checkpointer = MemorySaver()
+    async with checkpointer:
+        graph = _build_graph(checkpointer)
+        await ResponsesHostServer(graph).run_async(
+            port=int(os.environ.get("PORT", "8088"))
+        )
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/samples/hosting/langgraph-hosted-agents/responses/08_hitl/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/08_hitl/README.md
@@ -50,9 +50,10 @@ LangGraph interrupt id:
    interrupt.id` carrying the same `arguments`. (Parallel rich channel
    for callers that need to drive an arbitrary LangGraph `Command`.)
 
-State is persisted by an `InMemorySaver` checkpointer keyed by the
-`conversation.id`, so the second request continues the paused run from
-exactly where it left off.
+State is persisted by a checkpointer keyed by the `conversation.id`, so the
+second request continues the paused run from exactly where it left off. Local
+runs use `InMemorySaver`; Foundry-hosted runs use `FoundryCheckpointSaver` so
+an approval pause survives container replacement.
 
 ### Agent Hosting
 
@@ -205,8 +206,5 @@ the Agent to
 Foundry](../../README.md#deploying-the-agent-to-foundry) section of
 the README in the parent directory.
 
-> The `InMemorySaver` checkpointer used here is in-process only —
-> conversation state will not survive container restarts. For
-> production-grade durable HITL, swap in a persistent checkpointer
-> backed by Cosmos DB, Redis, or Azure AI Foundry's managed checkpoint
-> storage.
+The deployment descriptors declare Responses protocol `2.0.0`, which supplies
+the hosted request context required by `FoundryCheckpointSaver`.

--- a/samples/hosting/langgraph-hosted-agents/responses/08_hitl/agent.manifest.yaml
+++ b/samples/hosting/langgraph-hosted-agents/responses/08_hitl/agent.manifest.yaml
@@ -16,7 +16,7 @@ template:
   kind: hosted
   protocols:
     - protocol: responses
-      version: 1.0.0
+      version: 2.0.0
   environment_variables:
     - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
       value: "{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}"

--- a/samples/hosting/langgraph-hosted-agents/responses/08_hitl/agent.yaml
+++ b/samples/hosting/langgraph-hosted-agents/responses/08_hitl/agent.yaml
@@ -3,7 +3,7 @@ kind: hosted
 name: langchain-azure-agent-hitl-responses
 protocols:
   - protocol: responses
-    version: 1.0.0
+    version: 2.0.0
 resources:
   cpu: '0.25'
   memory: '0.5Gi'

--- a/samples/hosting/langgraph-hosted-agents/responses/08_hitl/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/08_hitl/main.py
@@ -199,7 +199,7 @@ async def main() -> None:
         enable_auto_tracing(auto_configure_azure_monitor=True)
 
     if AgentConfig.from_env().is_hosted:
-        checkpointer = FoundryCheckpointSaver()
+        checkpointer = FoundryCheckpointSaver(user_isolation=False)
     else:
         checkpointer = InMemorySaver()
     async with checkpointer:

--- a/samples/hosting/langgraph-hosted-agents/responses/08_hitl/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/08_hitl/main.py
@@ -19,8 +19,9 @@ the same response, both keyed by the same LangGraph interrupt id:
   channel for callers that want to send arbitrary resume payloads
   (``{"resume", "update", "goto"}``) via ``function_call_output``.
 
-State is persisted by an ``InMemorySaver`` checkpointer keyed by the
-``conversation`` id, so the second request continues the paused run.
+State is persisted by a checkpointer keyed by the ``conversation`` id, so the
+second request continues the paused run. Local runs use ``InMemorySaver``;
+Foundry-hosted runs use ``FoundryCheckpointSaver``.
 
 Required environment variables (set in ``.env`` or your shell):
 
@@ -65,15 +66,18 @@ instead (its ``call_id`` is the same interrupt id)::
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import Annotated, Any
 
+from azure.ai.agentserver.core import AgentConfig
 from azure.ai.projects import AIProjectClient
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.types import interrupt
@@ -82,7 +86,10 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from langchain_azure_ai.agents.hosting import ResponsesHostServer
+from langchain_azure_ai.agents.hosting import (
+    FoundryCheckpointSaver,
+    ResponsesHostServer,
+)
 from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
 
 load_dotenv()
@@ -132,7 +139,7 @@ def _build_chat_model() -> ChatOpenAI:
 # ---------------------------------------------------------------------------
 
 
-def _build_graph() -> "object":
+def _build_graph(checkpointer: BaseCheckpointSaver[Any]) -> "object":
     llm = _build_chat_model()
     tools = list(_TOOLS_BY_NAME.values())
     model = llm.bind_tools(tools)
@@ -141,8 +148,7 @@ def _build_graph() -> "object":
         return {"messages": [model.invoke(state["messages"])]}
 
     def approve_and_call_tool(state: MessagesState) -> dict:
-        """Pause for human approval, then execute the proposed tool call.
-        """
+        """Pause for human approval, then execute the proposed tool call."""
         last = state["messages"][-1]
         tool_call = last.tool_calls[0]  # type: ignore[attr-defined]
         proposed: dict[str, Any] = {
@@ -161,9 +167,7 @@ def _build_graph() -> "object":
         tool_fn = _TOOLS_BY_NAME[approved["tool"]]
         result = tool_fn.invoke(approved.get("arguments") or {})
         return {
-            "messages": [
-                ToolMessage(content=str(result), tool_call_id=tool_call["id"])
-            ]
+            "messages": [ToolMessage(content=str(result), tool_call_id=tool_call["id"])]
         }
 
     def should_continue(state: MessagesState) -> str:
@@ -182,10 +186,10 @@ def _build_graph() -> "object":
         path_map=["approve_and_call_tool", END],
     )
     workflow.add_edge("approve_and_call_tool", "agent")
-    return workflow.compile(checkpointer=InMemorySaver())
+    return workflow.compile(checkpointer=checkpointer)
 
 
-def main() -> None:
+async def main() -> None:
     if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
         provider = TracerProvider()
         provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
@@ -194,10 +198,16 @@ def main() -> None:
     else:
         enable_auto_tracing(auto_configure_azure_monitor=True)
 
-    graph = _build_graph()
-    port = int(os.environ.get("PORT", "8088"))
-    ResponsesHostServer(graph).run(port=port)
+    if AgentConfig.from_env().is_hosted:
+        checkpointer = FoundryCheckpointSaver()
+    else:
+        checkpointer = InMemorySaver()
+    async with checkpointer:
+        graph = _build_graph(checkpointer)
+        await ResponsesHostServer(graph).run_async(
+            port=int(os.environ.get("PORT", "8088"))
+        )
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
1. Adds `FoundryCheckpointSaver`, an async LangGraph checkpointer backed by Foundry State Store with typed checkpoint and pending-write schemas and User-Agent propagation.

2. Updates checkpointed Responses samples to use [FoundryCheckpointSaver](vscode-file://vscode-app/c:/Users/aochengwang/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when hosted while preserving their existing in-memory or SQLite savers locally. Deployment manifests now use Responses protocol 2.0.0 for Foundry request-context propagation.

Note: disabled user isolation for now to workaround platform bug, will enable after they fix it.