### PR TITLE
feat: add langchain_azure_ai.agents.hosting.run SDK for effortless migration from existing langgraph agents

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/run.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/run.py
@@ -23,13 +23,19 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Host a graph from a LangGraph configuration file with "
-            "the Microsoft Foundry Responses API server."
+            "a Microsoft Foundry agent server."
         )
     )
     parser.add_argument(
         "agent",
         nargs="?",
         help="graph name; required when the configuration defines multiple graphs",
+    )
+    parser.add_argument(
+        "--protocol",
+        required=True,
+        choices=("responses", "invocations"),
+        help="agent server protocol to expose",
     )
     parser.add_argument(
         "--config",
@@ -178,9 +184,7 @@ def _parse_option(raw_option: str) -> tuple[str, Any]:
     try:
         name, raw_value = raw_option.split("=", 1)
     except ValueError as exc:
-        raise ValueError(
-            f"invalid option {raw_option!r}; expected NAME=VALUE"
-        ) from exc
+        raise ValueError(f"invalid option {raw_option!r}; expected NAME=VALUE") from exc
     name = name.strip()
     raw_value = raw_value.strip()
     if not name or not raw_value:
@@ -202,18 +206,27 @@ def _server_options(raw_options: Sequence[str]) -> ResponsesServerOptions:
 
 def _run_server(
     graph: Any,
-    options: ResponsesServerOptions,
     *,
+    protocol: str,
+    options: ResponsesServerOptions | None,
     host: str,
     port: int | None,
 ) -> None:
-    from . import ResponsesHostServer
+    if protocol == "responses":
+        from . import ResponsesHostServer
 
-    ResponsesHostServer(graph, options=options).run(host=host, port=port)
+        ResponsesHostServer(graph, options=options).run(host=host, port=port)
+        return
+    if protocol == "invocations":
+        from . import InvocationsHostServer
+
+        InvocationsHostServer(graph).run(host=host, port=port)
+        return
+    raise ValueError(f"unsupported protocol: {protocol}")
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    """Load the selected graph and run it with ``ResponsesHostServer``."""
+    """Load the selected graph and run it with the requested protocol."""
     parser = _parser()
     args = parser.parse_args(argv)
     directory = Path.cwd()
@@ -225,8 +238,16 @@ def main(argv: Sequence[str] | None = None) -> None:
         graphs = _read_graphs(config_path)
         _, target = _select_graph(graphs, args.agent)
         graph = _load_graph(target, config_path.parent)
-        options = _server_options(args.option)
-        _run_server(graph, options, host=args.host, port=args.port)
+        if args.protocol == "invocations" and args.option:
+            raise ValueError("--option is only supported by the responses protocol")
+        options = _server_options(args.option) if args.protocol == "responses" else None
+        _run_server(
+            graph,
+            protocol=args.protocol,
+            options=options,
+            host=args.host,
+            port=args.port,
+        )
     except (ImportError, OSError, ValueError) as exc:
         parser.error(str(exc))
 

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/run.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/run.py
@@ -1,0 +1,235 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Run a graph from a LangGraph configuration file."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import importlib.util
+import inspect
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Awaitable, Sequence
+
+from azure.ai.agentserver.responses import ResponsesServerOptions
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Host a graph from a LangGraph configuration file with "
+            "the Microsoft Foundry Responses API server."
+        )
+    )
+    parser.add_argument(
+        "agent",
+        nargs="?",
+        help="graph name; required when the configuration defines multiple graphs",
+    )
+    parser.add_argument(
+        "--config",
+        default="langgraph.json",
+        help="path to the LangGraph configuration file (default: langgraph.json)",
+    )
+    parser.add_argument(
+        "--option",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help=(
+            "ResponsesServerOptions value; repeat for multiple options "
+            "(for example, --option resilient_background=true)"
+        ),
+    )
+    parser.add_argument("--host", default="0.0.0.0", help="interface to bind")
+    parser.add_argument(
+        "--port", type=int, help="port to bind; defaults to PORT or 8088"
+    )
+    return parser
+
+
+def _read_graphs(config_path: Path) -> dict[str, str]:
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(
+            f"{config_path.name} was not found in {config_path.parent}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid {config_path.name}: {exc}") from exc
+
+    graphs = config.get("graphs") if isinstance(config, dict) else None
+    if not isinstance(graphs, dict) or not graphs:
+        raise ValueError(f"{config_path.name} must define a non-empty 'graphs' object")
+
+    targets: dict[str, str] = {}
+    for name, graph_definition in graphs.items():
+        if not isinstance(name, str):
+            raise ValueError(f"{config_path.name} graph names must be strings")
+        if isinstance(graph_definition, str):
+            targets[name] = graph_definition
+        elif isinstance(graph_definition, dict) and isinstance(
+            graph_definition.get("path"), str
+        ):
+            targets[name] = graph_definition["path"]
+        else:
+            raise ValueError(
+                f"{config_path.name} graph {name!r} must be a target string "
+                "or an object with a string 'path'"
+            )
+    return targets
+
+
+def _select_graph(graphs: dict[str, str], agent: str | None) -> tuple[str, str]:
+    if agent is None:
+        if len(graphs) == 1:
+            return next(iter(graphs.items()))
+        names = ", ".join(sorted(graphs))
+        raise ValueError(f"multiple graphs are configured; specify one of: {names}")
+    try:
+        return agent, graphs[agent]
+    except KeyError as exc:
+        names = ", ".join(sorted(graphs))
+        raise ValueError(f"unknown graph {agent!r}; choose one of: {names}") from exc
+
+
+def _module_name_for_path(module_path: Path) -> tuple[str, Path]:
+    parts = [module_path.stem]
+    package_root = module_path.parent
+    while (package_root / "__init__.py").is_file():
+        parts.append(package_root.name)
+        package_root = package_root.parent
+    if len(parts) == 1:
+        parts[0] = f"_langchain_azure_hosting_{module_path.stem}"
+    return ".".join(reversed(parts)), package_root
+
+
+def _load_file_module(module_path: Path) -> ModuleType:
+    if not module_path.is_file():
+        raise ValueError(f"graph module file does not exist: {module_path}")
+    module_name, import_root = _module_name_for_path(module_path)
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"could not load graph module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+async def _await_graph(value: Awaitable[Any]) -> Any:
+    return await value
+
+
+def _resolve_graph(value: Any, target: str) -> Any:
+    if callable(getattr(value, "astream", None)):
+        return value
+    if callable(value):
+        try:
+            inspect.signature(value).bind()
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"graph factory {target!r} must accept no arguments"
+            ) from exc
+        value = value()
+    if inspect.isawaitable(value):
+        value = asyncio.run(_await_graph(value))
+    return value
+
+
+def _load_graph(target: str, directory: Path) -> Any:
+    try:
+        module_target, symbol_target = target.rsplit(":", 1)
+    except ValueError as exc:
+        raise ValueError(
+            f"invalid graph target {target!r}; expected 'module-or-file:symbol'"
+        ) from exc
+    if not module_target or not symbol_target:
+        raise ValueError(
+            f"invalid graph target {target!r}; expected 'module-or-file:symbol'"
+        )
+
+    if module_target.endswith(".py") or "/" in module_target or "\\" in module_target:
+        module = _load_file_module((directory / module_target).resolve())
+    else:
+        if str(directory) not in sys.path:
+            sys.path.insert(0, str(directory))
+        module = importlib.import_module(module_target)
+
+    value: Any = module
+    try:
+        for part in symbol_target.split("."):
+            value = getattr(value, part)
+    except AttributeError as exc:
+        raise ValueError(
+            f"graph target {target!r} has no symbol {symbol_target!r}"
+        ) from exc
+    return _resolve_graph(value, target)
+
+
+def _parse_option(raw_option: str) -> tuple[str, Any]:
+    try:
+        name, raw_value = raw_option.split("=", 1)
+    except ValueError as exc:
+        raise ValueError(
+            f"invalid option {raw_option!r}; expected NAME=VALUE"
+        ) from exc
+    name = name.strip()
+    raw_value = raw_value.strip()
+    if not name or not raw_value:
+        raise ValueError(f"invalid option {raw_option!r}; expected NAME=VALUE")
+    try:
+        value = json.loads(raw_value)
+    except json.JSONDecodeError:
+        value = raw_value
+    return name, value
+
+
+def _server_options(raw_options: Sequence[str]) -> ResponsesServerOptions:
+    kwargs = dict(_parse_option(raw_option) for raw_option in raw_options)
+    try:
+        return ResponsesServerOptions(**kwargs)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid server options: {exc}") from exc
+
+
+def _run_server(
+    graph: Any,
+    options: ResponsesServerOptions,
+    *,
+    host: str,
+    port: int | None,
+) -> None:
+    from . import ResponsesHostServer
+
+    ResponsesHostServer(graph, options=options).run(host=host, port=port)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Load the selected graph and run it with ``ResponsesHostServer``."""
+    parser = _parser()
+    args = parser.parse_args(argv)
+    directory = Path.cwd()
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = directory / config_path
+    config_path = config_path.resolve()
+    try:
+        graphs = _read_graphs(config_path)
+        _, target = _select_graph(graphs, args.agent)
+        graph = _load_graph(target, config_path.parent)
+        options = _server_options(args.option)
+        _run_server(graph, options, host=args.host, port=args.port)
+    except (ImportError, OSError, ValueError) as exc:
+        parser.error(str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/run.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/run.py
@@ -11,6 +11,7 @@ import importlib
 import importlib.util
 import inspect
 import json
+import os
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -241,12 +242,16 @@ def main(argv: Sequence[str] | None = None) -> None:
         if args.protocol == "invocations" and args.option:
             raise ValueError("--option is only supported by the responses protocol")
         options = _server_options(args.option) if args.protocol == "responses" else None
+        if args.port is not None:
+            port = args.port
+        else:
+            port = int(os.environ.get("PORT", "8088"))
         _run_server(
             graph,
             protocol=args.protocol,
             options=options,
             host=args.host,
-            port=args.port,
+            port=port,
         )
     except (ImportError, OSError, ValueError) as exc:
         parser.error(str(exc))

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_run.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_run.py
@@ -86,8 +86,23 @@ def test_main_selects_named_graph(
         "protocol": "invocations",
         "options": None,
         "host": "0.0.0.0",
-        "port": None,
+        "port": 8088,
     }
+
+
+def test_main_uses_port_from_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "graph.py").write_text("graph = object()\n", encoding="utf-8")
+    _write_config(tmp_path, {"agent": "./graph.py:graph"})
+    run_server = MagicMock()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PORT", "9001")
+    monkeypatch.setattr(run, "_run_server", run_server)
+
+    run.main(["--protocol", "responses"])
+
+    assert run_server.call_args.kwargs["port"] == 9001
 
 
 def test_main_loads_structured_graph_definition(

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_run.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_run.py
@@ -1,0 +1,183 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("azure.ai.agentserver.responses")
+
+from langchain_azure_ai.agents.hosting import run  # noqa: E402
+
+
+def _write_config(directory: Path, graphs: dict[str, object]) -> None:
+    (directory / "langgraph.json").write_text(
+        json.dumps({"graphs": graphs}), encoding="utf-8"
+    )
+
+
+def test_main_hosts_only_graph_with_options(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "graph.py").write_text("graph = object()\n", encoding="utf-8")
+    _write_config(tmp_path, {"agent": "./graph.py:graph"})
+    run_server = MagicMock()
+    options = object()
+    options_type = MagicMock(return_value=options)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run, "_run_server", run_server)
+    monkeypatch.setattr(run, "ResponsesServerOptions", options_type)
+
+    run.main(
+        [
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "9000",
+            "--option",
+            "resilient_background=true",
+            "--option",
+            "default_fetch_history_count=25",
+        ]
+    )
+
+    loaded_graph = run_server.call_args.args[0]
+    assert loaded_graph is not None
+    options_type.assert_called_once_with(
+        resilient_background=True, default_fetch_history_count=25
+    )
+    run_server.assert_called_once_with(
+        loaded_graph, options, host="127.0.0.1", port=9000
+    )
+
+
+def test_main_selects_named_graph(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "graphs.py").write_text(
+        "first = object()\nsecond = object()\n", encoding="utf-8"
+    )
+    _write_config(
+        tmp_path,
+        {
+            "first": "./graphs.py:first",
+            "second": "./graphs.py:second",
+        },
+    )
+    run_server = MagicMock()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run, "_run_server", run_server)
+
+    run.main(["second"])
+
+    assert run_server.call_args.args[0] is not None
+    assert run_server.call_args.kwargs == {"host": "0.0.0.0", "port": None}
+
+
+def test_main_loads_structured_graph_definition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "graph.py").write_text("graph = object()\n", encoding="utf-8")
+    _write_config(
+        tmp_path,
+        {"agent": {"path": "./graph.py:graph", "description": "Test graph"}},
+    )
+    run_server = MagicMock()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run, "_run_server", run_server)
+
+    run.main([])
+
+    assert run_server.call_args.args[0] is not None
+
+
+def test_main_loads_graph_from_custom_config_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_directory = tmp_path / "config"
+    config_directory.mkdir()
+    (config_directory / "graph.py").write_text(
+        "graph = object()\n", encoding="utf-8"
+    )
+    (config_directory / "custom.json").write_text(
+        json.dumps({"graphs": {"agent": "./graph.py:graph"}}), encoding="utf-8"
+    )
+    run_server = MagicMock()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run, "_run_server", run_server)
+
+    run.main(["--config", "config/custom.json"])
+
+    assert run_server.call_args.args[0] is not None
+
+
+def test_load_graph_invokes_sync_factory(tmp_path: Path) -> None:
+    (tmp_path / "graph.py").write_text(
+        "def make_graph():\n    return {'kind': 'graph'}\n",
+        encoding="utf-8",
+    )
+
+    graph = run._load_graph("./graph.py:make_graph", tmp_path)
+
+    assert graph == {"kind": "graph"}
+
+
+def test_load_graph_awaits_async_factory(tmp_path: Path) -> None:
+    (tmp_path / "graph.py").write_text(
+        "async def make_graph():\n    return {'kind': 'graph'}\n",
+        encoding="utf-8",
+    )
+
+    graph = run._load_graph("./graph.py:make_graph", tmp_path)
+
+    assert graph == {"kind": "graph"}
+
+
+def test_load_graph_preserves_callable_graph(tmp_path: Path) -> None:
+    (tmp_path / "graph.py").write_text(
+        "class Graph:\n"
+        "    def __call__(self):\n"
+        "        raise AssertionError('graph should not be invoked')\n"
+        "\n"
+        "    async def astream(self):\n"
+        "        yield None\n"
+        "\n"
+        "graph = Graph()\n",
+        encoding="utf-8",
+    )
+
+    graph = run._load_graph("./graph.py:graph", tmp_path)
+
+    assert callable(graph.astream)
+
+
+def test_main_requires_name_for_multiple_graphs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_config(tmp_path, {"first": "a:graph", "second": "b:graph"})
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit, match="2"):
+        run.main([])
+
+    assert "specify one of: first, second" in capsys.readouterr().err
+
+
+def test_main_rejects_unknown_graph(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_config(tmp_path, {"agent": "graph:agent"})
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit, match="2"):
+        run.main(["missing"])
+
+    assert "unknown graph 'missing'; choose one of: agent" in capsys.readouterr().err

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_run.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_run.py
@@ -11,6 +11,7 @@ import pytest
 
 pytest.importorskip("azure.ai.agentserver.responses")
 
+import langchain_azure_ai.agents.hosting as hosting  # noqa: E402
 from langchain_azure_ai.agents.hosting import run  # noqa: E402
 
 
@@ -34,6 +35,8 @@ def test_main_hosts_only_graph_with_options(
 
     run.main(
         [
+            "--protocol",
+            "responses",
             "--host",
             "127.0.0.1",
             "--port",
@@ -51,7 +54,11 @@ def test_main_hosts_only_graph_with_options(
         resilient_background=True, default_fetch_history_count=25
     )
     run_server.assert_called_once_with(
-        loaded_graph, options, host="127.0.0.1", port=9000
+        loaded_graph,
+        protocol="responses",
+        options=options,
+        host="127.0.0.1",
+        port=9000,
     )
 
 
@@ -72,10 +79,15 @@ def test_main_selects_named_graph(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(run, "_run_server", run_server)
 
-    run.main(["second"])
+    run.main(["second", "--protocol", "invocations"])
 
     assert run_server.call_args.args[0] is not None
-    assert run_server.call_args.kwargs == {"host": "0.0.0.0", "port": None}
+    assert run_server.call_args.kwargs == {
+        "protocol": "invocations",
+        "options": None,
+        "host": "0.0.0.0",
+        "port": None,
+    }
 
 
 def test_main_loads_structured_graph_definition(
@@ -90,7 +102,7 @@ def test_main_loads_structured_graph_definition(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(run, "_run_server", run_server)
 
-    run.main([])
+    run.main(["--protocol", "responses"])
 
     assert run_server.call_args.args[0] is not None
 
@@ -100,9 +112,7 @@ def test_main_loads_graph_from_custom_config_path(
 ) -> None:
     config_directory = tmp_path / "config"
     config_directory.mkdir()
-    (config_directory / "graph.py").write_text(
-        "graph = object()\n", encoding="utf-8"
-    )
+    (config_directory / "graph.py").write_text("graph = object()\n", encoding="utf-8")
     (config_directory / "custom.json").write_text(
         json.dumps({"graphs": {"agent": "./graph.py:graph"}}), encoding="utf-8"
     )
@@ -110,7 +120,7 @@ def test_main_loads_graph_from_custom_config_path(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(run, "_run_server", run_server)
 
-    run.main(["--config", "config/custom.json"])
+    run.main(["--protocol", "responses", "--config", "config/custom.json"])
 
     assert run_server.call_args.args[0] is not None
 
@@ -164,7 +174,7 @@ def test_main_requires_name_for_multiple_graphs(
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(SystemExit, match="2"):
-        run.main([])
+        run.main(["--protocol", "responses"])
 
     assert "specify one of: first, second" in capsys.readouterr().err
 
@@ -178,6 +188,75 @@ def test_main_rejects_unknown_graph(
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(SystemExit, match="2"):
-        run.main(["missing"])
+        run.main(["missing", "--protocol", "responses"])
 
     assert "unknown graph 'missing'; choose one of: agent" in capsys.readouterr().err
+
+
+def test_main_requires_protocol(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        run.main([])
+
+    assert "--protocol" in capsys.readouterr().err
+
+
+def test_main_rejects_options_for_invocations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "graph.py").write_text("graph = object()\n", encoding="utf-8")
+    _write_config(tmp_path, {"agent": "./graph.py:graph"})
+    run_server = MagicMock()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run, "_run_server", run_server)
+
+    with pytest.raises(SystemExit, match="2"):
+        run.main(
+            [
+                "--protocol",
+                "invocations",
+                "--option",
+                "resilient_background=true",
+            ]
+        )
+
+    assert "--option is only supported" in capsys.readouterr().err
+    run_server.assert_not_called()
+
+
+def test_run_server_uses_responses_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    graph = object()
+    options = MagicMock(spec=run.ResponsesServerOptions)
+    responses_host = MagicMock()
+    monkeypatch.setattr(hosting, "ResponsesHostServer", responses_host)
+
+    run._run_server(
+        graph,
+        protocol="responses",
+        options=options,
+        host="127.0.0.1",
+        port=9000,
+    )
+
+    responses_host.assert_called_once_with(graph, options=options)
+    responses_host.return_value.run.assert_called_once_with(host="127.0.0.1", port=9000)
+
+
+def test_run_server_uses_invocations_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    graph = object()
+    invocations_host = MagicMock()
+    monkeypatch.setattr(hosting, "InvocationsHostServer", invocations_host)
+
+    run._run_server(
+        graph,
+        protocol="invocations",
+        options=None,
+        host="127.0.0.1",
+        port=9000,
+    )
+
+    invocations_host.assert_called_once_with(graph)
+    invocations_host.return_value.run.assert_called_once_with(
+        host="127.0.0.1", port=9000
+    )

--- a/samples/hosting/langgraph-hosted-agents/README.md
+++ b/samples/hosting/langgraph-hosted-agents/README.md
@@ -10,8 +10,8 @@ REST endpoint that speaks either the **Responses** protocol or the
 
 Each sample is a self-contained folder with its own `main.py`,
 `README.md`, `requirements.txt`, `Dockerfile`, `agent.manifest.yaml`,
-and `agent.yaml` so it can be run locally with `python main.py` or
-deployed to Foundry with `azd`.
+and `agent.yaml` so it can be run locally with the command in its README
+or deployed to Foundry with `azd`.
 
 ## Samples
 
@@ -27,6 +27,7 @@ deployed to Foundry with `azd`.
 | 6 | [Files](responses/06_files/) | Filesystem tools (`list_files`, `read_text_file`) that let the agent read files shipped with the container under a configurable data root. |
 | 7 | [Observability](responses/07_observability/) | Standalone observability sample — minimal `create_agent` graph with GenAI OpenTelemetry tracing wired to the Foundry project's managed Application Insights, with `AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED=true` enabled by default. |
 | 8 | [HITL](responses/08_hitl/) | Approval-style human-in-the-loop using `langgraph.types.interrupt`. Pending interrupts surface as the standard OpenAI `mcp_approval_request` output item; the client approves (or rejects) via `mcp_approval_response` — the same flow OpenAI uses for MCP server tool approvals. A paired `function_call` item is also emitted for callers that need to override the proposed payload via `function_call_output`. |
+| 9 | [Run entrypoint](responses/09_run/) | The basic `create_agent` graph loaded from `langgraph.json` and hosted through `langchain_azure_ai.agents.hosting.run`. |
 
 > This tree follows the Agent Framework's [`foundry-hosted-agents`](https://github.com/microsoft/agent-framework/tree/main/python/samples/04-hosting/foundry-hosted-agents)
 > folder structure and naming style. Observability coverage for the
@@ -39,6 +40,7 @@ deployed to Foundry with `azd`.
 |---|--------|-------------|
 | 1 | [Basic](invocations/01_basic/) | Minimal `create_agent` + `MemorySaver` checkpointer for multi-turn continuity via `agent_session_id` headers/URL params. |
 | 2 | [Tools](invocations/02_tools/) | Repo-specific LangChain tools sample. The tool round-trip runs server-side and the client sees only the final assistant text (or token deltas when streaming). This differs from the Agent Framework's current `02_break_glass` sample. |
+| 3 | [Run entrypoint](invocations/03_run/) | The basic `create_agent` + `MemorySaver` graph loaded from `langgraph.json` and hosted through `langchain_azure_ai.agents.hosting.run`. |
 
 ## Running the Agent Host Locally
 
@@ -158,8 +160,20 @@ across all samples.
 
 #### Run the agent host
 
+Most samples start with:
+
 ```bash
 python main.py
+```
+
+The configuration-driven samples instead start with:
+
+```bash
+# responses/09_run
+python -m langchain_azure_ai.agents.hosting.run --protocol responses
+
+# invocations/03_run
+python -m langchain_azure_ai.agents.hosting.run --protocol invocations
 ```
 
 The host serves on `http://127.0.0.1:8088`.

--- a/samples/hosting/langgraph-hosted-agents/invocations/03_run/.dockerignore
+++ b/samples/hosting/langgraph-hosted-agents/invocations/03_run/.dockerignore
@@ -1,0 +1,7 @@
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+.env

--- a/samples/hosting/langgraph-hosted-agents/invocations/03_run/Dockerfile
+++ b/samples/hosting/langgraph-hosted-agents/invocations/03_run/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . user_agent/
+WORKDIR /app/user_agent
+
+RUN python -m pip install --upgrade pip && \
+    if [ -f requirements.txt ]; then \
+        python -m pip install -r requirements.txt; \
+    else \
+        echo "No requirements.txt found"; \
+    fi
+
+EXPOSE 8088
+
+CMD ["python", "-m", "langchain_azure_ai.agents.hosting.run", "--protocol", "invocations"]

--- a/samples/hosting/langgraph-hosted-agents/invocations/03_run/README.md
+++ b/samples/hosting/langgraph-hosted-agents/invocations/03_run/README.md
@@ -1,0 +1,94 @@
+# What this sample demonstrates
+
+A [LangGraph](https://langchain-ai.github.io/langgraph/) agent hosted
+using the **Invocations protocol** with session management. It uses the
+configuration-driven `langchain_azure_ai.agents.hosting.run` entrypoint
+instead of constructing an `InvocationsHostServer` in application code.
+
+> **No agent code changes are required to migrate an existing LangChain
+> agent to this approach.** Keep the existing graph implementation as-is,
+> point `langgraph.json` at its exported graph, and launch the hosting
+> entrypoint with the desired protocol.
+
+Multi-turn continuity is provided by a LangGraph `MemorySaver`
+checkpointer: the resolved `agent_session_id` is forwarded to the graph
+as `RunnableConfig.configurable.thread_id`, so each session's history is
+preserved in process memory.
+
+## How It Works
+
+### Model Integration
+
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient`. The graph is the same
+`create_agent(model, tools=[], checkpointer=MemorySaver())` graph used by
+[`invocations/01_basic`](../01_basic/).
+
+See [main.py](main.py) for the graph and [langgraph.json](langgraph.json)
+for its entrypoint configuration.
+
+### Migrating an Existing Agent
+
+An existing LangChain agent that exports a compiled graph does not need a
+hosting wrapper, an `InvocationsHostServer` import, or a new `main()`
+function. Add a `langgraph.json` file that references the existing graph
+symbol, then use the command shown below. The agent's model, tools,
+prompts, state, checkpointer, and graph code remain unchanged.
+
+### Agent Hosting
+
+The `langgraph.json` file maps the `agent` name to the compiled graph in
+`main.py`. The hosting entrypoint loads that graph and exposes it through
+the protocol selected by the required `--protocol` argument. This sample
+selects `invocations` in both its local command and Docker image.
+
+## Running the Agent Host
+
+Follow the environment setup instructions in the [Running the Agent Host
+Locally](../../README.md#running-the-agent-host-locally) section of the
+parent README, then start this sample with:
+
+```bash
+python -m langchain_azure_ai.agents.hosting.run --protocol invocations
+```
+
+## Interacting with the agent
+
+Send a POST request with a `"message"` field. The response headers include
+the `x-agent-session-id` used for multi-turn conversations:
+
+```bash
+curl -i -X POST http://127.0.0.1:8088/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"message": "My name is Alice."}'
+```
+
+### Multi-turn conversation
+
+Pass the returned session ID with the next request:
+
+```bash
+curl -X POST 'http://127.0.0.1:8088/invocations?agent_session_id=REPLACE_WITH_SESSION_ID' \
+  -H "Content-Type: application/json" \
+  -d '{"message": "What is my name?"}'
+```
+
+### Streaming
+
+Add `"stream": true` to receive per-token text deltas as SSE events:
+
+```bash
+curl -N -X POST http://127.0.0.1:8088/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Count to 5.", "stream": true}'
+```
+
+## Deploying the Agent to Foundry
+
+To host the agent on Foundry, follow the [Deploying the Agent to
+Foundry](../../README.md#deploying-the-agent-to-foundry) section of the
+parent README.
+
+> The `MemorySaver` checkpointer is in-process only. Session state does not
+> survive container restarts; use a durable checkpointer in production.

--- a/samples/hosting/langgraph-hosted-agents/invocations/03_run/agent.manifest.yaml
+++ b/samples/hosting/langgraph-hosted-agents/invocations/03_run/agent.manifest.yaml
@@ -1,0 +1,25 @@
+name: langchain-azure-agent-run-invocations
+description: >
+  A configuration-driven LangGraph agent hosted by Foundry over the
+  Invocations protocol with session continuity.
+metadata:
+  tags:
+    - LangChain
+    - LangGraph
+    - AI Agent Hosting
+    - Azure AI AgentServer
+    - Invocations Protocol
+    - Streaming
+template:
+  name: langchain-azure-agent-run-invocations
+  kind: hosted
+  protocols:
+    - protocol: invocations
+      version: 1.0.0
+  environment_variables:
+    - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+      value: "{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}"
+resources:
+  - kind: model
+    id: gpt-4.1-mini
+    name: AZURE_AI_MODEL_DEPLOYMENT_NAME

--- a/samples/hosting/langgraph-hosted-agents/invocations/03_run/agent.yaml
+++ b/samples/hosting/langgraph-hosted-agents/invocations/03_run/agent.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/AgentSchema/refs/heads/main/schemas/v1.0/ContainerAgent.yaml
+kind: hosted
+name: langchain-azure-agent-run-invocations
+protocols:
+  - protocol: invocations
+    version: 1.0.0
+resources:
+  cpu: '0.25'
+  memory: '0.5Gi'
+environment_variables:
+  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}

--- a/samples/hosting/langgraph-hosted-agents/invocations/03_run/langgraph.json
+++ b/samples/hosting/langgraph-hosted-agents/invocations/03_run/langgraph.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://langgra.ph/schema.json",
+  "dependencies": ["."],
+  "graphs": {
+    "agent": "./main.py:graph"
+  },
+  "env": ".env"
+}

--- a/samples/hosting/langgraph-hosted-agents/invocations/03_run/main.py
+++ b/samples/hosting/langgraph-hosted-agents/invocations/03_run/main.py
@@ -1,0 +1,73 @@
+"""Sample 03 - Configuration-driven Invocations API host.
+
+Defines the same ``create_agent`` graph with ``MemorySaver`` as sample 01.
+The ``langchain_azure_ai.agents.hosting.run`` module loads the graph from
+``langgraph.json`` and hosts it with the selected protocol.
+
+Required environment variables (set in `.env` or your shell):
+
+    FOUNDRY_PROJECT_ENDPOINT        e.g. https://<acct>.services.ai.azure.com/api/projects/<proj>
+    AZURE_AI_MODEL_DEPLOYMENT_NAME  e.g. gpt-4o   (defaults to "gpt-4o")
+    PORT                            optional, defaults to 8088
+
+Run::
+
+    az login
+    cp .env.example .env  # then edit the values
+    python -m langchain_azure_ai.agents.hosting.run --protocol invocations
+
+Then in another terminal:
+
+    curl -i -X POST http://127.0.0.1:8088/invocations -H 'Content-Type: application/json' -d '{"message":"My name is Alice."}'
+"""
+from __future__ import annotations
+
+import os
+
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from dotenv import load_dotenv
+from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
+from langgraph.checkpoint.memory import MemorySaver
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
+
+load_dotenv()
+
+
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
+    project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
+    deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
+        model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
+    )
+
+
+def _configure_tracing() -> None:
+    if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        provider = TracerProvider()
+        provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+        trace.set_tracer_provider(provider)
+        enable_auto_tracing()
+    else:
+        enable_auto_tracing(auto_configure_azure_monitor=True)
+
+
+_configure_tracing()
+graph = create_agent(_build_chat_model(), tools=[], checkpointer=MemorySaver())

--- a/samples/hosting/langgraph-hosted-agents/invocations/03_run/requirements.txt
+++ b/samples/hosting/langgraph-hosted-agents/invocations/03_run/requirements.txt
@@ -1,0 +1,5 @@
+langchain-azure-ai[hosting,opentelemetry]
+langchain
+langchain-openai
+python-dotenv
+opentelemetry-exporter-otlp-proto-http>=1.37

--- a/samples/hosting/langgraph-hosted-agents/responses/09_run/.dockerignore
+++ b/samples/hosting/langgraph-hosted-agents/responses/09_run/.dockerignore
@@ -1,0 +1,7 @@
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+.env

--- a/samples/hosting/langgraph-hosted-agents/responses/09_run/Dockerfile
+++ b/samples/hosting/langgraph-hosted-agents/responses/09_run/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . user_agent/
+WORKDIR /app/user_agent
+
+RUN python -m pip install --upgrade pip && \
+    if [ -f requirements.txt ]; then \
+        python -m pip install -r requirements.txt; \
+    else \
+        echo "No requirements.txt found"; \
+    fi
+
+EXPOSE 8088
+
+CMD ["python", "-m", "langchain_azure_ai.agents.hosting.run", "--protocol", "responses"]

--- a/samples/hosting/langgraph-hosted-agents/responses/09_run/README.md
+++ b/samples/hosting/langgraph-hosted-agents/responses/09_run/README.md
@@ -1,0 +1,86 @@
+# What this sample demonstrates
+
+A minimal [LangGraph](https://langchain-ai.github.io/langgraph/) agent
+built with `langchain.agents.create_agent` and hosted using the
+**Responses protocol**. It uses the configuration-driven
+`langchain_azure_ai.agents.hosting.run` entrypoint instead of constructing
+a `ResponsesHostServer` in application code.
+
+> **No agent code changes are required to migrate an existing LangChain
+> agent to this approach.** Keep the existing graph implementation as-is,
+> point `langgraph.json` at its exported graph, and launch the hosting
+> entrypoint with the desired protocol.
+
+## How It Works
+
+### Model Integration
+
+The agent uses `langchain_openai.ChatOpenAI` with an Azure bearer token
+provider from `DefaultAzureCredential` and an OpenAI-compatible endpoint
+from `azure.ai.projects.AIProjectClient` (`az login` is enough for local
+development). The graph is the same no-tool `create_agent` graph used by
+[`responses/01_basic`](../01_basic/).
+
+See [main.py](main.py) for the graph and [langgraph.json](langgraph.json)
+for its entrypoint configuration.
+
+### Migrating an Existing Agent
+
+An existing LangChain agent that exports a compiled graph does not need a
+hosting wrapper, a `ResponsesHostServer` import, or a new `main()` function.
+Add a `langgraph.json` file that references the existing graph symbol, then
+use the command shown below. The agent's model, tools, prompts, state, and
+graph code remain unchanged.
+
+### Agent Hosting
+
+The `langgraph.json` file maps the `agent` name to the compiled graph in
+`main.py`. The hosting entrypoint loads that graph and exposes it through
+the protocol selected by the required `--protocol` argument. This sample
+selects `responses` in both its local command and Docker image.
+
+## Running the Agent Host
+
+Follow the environment setup instructions in the [Running the Agent Host
+Locally](../../README.md#running-the-agent-host-locally) section of the
+parent README, then start this sample with:
+
+```bash
+python -m langchain_azure_ai.agents.hosting.run --protocol responses
+```
+
+## Interacting with the agent
+
+Send a POST request with an `"input"` field:
+
+```bash
+curl -X POST http://127.0.0.1:8088/responses \
+  -H "Content-Type: application/json" \
+  -d '{"input": "Hello!"}'
+```
+
+### Streaming
+
+Add `"stream": true` to receive SSE events as the model produces tokens:
+
+```bash
+curl -N -X POST http://127.0.0.1:8088/responses \
+  -H "Content-Type: application/json" \
+  -d '{"input": "Hello!", "stream": true}'
+```
+
+### Multi-turn conversation
+
+Include the previous response ID to continue a conversation:
+
+```bash
+curl -X POST http://127.0.0.1:8088/responses \
+  -H "Content-Type: application/json" \
+  -d '{"input": "How are you?", "previous_response_id": "REPLACE_WITH_PREVIOUS_RESPONSE_ID"}'
+```
+
+## Deploying the Agent to Foundry
+
+To host the agent on Foundry, follow the [Deploying the Agent to
+Foundry](../../README.md#deploying-the-agent-to-foundry) section of the
+parent README.

--- a/samples/hosting/langgraph-hosted-agents/responses/09_run/agent.manifest.yaml
+++ b/samples/hosting/langgraph-hosted-agents/responses/09_run/agent.manifest.yaml
@@ -1,0 +1,24 @@
+name: langchain-azure-agent-run-responses
+description: >
+  A configuration-driven LangGraph agent hosted by Foundry over the Responses protocol.
+metadata:
+  tags:
+    - LangChain
+    - LangGraph
+    - AI Agent Hosting
+    - Azure AI AgentServer
+    - Responses Protocol
+    - Streaming
+template:
+  name: langchain-azure-agent-run-responses
+  kind: hosted
+  protocols:
+    - protocol: responses
+      version: 1.0.0
+  environment_variables:
+    - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+      value: "{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}"
+resources:
+  - kind: model
+    id: gpt-4.1-mini
+    name: AZURE_AI_MODEL_DEPLOYMENT_NAME

--- a/samples/hosting/langgraph-hosted-agents/responses/09_run/agent.yaml
+++ b/samples/hosting/langgraph-hosted-agents/responses/09_run/agent.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/AgentSchema/refs/heads/main/schemas/v1.0/ContainerAgent.yaml
+kind: hosted
+name: langchain-azure-agent-run-responses
+protocols:
+  - protocol: responses
+    version: 1.0.0
+resources:
+  cpu: '0.25'
+  memory: '0.5Gi'
+environment_variables:
+  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}

--- a/samples/hosting/langgraph-hosted-agents/responses/09_run/langgraph.json
+++ b/samples/hosting/langgraph-hosted-agents/responses/09_run/langgraph.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://langgra.ph/schema.json",
+  "dependencies": ["."],
+  "graphs": {
+    "agent": "./main.py:graph"
+  },
+  "env": ".env"
+}

--- a/samples/hosting/langgraph-hosted-agents/responses/09_run/main.py
+++ b/samples/hosting/langgraph-hosted-agents/responses/09_run/main.py
@@ -1,0 +1,72 @@
+"""Sample 09 - Configuration-driven Responses API host.
+
+Defines the same no-tool ``create_agent`` graph as sample 01. The
+``langchain_azure_ai.agents.hosting.run`` module loads the graph from
+``langgraph.json`` and hosts it with the selected protocol.
+
+Required environment variables (set in `.env` or your shell):
+
+    FOUNDRY_PROJECT_ENDPOINT        e.g. https://<acct>.services.ai.azure.com/api/projects/<proj>
+    AZURE_AI_MODEL_DEPLOYMENT_NAME  e.g. gpt-4o   (defaults to "gpt-4o")
+    PORT                            optional, defaults to 8088
+
+Run::
+
+    az login
+    cp .env.example .env  # then edit the values
+    python -m langchain_azure_ai.agents.hosting.run --protocol responses
+
+Then in another terminal:
+
+    curl -N -X POST http://127.0.0.1:8088/responses -H 'Content-Type: application/json' -d '{"input":"Hello!","model":"gpt-4o","stream":true}'
+"""
+from __future__ import annotations
+
+import os
+
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from dotenv import load_dotenv
+from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from langchain_azure_ai.callbacks.tracers import enable_auto_tracing
+
+load_dotenv()
+
+
+_AZURE_AI_SCOPE = "https://ai.azure.com/.default"
+
+
+def _build_chat_model() -> ChatOpenAI:
+    project_endpoint = os.environ["FOUNDRY_PROJECT_ENDPOINT"].rstrip("/")
+    deployment = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME", "gpt-4o")
+    credential = DefaultAzureCredential()
+    project = AIProjectClient(endpoint=project_endpoint, credential=credential)
+    openai_client = project.get_openai_client()
+    token_provider = get_bearer_token_provider(credential, _AZURE_AI_SCOPE)
+
+    return ChatOpenAI(
+        model=deployment,
+        base_url=str(openai_client.base_url),
+        api_key=token_provider,
+    )
+
+
+def _configure_tracing() -> None:
+    if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        provider = TracerProvider()
+        provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+        trace.set_tracer_provider(provider)
+        enable_auto_tracing()
+    else:
+        enable_auto_tracing(auto_configure_azure_monitor=True)
+
+
+_configure_tracing()
+graph = create_agent(_build_chat_model(), tools=[])

--- a/samples/hosting/langgraph-hosted-agents/responses/09_run/requirements.txt
+++ b/samples/hosting/langgraph-hosted-agents/responses/09_run/requirements.txt
@@ -1,0 +1,5 @@
+langchain-azure-ai[hosting,opentelemetry]
+langchain
+langchain-openai
+python-dotenv
+opentelemetry-exporter-otlp-proto-http>=1.37


### PR DESCRIPTION
## Summary

- Add a `langchain_azure_ai.agents.hosting.run` CLI that loads graphs from `langgraph.json`.
- Support Responses and Invocations protocols, named graphs, custom config paths, sync/async factories, and Responses server options.
- Add deployable Foundry samples for both protocols, including Dockerfiles, manifests, tracing, and documentation.
- Enable existing LangGraph agents to use Foundry hosting without changing agent code.

Will add the document to langchain docs after sdk is published