### PR TITLE
Deprecate Python 3.10 support for `langchain-sqlserver`

### DIFF
--- a/.github/agents/langchain-azure.agent.md
+++ b/.github/agents/langchain-azure.agent.md
@@ -61,7 +61,7 @@ make format && make lint_package && make lint_tests
 
 ### CI/CD
 
-CI is path-aware — it only runs lint/test for packages with changed files (via `.github/scripts/check_diff.py`). Tests run on Python 3.10 and 3.12. Infrastructure changes (`.github/workflows`, `.github/scripts`) trigger all packages.
+CI is path-aware — it only runs lint/test for packages with changed files (via `.github/scripts/check_diff.py`). Tests run on Python 3.10 and 3.14 for all packages except for `langchain-sqlserver` that runs on Python 3.11 and 3.14. Infrastructure changes (`.github/workflows`, `.github/scripts`) trigger all packages.
 
 The main CI workflow (`.github/workflows/check_diffs.yml`) fans out into:
 - `_lint.yml` — `uv lock --check`, `make lint_package`, `make lint_tests`
@@ -351,7 +351,7 @@ class PreviewClass:
 
 ### Pydantic Usage
 
-- All packages require Python ≥ 3.10 and use Pydantic v2
+- All packages require Python ≥ 3.10 except `langchain-sqlserver` that requires Python ≥ 3.11. All use Pydantic v2
 - Use `model_validator(mode="after")` for post-initialization logic (client creation, table verification)
 - Use `@pre_init` (from `langchain_core.utils`) for pre-initialization validation in resource service classes
 - Use `PrivateAttr` for SDK client instances that shouldn't be serialized

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -15,7 +15,11 @@ on:
 permissions: {}
 
 env:
-  PYTHON_VERSION: "3.10"
+  DEFAULT_PYTHON_VERSION: "3.10"
+  PYTHON_VERSION_BY_DIRECTORY: >-
+    {
+      "libs/sqlserver": "3.11"
+    }
 
 jobs:
   build:
@@ -35,7 +39,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           version: ${{ inputs.uv-version }}
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ fromJSON(env.PYTHON_VERSION_BY_DIRECTORY)[inputs.working-directory] || env.DEFAULT_PYTHON_VERSION }}
 
       # We want to keep this build stage *separate* from the release stage,
       # so that there's no sharing of permissions between them.

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -35,7 +35,11 @@ jobs:
           python .github/scripts/check_diff.py ${{ steps.files.outputs.all }} >> $GITHUB_OUTPUT
     outputs:
       uv-version: "0.12.3"
-      python-versions: '["3.10", "3.14"]'
+      default-python-versions: '["3.10", "3.14"]'
+      python-versions-by-directory: >-
+        {
+          "libs/sqlserver": ["3.11", "3.14"]
+        }
       dirs-to-lint: ${{ steps.set-matrix.outputs.dirs-to-lint }}
       dirs-to-test: ${{ steps.set-matrix.outputs.dirs-to-test }}
 
@@ -49,7 +53,7 @@ jobs:
     uses: ./.github/workflows/_lint.yml
     with:
       uv-version: ${{ needs.build.outputs.uv-version }}
-      python-versions: ${{ needs.build.outputs.python-versions }}
+      python-versions: ${{ toJSON(fromJSON(needs.build.outputs.python-versions-by-directory)[matrix.working-directory] || fromJSON(needs.build.outputs.default-python-versions)) }}
       working-directory: ${{ matrix.working-directory }}
     secrets: inherit
 
@@ -63,7 +67,7 @@ jobs:
     uses: ./.github/workflows/_test.yml
     with:
       uv-version: ${{ needs.build.outputs.uv-version }}
-      python-versions: ${{ needs.build.outputs.python-versions }}
+      python-versions: ${{ toJSON(fromJSON(needs.build.outputs.python-versions-by-directory)[matrix.working-directory] || fromJSON(needs.build.outputs.default-python-versions)) }}
       working-directory: ${{ matrix.working-directory }}
     secrets: inherit
 
@@ -77,7 +81,7 @@ jobs:
     uses: ./.github/workflows/_compile_integration_test.yml
     with:
       uv-version: ${{ needs.build.outputs.uv-version }}
-      python-versions: ${{ needs.build.outputs.python-versions }}
+      python-versions: ${{ toJSON(fromJSON(needs.build.outputs.python-versions-by-directory)[matrix.working-directory] || fromJSON(needs.build.outputs.default-python-versions)) }}
       working-directory: ${{ matrix.working-directory }}
     secrets: inherit
 

--- a/libs/sqlserver/README.md
+++ b/libs/sqlserver/README.md
@@ -4,6 +4,8 @@ This package contains the LangChain integration for Azure SQL and SQL Server to 
 
 ## Installation
 
+Python 3.11 or later is required.
+
 ```bash
 pip install -U langchain-sqlserver
 ```

--- a/libs/sqlserver/pyproject.toml
+++ b/libs/sqlserver/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.1"
 description = "An integration package to support SQL Server in LangChain."
 license = { file = "LICENSE" }
 readme = "README.md"
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.11,<4.0"
 
 dependencies = [
   "aioodbc~=0.5",

--- a/libs/sqlserver/uv.lock
+++ b/libs/sqlserver/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10, <4.0"
+requires-python = ">=3.11, <4.0"
 resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version < '3.15'",


### PR DESCRIPTION
## Summary

Raise the minimum supported Python version for `langchain-sqlserver` from
Python 3.10 to Python 3.11.

This change is scoped to the SQL Server package. Other packages in this
monorepo continue to support and validate against Python 3.10.

## Motivation

Python 3.10 is approaching end of life in October 2026. Since
`langchain-sqlserver` is independently packaged and does not have runtime
dependencies on sibling packages in this repository, its minimum version can
be raised without changing the support policy of those packages.

Declaring Python 3.11 as the package minimum also ensures that package managers
reject unsupported Python 3.10 environments at install time.

Related to #815, which tracks the broader repository-wide Python 3.10
retirement. This PR deliberately limits the change to `langchain-sqlserver`.

## Changes

- Set `langchain-sqlserver` `requires-python` to `>=3.11,<4.0`.
- Update its universal lockfile to cover Python `>=3.11,<4.0`.
- Document the Python 3.11 requirement in the package README.
- Run SQL Server lint, type-check, unit-test, and integration-compilation jobs
  on Python 3.11 and 3.14.
- Preserve the default Python 3.10 and 3.14 CI matrix for sibling packages.
- Build the SQL Server Test PyPI candidate on Python 3.11 while retaining
  Python 3.10 for sibling packages.
- Update repository agent guidance to describe the package-specific version
  policy.

Production artifacts were already built with Python 3.11, so the production
build interpreter does not need to change.

## Compatibility impact

New `langchain-sqlserver` releases produced from this change cannot be installed
on Python 3.10. Package managers may still select an older compatible release
when no package version is explicitly requested.

There are no runtime API or behavior changes.

## Validation

Validated on Python 3.11 and Python 3.14 using the CI-pinned uv 0.12.3:

- `uv lock --check`
- Ruff checks and formatting verification
- mypy for package and test code
- Unit tests: 17 passed, 1 skipped on each Python version
- Integration-test compilation: 1 passed, 99 live tests deselected on each version
- Wheel and source distribution build
- Wheel import on Python 3.11
- Wheel metadata accepts Python 3.11/3.14 and rejects Python 3.10

Live SQL Server integration tests were not run because the required connection
environment variables were not available.