### PR TITLE
chore: update license notices for 2026

### DIFF
--- a/libs/azure-ai/LICENSE
+++ b/libs/azure-ai/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 LangChain, Inc.
+Copyright (c) 2026 LangChain, Inc., Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/libs/azure-ai/pyproject.toml
+++ b/libs/azure-ai/pyproject.toml
@@ -2,7 +2,7 @@
 name = "langchain-azure-ai"
 version = "1.2.9"
 description = "An integration package to support Microsoft Foundry (formerly Azure AI) capabilities in LangChain/LangGraph ecosystem."
-license = "MIT"
+license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = "~=3.10"
 keywords = [

--- a/libs/azure-ai/pyproject.toml
+++ b/libs/azure-ai/pyproject.toml
@@ -2,7 +2,8 @@
 name = "langchain-azure-ai"
 version = "1.2.9"
 description = "An integration package to support Microsoft Foundry (formerly Azure AI) capabilities in LangChain/LangGraph ecosystem."
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = "~=3.10"
 keywords = [

--- a/libs/azure-compute/pyproject.toml
+++ b/libs/azure-compute/pyproject.toml
@@ -5,7 +5,8 @@ description = "LangChain integrations for Azure Container Apps"
 authors = [
     {name="Microsoft Corporation", email="ascl@microsoft.com"},
 ]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 keywords = ["langchain", "azure", "container-apps", "sandboxes", "dynamic-sessions"]

--- a/libs/azure-cosmosdb/LICENSE
+++ b/libs/azure-cosmosdb/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 LangChain, Inc., Microsoft Corporation
+Copyright (c) 2026 LangChain, Inc., Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/libs/azure-cosmosdb/pyproject.toml
+++ b/libs/azure-cosmosdb/pyproject.toml
@@ -2,7 +2,8 @@
 name = "langchain-azure-cosmosdb"
 version = "1.0.0"
 description = "Azure CosmosDB integrations for LangChain and LangGraph, including vector store, cache, chat history, and checkpoint."
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 authors = [

--- a/libs/azure-cosmosdb/pyproject.toml
+++ b/libs/azure-cosmosdb/pyproject.toml
@@ -2,7 +2,7 @@
 name = "langchain-azure-cosmosdb"
 version = "1.0.0"
 description = "Azure CosmosDB integrations for LangChain and LangGraph, including vector store, cache, chat history, and checkpoint."
-license = "MIT"
+license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 authors = [

--- a/libs/azure-dynamic-sessions/LICENSE
+++ b/libs/azure-dynamic-sessions/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 LangChain, Inc.
+Copyright (c) 2026 LangChain, Inc., Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/libs/azure-dynamic-sessions/pyproject.toml
+++ b/libs/azure-dynamic-sessions/pyproject.toml
@@ -2,7 +2,8 @@
 name = "langchain-azure-dynamic-sessions"
 version = "1.0.3"
 description = "Deprecated: use langchain-azure-compute. Connects Azure Container Apps dynamic sessions and LangChain"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 

--- a/libs/azure-postgresql/LICENSE
+++ b/libs/azure-postgresql/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Microsoft Corporation
+Copyright (c) 2026 LangChain, Inc., Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/libs/azure-postgresql/pyproject.toml
+++ b/libs/azure-postgresql/pyproject.toml
@@ -3,7 +3,8 @@
 name = "langchain-azure-postgresql"
 version = "1.0.1"
 description = "LangChain VectorStore integrations for Azure Database for PostgreSQL"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = "~=3.10"
 

--- a/libs/azure-storage/LICENSE
+++ b/libs/azure-storage/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 LangChain, Inc., Microsoft Corporation.
+Copyright (c) 2026 LangChain, Inc., Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/libs/azure-storage/pyproject.toml
+++ b/libs/azure-storage/pyproject.toml
@@ -5,7 +5,8 @@ description = "LangChain integrations for Azure Storage"
 authors = [
     {name="Microsoft Corporation", email="ascl@microsoft.com"},
 ]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = "~=3.10"
 keywords = ["langchain", "azure"]

--- a/libs/sqlserver/LICENSE
+++ b/libs/sqlserver/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 LangChain, Inc.
+Copyright (c) 2026 LangChain, Inc., Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/libs/sqlserver/pyproject.toml
+++ b/libs/sqlserver/pyproject.toml
@@ -2,7 +2,8 @@
 name = "langchain-sqlserver"
 version = "1.0.1"
 description = "An integration package to support SQL Server in LangChain."
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 


### PR DESCRIPTION
## Summary

- update copyright notices to 2026 and standardize the copyright holders across six package license files
- reference the package license files explicitly from the Azure AI and Azure Cosmos DB project metadata

## Validation

- `git diff --check upstream/main...HEAD`