### PR TITLE
fix: remove unused pytest mark 'compile'

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         python-version: ${{ fromJson(inputs.python-versions) }}
-    name: "uv run pytest -m compile tests/integration_tests #${{ matrix.python-version }}"
+    name: "uv run pytest tests/integration_tests #${{ matrix.python-version }}"
     steps:
       - uses: actions/checkout@v7
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Check integration tests compile
         shell: bash
-        run: uv run --frozen --all-extras --group test_integration --group test pytest -m compile tests/integration_tests
+        run: uv run --frozen --all-extras --group test_integration --group test pytest tests/integration_tests
 
       - name: Ensure the tests did not create any additional files
         shell: bash

--- a/libs/azure-ai/Makefile
+++ b/libs/azure-ai/Makefile
@@ -4,7 +4,7 @@
 all: help
 
 # Define a variable for the test file path.
-TEST_FILE ?= tests/unit_tests/ tests/integration_tests/
+TEST_FILE ?= tests/unit_tests/
 
 # uv run helpers. `--frozen` keeps the lockfile authoritative (no implicit
 # updates), so CI's "did the run create new files" check stays green.

--- a/libs/azure-ai/tests/integration_tests/test_compile.py
+++ b/libs/azure-ai/tests/integration_tests/test_compile.py
@@ -1,7 +1,0 @@
-import pytest  # type: ignore[import-not-found]
-
-
-@pytest.mark.compile
-def test_placeholder() -> None:
-    """Used for compiling integration tests without running any real tests."""
-    pass

--- a/libs/azure-compute/tests/integration_tests/test_compile.py
+++ b/libs/azure-compute/tests/integration_tests/test_compile.py
@@ -1,7 +1,0 @@
-import pytest  # type: ignore[import-not-found]
-
-
-@pytest.mark.compile
-def test_placeholder() -> None:
-    """Used for compiling integration tests without running any real tests."""
-    pass

--- a/libs/azure-dynamic-sessions/tests/integration_tests/test_compile.py
+++ b/libs/azure-dynamic-sessions/tests/integration_tests/test_compile.py
@@ -1,7 +1,0 @@
-import pytest  # type: ignore[import-not-found]
-
-
-@pytest.mark.compile
-def test_placeholder() -> None:
-    """Used for compiling integration tests without running any real tests."""
-    pass

--- a/libs/azure-storage/tests/integration_tests/test_compile.py
+++ b/libs/azure-storage/tests/integration_tests/test_compile.py
@@ -1,7 +1,0 @@
-import pytest  # type: ignore[import-not-found]
-
-
-@pytest.mark.compile
-def test_placeholder() -> None:
-    """Used for compiling integration tests without running any real tests."""
-    pass

--- a/libs/sqlserver/tests/integration_tests/test_compile.py
+++ b/libs/sqlserver/tests/integration_tests/test_compile.py
@@ -1,7 +1,0 @@
-import pytest
-
-
-@pytest.mark.compile
-def test_placeholder() -> None:
-    """Used for compiling integration tests without running any real tests."""
-    pass


### PR DESCRIPTION
fix: remove unused pytest mark 'compile'