### PR TITLE
Bump langchain-azure-storage to 1.2.0

### DIFF
--- a/libs/azure-storage/pyproject.toml
+++ b/libs/azure-storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-azure-storage"
-version = "1.1.1"
+version = "1.2.0"
 description = "LangChain integrations for Azure Storage"
 authors = [
     {name="Microsoft Corporation", email="ascl@microsoft.com"},

--- a/libs/azure-storage/uv.lock
+++ b/libs/azure-storage/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "langchain-azure-storage"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-core" },


### PR DESCRIPTION
It is a minor version bump because we started supporting `deepagents` 0.7+ which includes some additional features (e.g., `delete()`) and some backwards incompatible changes (e.g., `write()` overwrites by default now).