### PR TITLE
feat: storing feature telemetry in user agent comments

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/_user_agent.py
+++ b/libs/azure-ai/langchain_azure_ai/_user_agent.py
@@ -155,10 +155,15 @@ def get_user_agent() -> str:
     _detect_hosted_environment()
     if not _user_agent_prefixes:
         return BASE_USER_AGENT
-    prefixes = tuple(
-        prefix() if callable(prefix) else prefix
-        for prefix in _user_agent_prefixes.values()
-    )
+    prefixes: list[str] = []
+    for prefix in _user_agent_prefixes.values():
+        try:
+            resolved = prefix() if callable(prefix) else prefix
+        except Exception:
+            logger.debug("Skipping failing User-Agent prefix provider.", exc_info=True)
+            continue
+        if resolved:
+            prefixes.append(resolved)
     return " ".join((*filter(None, prefixes), BASE_USER_AGENT))
 
 

--- a/libs/azure-ai/langchain_azure_ai/_user_agent.py
+++ b/libs/azure-ai/langchain_azure_ai/_user_agent.py
@@ -29,6 +29,7 @@ import importlib.metadata
 import importlib.util
 import logging
 import os
+from collections.abc import Callable
 from typing import Any, Final
 
 logger = logging.getLogger(__name__)
@@ -52,8 +53,9 @@ USER_AGENT_TELEMETRY_DISABLED_ENV_VAR: Final[str] = (
 
 _FOUNDRY_HOSTING_ENV_VAR: Final[str] = "FOUNDRY_HOSTING_ENVIRONMENT"
 
-# Insertion-ordered prefix registry (dict-as-ordered-set).
-_user_agent_prefixes: "dict[str, None]" = {}
+# Insertion-ordered prefix registry. Keys identify registrations so dynamic
+# prefixes can be updated in place without changing their emission order.
+_user_agent_prefixes: "dict[str, str | Callable[[], str]]" = {}
 _hosted_env_detected: bool = False
 
 
@@ -76,7 +78,25 @@ def add_user_agent_prefix(prefix: str) -> None:
         prefix: The token to register. Empty strings are ignored.
     """
     if prefix:
-        _user_agent_prefixes.setdefault(prefix, None)
+        _user_agent_prefixes.setdefault(prefix, prefix)
+
+
+def set_user_agent_prefix(key: str, prefix: "str | Callable[[], str]") -> None:
+    """Register or replace a named UA prefix.
+
+    The key retains its insertion position when its value changes, allowing
+    feature-bearing prefixes to evolve without leaving stale tokens behind.
+    Callable prefixes are resolved each time :func:`get_user_agent` runs.
+
+    Args:
+        key: Stable identifier for the registration.
+        prefix: The token or token provider to emit. An empty string removes
+            the registration.
+    """
+    if isinstance(prefix, str) and not prefix:
+        _user_agent_prefixes.pop(key, None)
+        return
+    _user_agent_prefixes[key] = prefix
 
 
 def _detect_hosted_environment() -> None:
@@ -135,7 +155,11 @@ def get_user_agent() -> str:
     _detect_hosted_environment()
     if not _user_agent_prefixes:
         return BASE_USER_AGENT
-    return " ".join((*_user_agent_prefixes.keys(), BASE_USER_AGENT))
+    prefixes = tuple(
+        prefix() if callable(prefix) else prefix
+        for prefix in _user_agent_prefixes.values()
+    )
+    return " ".join((*filter(None, prefixes), BASE_USER_AGENT))
 
 
 def with_user_agent(headers: "dict[str, Any] | None" = None) -> "dict[str, Any]":

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -112,7 +112,7 @@ class HostingFeature(IntFlag):
     NONE = 0x0
     RESPONSES = 0x1
     INVOCATIONS = 0x2
-    HITL = 0x10
+    HITL = 0x4
 
 
 _HOSTING_PREFIX_KEY = "langchain_azure_ai.agents.hosting"

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -113,6 +113,7 @@ class HostingFeature(IntFlag):
     RESPONSES = 0x1
     INVOCATIONS = 0x2
     HITL = 0x4
+    FOUNDRY_CHECKPOINT = 0x8
 
 
 _HOSTING_PREFIX_KEY = "langchain_azure_ai.agents.hosting"

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/__init__.py
@@ -81,11 +81,15 @@ applications do not need to import Azure SDK modules directly.
 import importlib
 import importlib.metadata
 import os
+from collections.abc import Generator, Iterator, MutableMapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from enum import IntFlag
 from typing import TYPE_CHECKING, Any
 
 from langchain_azure_ai._user_agent import (
-    add_user_agent_prefix,
     get_user_agent,
+    set_user_agent_prefix,
     with_user_agent,
 )
 
@@ -97,10 +101,84 @@ except importlib.metadata.PackageNotFoundError:
 #: UA token contributed by this subpackage.
 HOSTING_USER_AGENT: str = f"langchain_azure_ai.agents.hosting/{_HOSTING_VERSION}"
 
+
+class HostingFeature(IntFlag):
+    """Stable bit assignments for hosting features reported in telemetry.
+
+    Values are ORed into a compact user-agent comment such as
+    ``(features=1f)``. Existing assignments must not be changed or reused.
+    """
+
+    NONE = 0x0
+    RESPONSES = 0x1
+    INVOCATIONS = 0x2
+    HITL = 0x10
+
+
+_HOSTING_PREFIX_KEY = "langchain_azure_ai.agents.hosting"
+_AZURE_HTTP_USER_AGENT_ENV_VAR = "AZURE_HTTP_USER_AGENT"
+_process_hosting_features = HostingFeature.NONE
+_request_hosting_features: ContextVar[HostingFeature] = ContextVar(
+    "langchain_azure_ai_hosting_features",
+    default=HostingFeature.NONE,
+)
+_managed_azure_http_user_agent: str | None = globals().get(
+    "_managed_azure_http_user_agent"
+)
+
+
+def _format_hosting_user_agent(features: HostingFeature) -> str:
+    return f"{HOSTING_USER_AGENT} (features={int(features):x})"
+
+
+def get_hosting_user_agent() -> str:
+    """Return the hosting UA with its compact hexadecimal feature mask."""
+    return _format_hosting_user_agent(get_hosting_features())
+
+
+def get_hosting_features() -> HostingFeature:
+    """Return the process and current-request hosting features."""
+    return _process_hosting_features | _request_hosting_features.get()
+
+
+@contextmanager
+def _hosting_feature_scope(features: HostingFeature) -> Generator[None, None, None]:
+    token = _request_hosting_features.set(features)
+    try:
+        yield
+    finally:
+        _request_hosting_features.reset(token)
+
+
+def _add_request_hosting_features(features: HostingFeature) -> None:
+    current = _request_hosting_features.get()
+    _request_hosting_features.set(current | features)
+
+
+def _sync_azure_http_user_agent() -> None:
+    global _managed_azure_http_user_agent
+    user_agent = _format_hosting_user_agent(_process_hosting_features)
+    current = os.environ.get(_AZURE_HTTP_USER_AGENT_ENV_VAR)
+    if current is None or current == _managed_azure_http_user_agent:
+        os.environ[_AZURE_HTTP_USER_AGENT_ENV_VAR] = user_agent
+        _managed_azure_http_user_agent = user_agent
+    else:
+        _managed_azure_http_user_agent = None
+
+
+def _add_process_hosting_features(features: HostingFeature) -> None:
+    global _process_hosting_features
+    updated = _process_hosting_features | features
+    if updated == _process_hosting_features:
+        return
+    _process_hosting_features = updated
+    _sync_azure_http_user_agent()
+
+
 # Register on import so any outbound SDK client built within a process
 # that uses this hosting layer (including by user code in the hosted
-# graph) automatically carries the hosting prefix.
-add_user_agent_prefix(HOSTING_USER_AGENT)
+# graph) automatically carries the hosting prefix and feature token.
+set_user_agent_prefix(_HOSTING_PREFIX_KEY, get_hosting_user_agent)
 
 # Opaque UA propagation for every ``azure-core`` based SDK client in
 # this process. ``UserAgentPolicy`` (the default policy attached to all
@@ -111,16 +189,16 @@ add_user_agent_prefix(HOSTING_USER_AGENT)
 # azure-ai-vision-*, azure-mgmt-logic, the agentserver host's internal
 # Foundry-storage calls, and the Azure Monitor exporter.
 #
-# ``setdefault`` so a caller-supplied value wins.
-os.environ.setdefault("AZURE_HTTP_USER_AGENT", HOSTING_USER_AGENT)
+# A caller-supplied value wins. While this package owns the value, feature
+# registration refreshes it so azure-core clients observe the latest mask.
+_sync_azure_http_user_agent()
 
 # Third leg of UA propagation: wrap LLM SDK client classes' ``__init__``
 # so any client instance constructed inside a process that imports this
-# hosting layer automatically carries the hosting-SDK UA. The patch
-# writes the merged value into ``self._custom_headers["User-Agent"]``,
-# which takes precedence in the SDK's ``BaseClient.default_headers``
-# merge over the built-in ``<ClientName>/Python <ver>`` token and over
-# ``self.user_agent``, so the prefix lands on every outbound request.
+# hosting layer automatically carries the hosting-SDK UA. The patch stores
+# a live mapping in ``self._custom_headers`` so features discovered after
+# client construction are reflected when ``BaseClient.default_headers``
+# expands the mapping for an outbound request.
 #
 # Two providers are stamped:
 #
@@ -143,6 +221,32 @@ os.environ.setdefault("AZURE_HTTP_USER_AGENT", HOSTING_USER_AGENT)
 # not installed in the environment.
 
 
+class _DynamicUserAgentHeaders(MutableMapping[str, Any]):
+    def __init__(self, headers: dict[str, Any]) -> None:
+        self._headers = headers
+
+    def __getitem__(self, key: str) -> Any:
+        value = self._headers[key]
+        if key != "User-Agent":
+            return value
+        prefix = get_user_agent()
+        if not prefix or prefix in str(value):
+            return value
+        return f"{prefix} {value}".strip()
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._headers[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._headers[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._headers)
+
+    def __len__(self) -> int:
+        return len(self._headers)
+
+
 def _wrap_init_with_user_agent(cls: type) -> None:
     """Patch ``cls.__init__`` to merge the hosting UA prefix into outbound headers.
 
@@ -160,12 +264,6 @@ def _wrap_init_with_user_agent(cls: type) -> None:
         prefix = get_user_agent()
         if not prefix:
             return
-        # ``BaseClient.default_headers`` is the merge of platform + auth
-        # + ``self.user_agent`` + ``self._custom_headers``;
-        # ``_custom_headers`` wins. Combine our prefix with whatever UA
-        # is currently effective so the SDK's own
-        # ``<ClientName>/Python <ver>`` (or a caller-supplied override)
-        # is preserved as the suffix.
         try:
             custom = getattr(self, "_custom_headers", None)
             if custom is None:
@@ -173,8 +271,9 @@ def _wrap_init_with_user_agent(cls: type) -> None:
             existing = custom.get("User-Agent") or getattr(self, "user_agent", "")
             if prefix in (existing or ""):
                 return
-            custom["User-Agent"] = f"{prefix} {existing}".strip()
-            self._custom_headers = custom
+            custom = dict(custom)
+            custom["User-Agent"] = existing
+            self._custom_headers = _DynamicUserAgentHeaders(custom)
         except Exception:
             # Never let UA stamping break client construction.
             pass
@@ -268,6 +367,7 @@ __all__ = [
     "HOSTING_USER_AGENT",
     "CreateResponse",
     "FoundryCheckpointSaver",
+    "HostingFeature",
     "InvocationsHostServer",
     "InvocationAgentServerHost",
     "ResponseContext",
@@ -276,6 +376,8 @@ __all__ = [
     "ResponsesAgentServerHost",
     "ResponsesHostServer",
     "ResponsesServerOptions",
+    "get_hosting_features",
+    "get_hosting_user_agent",
     "get_user_agent",
     "with_user_agent",
 ]

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_foundry_checkpoint_saver.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_foundry_checkpoint_saver.py
@@ -34,6 +34,10 @@ from langgraph.checkpoint.serde.base import SerializerProtocol
 from typing_extensions import NotRequired, TypedDict
 
 from langchain_azure_ai._user_agent import get_user_agent
+from langchain_azure_ai.agents.hosting import (
+    HostingFeature,
+    _add_process_hosting_features,
+)
 
 DEFAULT_STORE_NAME_PREFIX = "langchain_azure_ai.agents.hosting.FoundryCheckpointSaver"
 DEFAULT_ITEM_TTL_SECONDS = 30 * 24 * 60 * 60
@@ -140,6 +144,8 @@ class FoundryCheckpointSaver(BaseCheckpointSaver):
         if not store_name_prefix:
             raise ValueError("store_name_prefix must be a non-empty string")
 
+        self._hosting_features = HostingFeature.FOUNDRY_CHECKPOINT
+        _add_process_hosting_features(self._hosting_features)
         self._owns_credential = credential is None
         self._credential = (
             credential if credential is not None else DefaultAzureCredential()

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_invoke_host.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_invoke_host.py
@@ -55,6 +55,10 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 
 from langchain_azure_ai._api.base import experimental
+from langchain_azure_ai.agents.hosting import (
+    HostingFeature,
+    _hosting_feature_scope,
+)
 
 from ._converters import (
     build_messages_input_from_text,
@@ -147,6 +151,7 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
         graceful_shutdown_timeout: Optional[int] = None,
     ) -> None:
         self._validate_graph_schema(graph)
+        self._hosting_features = HostingFeature.INVOCATIONS
         self._graph = graph
         self._output_parser = output_parser
 
@@ -327,6 +332,10 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
     # ------------------------------------------------------------------
 
     async def _handle_invoke(self, request: Request) -> Response:
+        with _hosting_feature_scope(self._hosting_features):
+            return await self._handle_invoke_with_features(request)
+
+    async def _handle_invoke_with_features(self, request: Request) -> Response:
         try:
             message, stream = await self.parse_request(request)
         except ValueError as exc:
@@ -359,25 +368,26 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
         graph_input: GraphInputT,
         config: RunnableConfig,
     ) -> AsyncIterator[bytes]:
-        try:
-            async for chunk in self._graph.astream(
-                graph_input, config=config, stream_mode="messages"
-            ):
-                message_chunk = _extract_message_chunk(chunk)
-                if message_chunk is None:
-                    continue
-                text = extract_text(message_chunk.content)
-                if not text:
-                    continue
-                payload = json.dumps({"token": text}, ensure_ascii=False)
-                yield f"data: {payload}\n\n".encode("utf-8")
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("LangGraph streaming invocation failed")
-            payload = json.dumps({"error": str(exc)}, ensure_ascii=False)
-            yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
-            return
+        with _hosting_feature_scope(self._hosting_features):
+            try:
+                async for chunk in self._graph.astream(
+                    graph_input, config=config, stream_mode="messages"
+                ):
+                    message_chunk = _extract_message_chunk(chunk)
+                    if message_chunk is None:
+                        continue
+                    text = extract_text(message_chunk.content)
+                    if not text:
+                        continue
+                    payload = json.dumps({"token": text}, ensure_ascii=False)
+                    yield f"data: {payload}\n\n".encode("utf-8")
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("LangGraph streaming invocation failed")
+                payload = json.dumps({"error": str(exc)}, ensure_ascii=False)
+                yield f"event: error\ndata: {payload}\n\n".encode("utf-8")
+                return
 
-        yield b"event: done\ndata: {}\n\n"
+            yield b"event: done\ndata: {}\n\n"
 
     # ------------------------------------------------------------------
     # Validation

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_invoke_host.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_invoke_host.py
@@ -57,6 +57,7 @@ from starlette.responses import JSONResponse, Response, StreamingResponse
 from langchain_azure_ai._api.base import experimental
 from langchain_azure_ai.agents.hosting import (
     HostingFeature,
+    _add_process_hosting_features,
     _hosting_feature_scope,
 )
 
@@ -152,6 +153,7 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
     ) -> None:
         self._validate_graph_schema(graph)
         self._hosting_features = HostingFeature.INVOCATIONS
+        _add_process_hosting_features(self._hosting_features)
         self._graph = graph
         self._output_parser = output_parser
 

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
@@ -56,6 +56,11 @@ except ImportError as exc:
 from langchain_core.runnables import RunnableConfig
 
 from langchain_azure_ai._api.base import experimental
+from langchain_azure_ai.agents.hosting import (
+    HostingFeature,
+    _add_request_hosting_features,
+    _hosting_feature_scope,
+)
 
 from ._converters import (
     build_messages_input,
@@ -214,6 +219,7 @@ class ResponsesHostServer:
         self._validate_graph_schema(graph)
         self._graph = graph
         self._graph_has_checkpointer = _uses_langgraph_checkpointer(graph)
+        self._hosting_features = HostingFeature.RESPONSES
 
         if app is not None:
             # Attach to an existing host (e.g. a multi-protocol mixin).
@@ -668,6 +674,7 @@ class ResponsesHostServer:
             resume_command: Optional["Command"] = None
             consumed_call_ids: frozenset[str] = frozenset()
             if pending:
+                _add_request_hosting_features(HostingFeature.HITL)
                 # Rejection short-circuits the turn into ``response.failed``
                 # so a client-issued ``mcp_approval_response{approve:false}``
                 # is not silently dropped.
@@ -728,6 +735,7 @@ class ResponsesHostServer:
             # Surface any interrupts the graph paused on during this turn.
             new_pending = await detect_pending_interrupts(self._graph, config)
             if new_pending:
+                _add_request_hosting_features(HostingFeature.HITL)
                 async for event in emit_interrupts(new_pending, stream):
                     yield event
 
@@ -747,8 +755,11 @@ class ResponsesHostServer:
         context: ResponseContext,
         cancellation_signal: asyncio.Event,
     ) -> AsyncIterator[Any]:
-        async for event in self.handle_create(request, context, cancellation_signal):
-            yield event
+        with _hosting_feature_scope(self._hosting_features):
+            async for event in self.handle_create(
+                request, context, cancellation_signal
+            ):
+                yield event
 
     # ------------------------------------------------------------------
     # Validation

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
@@ -58,6 +58,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_azure_ai._api.base import experimental
 from langchain_azure_ai.agents.hosting import (
     HostingFeature,
+    _add_process_hosting_features,
     _add_request_hosting_features,
     _hosting_feature_scope,
 )
@@ -220,6 +221,7 @@ class ResponsesHostServer:
         self._graph = graph
         self._graph_has_checkpointer = _uses_langgraph_checkpointer(graph)
         self._hosting_features = HostingFeature.RESPONSES
+        _add_process_hosting_features(self._hosting_features)
 
         if app is not None:
             # Attach to an existing host (e.g. a multi-protocol mixin).

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_foundry_checkpoint_saver.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_foundry_checkpoint_saver.py
@@ -17,7 +17,7 @@ from langgraph.graph import END, START, StateGraph
 from typing_extensions import TypedDict
 
 from langchain_azure_ai._user_agent import get_user_agent
-from langchain_azure_ai.agents.hosting import FoundryCheckpointSaver
+from langchain_azure_ai.agents.hosting import FoundryCheckpointSaver, HostingFeature
 from langchain_azure_ai.agents.hosting._foundry_checkpoint_saver import (
     DEFAULT_STORE_NAME_PREFIX,
 )
@@ -160,6 +160,17 @@ def _checkpoint(checkpoint_id: str, value: str) -> Checkpoint:
             "updated_channels": ["messages"],
         },
     )
+
+
+def test_constructor_registers_foundry_checkpoint_feature() -> None:
+    with patch(
+        "langchain_azure_ai.agents.hosting._foundry_checkpoint_saver."
+        "_add_process_hosting_features"
+    ) as add_process_features:
+        saver = FoundryCheckpointSaver(_credential())
+
+    assert saver._hosting_features == HostingFeature.FOUNDRY_CHECKPOINT
+    add_process_features.assert_called_once_with(HostingFeature.FOUNDRY_CHECKPOINT)
 
 
 @pytest.mark.asyncio

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_invoke_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_invoke_host.py
@@ -15,7 +15,10 @@ from langchain_core.messages import AIMessage  # noqa: E402
 from langchain_core.runnables import RunnableLambda  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
-from langchain_azure_ai.agents.hosting import InvocationsHostServer  # noqa: E402
+from langchain_azure_ai.agents.hosting import (  # noqa: E402
+    HostingFeature,
+    InvocationsHostServer,
+)
 
 from .conftest import (  # noqa: E402
     make_custom_state_graph,
@@ -26,6 +29,12 @@ from .conftest import (  # noqa: E402
 
 def _client(server: InvocationsHostServer) -> TestClient:
     return TestClient(server.app)
+
+
+def test_constructor_registers_invocations_feature() -> None:
+    server = InvocationsHostServer(make_echo_graph())
+
+    assert server._hosting_features == HostingFeature.INVOCATIONS
 
 
 def test_non_streaming_invocation_returns_response_text() -> None:

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_invoke_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_invoke_host.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -32,9 +33,13 @@ def _client(server: InvocationsHostServer) -> TestClient:
 
 
 def test_constructor_registers_invocations_feature() -> None:
-    server = InvocationsHostServer(make_echo_graph())
+    with patch(
+        "langchain_azure_ai.agents.hosting._invoke_host._add_process_hosting_features"
+    ) as add_process_features:
+        server = InvocationsHostServer(make_echo_graph())
 
     assert server._hosting_features == HostingFeature.INVOCATIONS
+    add_process_features.assert_called_once_with(HostingFeature.INVOCATIONS)
 
 
 def test_non_streaming_invocation_returns_response_text() -> None:

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
@@ -9,7 +9,7 @@ import json
 import logging
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -42,9 +42,14 @@ def _client(server: ResponsesHostServer) -> TestClient:
 
 
 def test_constructor_registers_responses_features() -> None:
-    server = ResponsesHostServer(make_checkpointed_echo_graph())
+    with patch(
+        "langchain_azure_ai.agents.hosting._responses_host."
+        "_add_process_hosting_features"
+    ) as add_process_features:
+        server = ResponsesHostServer(make_checkpointed_echo_graph())
 
     assert server._hosting_features == HostingFeature.RESPONSES
+    add_process_features.assert_called_once_with(HostingFeature.RESPONSES)
 
 
 def _parse_sse(body: str) -> list[tuple[str, dict]]:

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
@@ -24,6 +24,7 @@ from azure.ai.agentserver.responses.models import (  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
 from langchain_azure_ai.agents.hosting import (  # noqa: E402
+    HostingFeature,
     ResponsesHostServer,
     ResponsesServerOptions,
 )
@@ -38,6 +39,12 @@ from .conftest import (  # noqa: E402
 
 def _client(server: ResponsesHostServer) -> TestClient:
     return TestClient(server.app)
+
+
+def test_constructor_registers_responses_features() -> None:
+    server = ResponsesHostServer(make_checkpointed_echo_graph())
+
+    assert server._hosting_features == HostingFeature.RESPONSES
 
 
 def _parse_sse(body: str) -> list[tuple[str, dict]]:

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -96,6 +96,17 @@ class TestGetUserAgent:
             f"features/2 {_user_agent.BASE_USER_AGENT}"
         )
 
+    def test_failing_named_prefix_provider_is_skipped(self) -> None:
+        def fail() -> str:
+            raise RuntimeError("provider failed")
+
+        _user_agent.set_user_agent_prefix("failing", fail)
+        _user_agent.add_user_agent_prefix("healthy/1.0")
+
+        assert _user_agent.get_user_agent() == (
+            f"healthy/1.0 {_user_agent.BASE_USER_AGENT}"
+        )
+
 
 class TestVersionResolution:
     def test_unknown_package_falls_back_to_zero(self) -> None:
@@ -152,6 +163,19 @@ class TestWithUserAgent:
     def test_none_input_returns_ua_only(self) -> None:
         result = _user_agent.with_user_agent(None)
         assert result == {_user_agent.USER_AGENT_KEY: _user_agent.BASE_USER_AGENT}
+
+    def test_failing_named_prefix_provider_does_not_break_stamping(self) -> None:
+        def fail() -> str:
+            raise RuntimeError("provider failed")
+
+        _user_agent.set_user_agent_prefix("failing", fail)
+
+        result = _user_agent.with_user_agent({"X-Trace-Id": "abc"})
+
+        assert result == {
+            "X-Trace-Id": "abc",
+            _user_agent.USER_AGENT_KEY: _user_agent.BASE_USER_AGENT,
+        }
 
     def test_empty_dict_input_returns_ua_only(self) -> None:
         result = _user_agent.with_user_agent({})
@@ -349,8 +373,7 @@ class TestHostingAzureHttpUserAgent:
     def test_feature_registration_updates_managed_value(self) -> None:
         with self._reload_hosting_with_env(None) as hosting:
             hosting._add_process_hosting_features(
-                hosting.HostingFeature.RESPONSES
-                | hosting.HostingFeature.INVOCATIONS
+                hosting.HostingFeature.RESPONSES | hosting.HostingFeature.INVOCATIONS
             )
 
             assert hosting.get_hosting_features() == 0x3

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -372,9 +372,9 @@ class TestHostingAzureHttpUserAgent:
             with hosting._hosting_feature_scope(hosting.HostingFeature.NONE):
                 hosting._add_request_hosting_features(hosting.HostingFeature.HITL)
 
-                assert hosting.get_hosting_features() == 0x11
-                assert hosting.get_hosting_user_agent().endswith("(features=11)")
-                assert _user_agent.get_user_agent().count("(features=11)") == 1
+                assert hosting.get_hosting_features() == 0x5
+                assert hosting.get_hosting_user_agent().endswith("(features=5)")
+                assert _user_agent.get_user_agent().count("(features=5)") == 1
                 assert os.environ["AZURE_HTTP_USER_AGENT"] == process_user_agent
 
             assert hosting.get_hosting_features() == 0x1
@@ -395,7 +395,7 @@ class TestHostingAzureHttpUserAgent:
                 read_features(hosting.HostingFeature.INVOCATIONS),
             )
 
-            assert hitl == 0x11
+            assert hitl == 0x5
             assert invocations == 0x3
             assert hosting.get_hosting_features() == 0x1
 
@@ -494,7 +494,7 @@ class TestHostingOpenAIUserAgentStamp:
                 hosting._add_request_hosting_features(hosting.HostingFeature.HITL)
                 ua = client.default_headers["User-Agent"]
 
-        assert ua.startswith(f"{hosting.HOSTING_USER_AGENT} (features=11) ")
+        assert ua.startswith(f"{hosting.HOSTING_USER_AGENT} (features=5) ")
         assert ua.count(hosting.HOSTING_USER_AGENT) == 1
 
     def test_opt_out_skips_stamping(self) -> None:

--- a/libs/azure-ai/tests/unit_tests/test_user_agent.py
+++ b/libs/azure-ai/tests/unit_tests/test_user_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import os
 import sys
@@ -67,6 +68,33 @@ class TestGetUserAgent:
     def test_empty_prefix_ignored(self) -> None:
         _user_agent.add_user_agent_prefix("")
         assert _user_agent.get_user_agent() == _user_agent.BASE_USER_AGENT
+
+    def test_named_prefix_is_replaced_in_place(self) -> None:
+        _user_agent.add_user_agent_prefix("alpha/1.0")
+        _user_agent.set_user_agent_prefix("features", "(features=1)")
+        _user_agent.add_user_agent_prefix("omega/1.0")
+
+        _user_agent.set_user_agent_prefix("features", "(features=3)")
+
+        assert _user_agent.get_user_agent() == (
+            f"alpha/1.0 (features=3) omega/1.0 {_user_agent.BASE_USER_AGENT}"
+        )
+
+    def test_empty_named_prefix_removes_registration(self) -> None:
+        _user_agent.set_user_agent_prefix("features", "(features=1)")
+        _user_agent.set_user_agent_prefix("features", "")
+
+        assert _user_agent.get_user_agent() == _user_agent.BASE_USER_AGENT
+
+    def test_named_prefix_provider_is_resolved_lazily(self) -> None:
+        value = "features/1"
+        _user_agent.set_user_agent_prefix("features", lambda: value)
+
+        value = "features/2"
+
+        assert _user_agent.get_user_agent() == (
+            f"features/2 {_user_agent.BASE_USER_AGENT}"
+        )
 
 
 class TestVersionResolution:
@@ -313,10 +341,72 @@ class TestHostingAzureHttpUserAgent:
     def test_env_var_is_set_on_import(self) -> None:
         """With no pre-existing env var, hosting injects its prefix."""
         with self._reload_hosting_with_env(None) as hosting:
-            assert os.environ.get("AZURE_HTTP_USER_AGENT") == hosting.HOSTING_USER_AGENT
+            assert (
+                os.environ.get("AZURE_HTTP_USER_AGENT")
+                == hosting.get_hosting_user_agent()
+            )
+
+    def test_feature_registration_updates_managed_value(self) -> None:
+        with self._reload_hosting_with_env(None) as hosting:
+            hosting._add_process_hosting_features(
+                hosting.HostingFeature.RESPONSES
+                | hosting.HostingFeature.INVOCATIONS
+            )
+
+            assert hosting.get_hosting_features() == 0x3
+            assert hosting.get_hosting_user_agent().endswith("(features=3)")
+            assert _user_agent.get_user_agent().count("(features=3)") == 1
+            assert os.environ["AZURE_HTTP_USER_AGENT"].endswith("(features=3)")
+
+    def test_feature_mask_expands_beyond_sixteen_bits(self) -> None:
+        with self._reload_hosting_with_env(None) as hosting:
+            hosting._add_process_hosting_features(hosting.HostingFeature(1 << 16))
+
+            assert hosting.get_hosting_user_agent().endswith("(features=10000)")
+
+    def test_request_features_merge_without_changing_azure_environment(self) -> None:
+        with self._reload_hosting_with_env(None) as hosting:
+            hosting._add_process_hosting_features(hosting.HostingFeature.RESPONSES)
+            process_user_agent = os.environ["AZURE_HTTP_USER_AGENT"]
+
+            with hosting._hosting_feature_scope(hosting.HostingFeature.NONE):
+                hosting._add_request_hosting_features(hosting.HostingFeature.HITL)
+
+                assert hosting.get_hosting_features() == 0x11
+                assert hosting.get_hosting_user_agent().endswith("(features=11)")
+                assert _user_agent.get_user_agent().count("(features=11)") == 1
+                assert os.environ["AZURE_HTTP_USER_AGENT"] == process_user_agent
+
+            assert hosting.get_hosting_features() == 0x1
+            assert hosting.get_hosting_user_agent().endswith("(features=1)")
+
+    async def test_request_features_are_isolated_across_tasks(self) -> None:
+        with self._reload_hosting_with_env(None) as hosting:
+            hosting._add_process_hosting_features(hosting.HostingFeature.RESPONSES)
+
+            async def read_features(feature: Any) -> Any:
+                with hosting._hosting_feature_scope(hosting.HostingFeature.NONE):
+                    hosting._add_request_hosting_features(feature)
+                    await asyncio.sleep(0)
+                    return hosting.get_hosting_features()
+
+            hitl, invocations = await asyncio.gather(
+                read_features(hosting.HostingFeature.HITL),
+                read_features(hosting.HostingFeature.INVOCATIONS),
+            )
+
+            assert hitl == 0x11
+            assert invocations == 0x3
+            assert hosting.get_hosting_features() == 0x1
+
+    def test_feature_registration_preserves_caller_value(self) -> None:
+        with self._reload_hosting_with_env("caller/1.0") as hosting:
+            hosting._add_process_hosting_features(hosting.HostingFeature.RESPONSES)
+
+            assert os.environ["AZURE_HTTP_USER_AGENT"] == "caller/1.0"
 
     def test_caller_value_wins(self) -> None:
-        """Hosting's ``setdefault`` preserves a caller-supplied value."""
+        """Hosting preserves a caller-supplied value."""
         with self._reload_hosting_with_env("caller/1.0") as hosting:
             assert os.environ["AZURE_HTTP_USER_AGENT"] == "caller/1.0"
             # Sanity: the hosting prefix exists but was not used here.
@@ -388,6 +478,24 @@ class TestHostingOpenAIUserAgentStamp:
         client = openai.AsyncOpenAI(api_key="test-key")
         ua = client._custom_headers["User-Agent"]
         assert ua.count(prefix) == 1
+
+    def test_existing_client_observes_updated_feature_mask(self) -> None:
+        openai = pytest.importorskip("openai")
+        import langchain_azure_ai.agents.hosting as hosting
+
+        _user_agent.set_user_agent_prefix("hosting", hosting.get_hosting_user_agent)
+        with patch.object(
+            hosting,
+            "_process_hosting_features",
+            hosting.HostingFeature.NONE,
+        ):
+            client = openai.AsyncOpenAI(api_key="test-key")
+            with hosting._hosting_feature_scope(hosting.HostingFeature.RESPONSES):
+                hosting._add_request_hosting_features(hosting.HostingFeature.HITL)
+                ua = client.default_headers["User-Agent"]
+
+        assert ua.startswith(f"{hosting.HOSTING_USER_AGENT} (features=11) ")
+        assert ua.count(hosting.HOSTING_USER_AGENT) == 1
 
     def test_opt_out_skips_stamping(self) -> None:
         openai = pytest.importorskip("openai")


### PR DESCRIPTION
## Summary
- Add compact feature telemetry to hosting user agents using contiguous bit flags.
- Track Responses, Invocations, checkpoint and HITL usage with request isolation.
- Dynamically propagate telemetry to supported SDK clients.

Example for Responses + HITL:
```
langchain_azure_ai.agents.hosting/1.2.8 (features=5)
```
Here, 5 = 0x1 | 0x4.