### PR TITLE
Prepare `langchain-azure-compute` 0.1.0 release notes

### DIFF
--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -18,22 +18,24 @@ Each package maintains a `## Changelog` section in its `README.md`. When a new v
 
 ## How to compile release notes
 
-1. **Identify the two release tags** you are comparing. Tags follow the pattern `<package>==<version>`, for example `langchain-azure-ai==1.2.1`. List available tags with:
+1. **Identify the release boundary** you are comparing. Published tags follow the pattern `libs/<directory>/v<version>`, for example `libs/azure-ai/v1.2.1`. During release preparation the target tag does not exist yet, so compare the previous tag with `HEAD`. List available tags with:
 
    ```bash
    gh release list --repo langchain-ai/langchain-azure
    # or
-   git tag --list | grep langchain-azure-ai
+   git tag --list 'libs/azure-ai/v*'
    ```
 
-2. **List the PRs merged between the two tags** using the GitHub CLI:
+   For a first release with no previous tag, review the package's history from its introduction through `HEAD` and include the meaningful package-scoped changes.
+
+2. **List the PRs merged since the previous tag** using the GitHub CLI:
 
    ```bash
-   # Get the commits between the two tags and look for merge commits
-   git log <old-tag>..<new-tag> --oneline --merges
+   # Get package commits since the previous tag; squash commits include PR numbers
+   git log <previous-tag>..HEAD --oneline -- libs/<directory>
 
    # Or use the GitHub compare API to get a full list of commits
-   gh api repos/langchain-ai/langchain-azure/compare/<old-tag>...<new-tag> \
+   gh api repos/langchain-ai/langchain-azure/compare/<previous-tag>...main \
      --jq '.commits[].commit.message'
    ```
 
@@ -71,6 +73,7 @@ Each package maintains a `## Changelog` section in its `README.md`. When a new v
    | Package | README location |
    |---------|----------------|
    | `langchain-azure-ai` | `libs/azure-ai/README.md` |
+   | `langchain-azure-compute` | `libs/azure-compute/README.md` |
    | `langchain-azure-dynamic-sessions` | `libs/azure-dynamic-sessions/README.md` |
    | `langchain-sqlserver` | `libs/sqlserver/README.md` |
    | `langchain-azure-storage` | `libs/azure-storage/README.md` |

--- a/libs/azure-compute/README.md
+++ b/libs/azure-compute/README.md
@@ -168,6 +168,14 @@ than raising, and the command may keep running server-side. To use timeouts
 above ~300 seconds, construct the `SandboxClient` with a transport whose read
 timeout exceeds them.
 
+## Changelog
+
+- **0.1.0**:
+
+  - **[NEW]** We introduced Python and Bash tools for running agent-authored code in Azure Container Apps dynamic sessions. [#908](https://github.com/langchain-ai/langchain-azure/pull/908)
+  - **[NEW]** We added a Deep Agents backend for persistent shell execution and file operations in dynamic sessions. [#909](https://github.com/langchain-ai/langchain-azure/pull/909)
+  - **[NEW]** We added the `ACASandbox` Deep Agents backend for stateful Azure Container Apps sandbox environments. [#910](https://github.com/langchain-ai/langchain-azure/pull/910)
+
 ## Development
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) in the repository root.

--- a/libs/azure-compute/README.md
+++ b/libs/azure-compute/README.md
@@ -172,9 +172,9 @@ timeout exceeds them.
 
 - **0.1.0**:
 
-  - **[NEW]** We introduced Python and Bash tools for running agent-authored code in Azure Container Apps dynamic sessions. [#908](https://github.com/langchain-ai/langchain-azure/pull/908)
-  - **[NEW]** We added a Deep Agents backend for persistent shell execution and file operations in dynamic sessions. [#909](https://github.com/langchain-ai/langchain-azure/pull/909)
-  - **[NEW]** We added the `ACASandbox` Deep Agents backend for stateful Azure Container Apps sandbox environments. [#910](https://github.com/langchain-ai/langchain-azure/pull/910)
+  - We introduced Python and Bash tools for running agent-authored code in Azure Container Apps dynamic sessions. [#908](https://github.com/langchain-ai/langchain-azure/pull/908)
+  - We added a Deep Agents backend for persistent shell execution and file operations in dynamic sessions. [#909](https://github.com/langchain-ai/langchain-azure/pull/909)
+  - We added the `ACASandbox` Deep Agents backend for stateful Azure Container Apps sandbox environments. [#910](https://github.com/langchain-ai/langchain-azure/pull/910)
 
 ## Development
 


### PR DESCRIPTION
## Summary

- add the initial `0.1.0` changelog for dynamic sessions tools/backend and the ACA sandbox backend
- document the workflow's actual `libs/<directory>/v<version>` tag format and first-release history process
- register `langchain-azure-compute` in the release-notes skill package table

## Validation

- `uv 0.12.3`: frozen lock consistency, Ruff, formatting, mypy, codespell, and import checks
- unit tests: 520 passed, 1 skipped
- integration tests without Azure credentials: 1 passed, 130 skipped
- coverage: 100%
- built and inspected the `langchain_azure_compute-0.1.0` wheel and source distribution

## Post-merge release steps

`langchain-azure-compute` is not published yet. After this PR merges, an authorized maintainer must configure Pending Trusted Publishers for `langchain-azure-compute` on both PyPI and TestPyPI. Then manually run `.github/workflows/_release.yml` from `main` with `working-directory: libs/azure-compute`. The workflow will publish the package and create tag `libs/azure-compute/v0.1.0`.

This PR does not trigger the release workflow or publish to PyPI.