### PR TITLE
ci: refine lint template

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }} + uv ${{ inputs.uv-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ inputs.uv-version }}
           python-version: ${{ matrix.python-version }}
@@ -59,12 +59,11 @@ jobs:
       - name: Get .mypy_cache to speed up mypy
         uses: actions/cache@v6
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "2"
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
         with:
           path: |
             ${{ env.WORKDIR }}/.mypy_cache
           key: mypy-lint-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ inputs.working-directory }}-${{ hashFiles(format('{0}/uv.lock', inputs.working-directory)) }}
-
 
       - name: Analysing the code with our lint
         working-directory: ${{ inputs.working-directory }}
@@ -74,7 +73,7 @@ jobs:
       - name: Get .mypy_cache_test to speed up mypy
         uses: actions/cache@v6
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: "2"
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
         with:
           path: |
             ${{ env.WORKDIR }}/.mypy_cache_test

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -56,28 +56,29 @@ jobs:
         run: |
           uv lock --check
 
-      - name: Get .mypy_cache to speed up mypy
+      - name: Get UTC cache date
+        id: cache-date
+        shell: bash
+        run: |
+          echo "value=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache ruff and mypy
         uses: actions/cache@v6
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: "3"
         with:
           path: |
+            ${{ env.WORKDIR }}/.ruff_cache
             ${{ env.WORKDIR }}/.mypy_cache
-          key: mypy-lint-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ inputs.working-directory }}-${{ hashFiles(format('{0}/uv.lock', inputs.working-directory)) }}
+            ${{ env.WORKDIR }}/.mypy_cache_test
+          key: ruff-mypy-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ inputs.working-directory }}-${{ hashFiles(format('{0}/uv.lock', inputs.working-directory)) }}-${{ steps.cache-date.outputs.value }}
+          restore-keys: |
+            ruff-mypy-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ inputs.working-directory }}-${{ hashFiles(format('{0}/uv.lock', inputs.working-directory)) }}-
 
       - name: Analysing the code with our lint
         working-directory: ${{ inputs.working-directory }}
         run: |
           make lint_package
-
-      - name: Get .mypy_cache_test to speed up mypy
-        uses: actions/cache@v6
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: "2"
-        with:
-          path: |
-            ${{ env.WORKDIR }}/.mypy_cache_test
-          key: mypy-test-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ inputs.working-directory }}-${{ hashFiles(format('{0}/uv.lock', inputs.working-directory)) }}
 
       - name: Analysing the code with our lint
         working-directory: ${{ inputs.working-directory }}

--- a/libs/azure-ai/.gitignore
+++ b/libs/azure-ai/.gitignore
@@ -1,4 +1,4 @@
 __pycache__
-.ruff_cache*
-.pytest_cache*
-.mypy_cache*
+.ruff_cache
+.pytest_cache
+.mypy_cache

--- a/libs/azure-ai/.gitignore
+++ b/libs/azure-ai/.gitignore
@@ -1,4 +1,4 @@
 __pycache__
 .ruff_cache
 .pytest_cache
-.mypy_cache
+.mypy_cache*

--- a/libs/azure-ai/.gitignore
+++ b/libs/azure-ai/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
-.ruff_cache
-.pytest_cache
+.ruff_cache*
+.pytest_cache*
+.mypy_cache*


### PR DESCRIPTION
- Upgrade astral-sh/setup-uv from v7 to v10.0.1.
- Fix the cache segment timeout environment variable.
- Consolidate Ruff and mypy caches into one cache action.
- Cache Ruff, package mypy, and test mypy results together.
- Rotate caches daily using UTC dates.