### PR TITLE
feat: support usage_metadata in AIMessage for responses hosting

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/__init__.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/__init__.py
@@ -25,7 +25,7 @@ from ._request import (
     build_messages_input_from_text,
     items_to_messages,
 )
-from ._stream import stream_graph_to_events
+from ._stream import UsageAccumulator, stream_graph_to_events
 from ._utils import (
     extract_reasoning_summary_fragments,
     extract_text,
@@ -53,4 +53,5 @@ __all__ = [
     "state_to_events",
     "stream_graph_to_events",
     "track_pending_interrupts",
+    "UsageAccumulator",
 ]

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_stream.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_stream.py
@@ -47,6 +47,7 @@ from collections.abc import AsyncIterator
 from typing import Any, cast
 
 from azure.ai.agentserver.responses import ResponseEventStream
+from azure.ai.agentserver.responses.models import ResponseUsage
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -64,6 +65,7 @@ async def stream_graph_to_events(
     *,
     cancellation_signal: asyncio.Event,
     shutdown_signal: asyncio.Event | None = None,
+    usage: UsageAccumulator | None = None,
 ) -> AsyncIterator[Any]:
     """Iterate the graph stream and yield Responses API events.
 
@@ -84,11 +86,12 @@ async def stream_graph_to_events(
             is cancelled; iteration stops on set.
         shutdown_signal: Set when the host is draining. Iteration stops on set
             so the caller can defer resilient work to the next lifetime.
+        usage: Optional accumulator for LangChain AI message usage metadata.
 
     Yields:
         Responses API event payload dicts.
     """
-    converter = StreamConverter(stream)
+    converter = StreamConverter(stream, usage=usage)
     task_storage = TaskStorageManager.from_stream(stream)
 
     # Common timeline:
@@ -139,6 +142,47 @@ async def stream_graph_to_events(
         yield event
 
 
+class UsageAccumulator:
+    """Aggregate LangChain usage metadata into Responses API usage."""
+
+    def __init__(self) -> None:
+        self._has_usage = False
+        self._input_tokens = 0
+        self._output_tokens = 0
+        self._total_tokens = 0
+        self._cached_tokens = 0
+        self._reasoning_tokens = 0
+
+    def add(self, message: AIMessage) -> None:
+        """Add usage reported by one AI message or message chunk."""
+        metadata = message.usage_metadata
+        if metadata is None:
+            return
+        self._has_usage = True
+        self._input_tokens += metadata["input_tokens"]
+        self._output_tokens += metadata["output_tokens"]
+        self._total_tokens += metadata["total_tokens"]
+        self._cached_tokens += metadata.get("input_token_details", {}).get(
+            "cache_read", 0
+        )
+        self._reasoning_tokens += metadata.get("output_token_details", {}).get(
+            "reasoning", 0
+        )
+
+    @property
+    def response_usage(self) -> ResponseUsage | None:
+        """Return accumulated usage in the standard Responses API shape."""
+        if not self._has_usage:
+            return None
+        return {
+            "input_tokens": self._input_tokens,
+            "input_tokens_details": {"cached_tokens": self._cached_tokens},
+            "output_tokens": self._output_tokens,
+            "output_tokens_details": {"reasoning_tokens": self._reasoning_tokens},
+            "total_tokens": self._total_tokens,
+        }
+
+
 class StreamConverter:
     """Convert one LangGraph invocation stream into Responses events.
 
@@ -146,8 +190,14 @@ class StreamConverter:
     state, such as a partially built message or IDs used for deduplication.
     """
 
-    def __init__(self, stream: ResponseEventStream) -> None:
+    def __init__(
+        self,
+        stream: ResponseEventStream,
+        *,
+        usage: UsageAccumulator | None = None,
+    ) -> None:
         self._stream = stream
+        self._usage = usage or UsageAccumulator()
         self._message_builder: Any = None
         self._text_builder: Any = None
         self._text_buffer: list[str] = []
@@ -177,6 +227,7 @@ class StreamConverter:
         message = _extract_ai_message(payload)
         if message is None:
             return
+        self._usage.add(message)
 
         message_id = message.id if isinstance(message.id, str) and message.id else None
         if (

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_stream.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_stream.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import Any, cast
 
 from azure.ai.agentserver.responses import ResponseEventStream
@@ -151,36 +151,136 @@ class UsageAccumulator:
         self._output_tokens = 0
         self._total_tokens = 0
         self._cached_tokens = 0
+        self._cache_write_tokens = 0
         self._reasoning_tokens = 0
 
     def add(self, message: AIMessage) -> None:
         """Add usage reported by one AI message or message chunk."""
-        metadata = message.usage_metadata
+        metadata = _coerce_mapping(
+            getattr(message, "usage_metadata", None),
+            (
+                "input_tokens",
+                "prompt_tokens",
+                "output_tokens",
+                "completion_tokens",
+                "total_tokens",
+                "input_token_details",
+                "input_tokens_details",
+                "output_token_details",
+                "output_tokens_details",
+            ),
+        )
         if metadata is None:
             return
+
+        input_tokens = _first_int(metadata, ("input_tokens", "prompt_tokens"))
+        output_tokens = _first_int(metadata, ("output_tokens", "completion_tokens"))
+        total_tokens = _first_int(metadata, ("total_tokens",))
+        input_details = _coerce_mapping(
+            metadata.get("input_token_details") or metadata.get("input_tokens_details"),
+            (
+                "cache_read",
+                "cached_tokens",
+                "cache_creation",
+                "cache_write_tokens",
+            ),
+        )
+        output_details = _coerce_mapping(
+            metadata.get("output_token_details")
+            or metadata.get("output_tokens_details"),
+            ("reasoning", "reasoning_tokens"),
+        )
+        cached_tokens = _first_int(input_details, ("cache_read", "cached_tokens"))
+        cache_write_tokens = _first_int(
+            input_details, ("cache_creation", "cache_write_tokens")
+        )
+        reasoning_tokens = _first_int(output_details, ("reasoning", "reasoning_tokens"))
+        if all(
+            value is None
+            for value in (
+                input_tokens,
+                output_tokens,
+                total_tokens,
+                cached_tokens,
+                cache_write_tokens,
+                reasoning_tokens,
+            )
+        ):
+            return
+
         self._has_usage = True
-        self._input_tokens += metadata["input_tokens"]
-        self._output_tokens += metadata["output_tokens"]
-        self._total_tokens += metadata["total_tokens"]
-        self._cached_tokens += metadata.get("input_token_details", {}).get(
-            "cache_read", 0
+        self._input_tokens += input_tokens or 0
+        self._output_tokens += output_tokens or 0
+        self._total_tokens += (
+            total_tokens
+            if total_tokens is not None
+            else (input_tokens or 0) + (output_tokens or 0)
         )
-        self._reasoning_tokens += metadata.get("output_token_details", {}).get(
-            "reasoning", 0
-        )
+        self._cached_tokens += cached_tokens or 0
+        self._cache_write_tokens += cache_write_tokens or 0
+        self._reasoning_tokens += reasoning_tokens or 0
 
     @property
     def response_usage(self) -> ResponseUsage | None:
         """Return accumulated usage in the standard Responses API shape."""
         if not self._has_usage:
             return None
-        return {
+        usage: ResponseUsage = {
             "input_tokens": self._input_tokens,
-            "input_tokens_details": {"cached_tokens": self._cached_tokens},
+            "input_tokens_details": {
+                "cached_tokens": self._cached_tokens,
+                "cache_write_tokens": self._cache_write_tokens,
+            },
             "output_tokens": self._output_tokens,
             "output_tokens_details": {"reasoning_tokens": self._reasoning_tokens},
             "total_tokens": self._total_tokens,
         }
+        return usage
+
+
+def _coerce_mapping(
+    value: Any,
+    attribute_names: Sequence[str],
+) -> Mapping[str, Any] | None:
+    """Return mapping or model data without assuming one concrete type."""
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return value
+    for method_name in ("model_dump", "dict"):
+        method = getattr(value, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            result = method(exclude_none=True)
+        except TypeError:
+            result = method()
+        if isinstance(result, Mapping):
+            return result
+    extracted = {
+        name: attribute
+        for name in attribute_names
+        if (attribute := getattr(value, name, None)) is not None
+    }
+    return extracted or None
+
+
+def _first_int(
+    values: Mapping[str, Any] | None,
+    keys: Sequence[str],
+) -> int | None:
+    """Return the first integer-like value under the requested keys."""
+    if values is None:
+        return None
+    for key in keys:
+        value = values.get(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 class StreamConverter:

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
@@ -71,6 +71,7 @@ from langchain_azure_ai.agents.hosting import (
 )
 
 from ._converters import (
+    UsageAccumulator,
     build_messages_input,
     detect_approval_rejection,
     detect_pending_interrupts,
@@ -842,6 +843,7 @@ class ResponsesHostServer:
             # Persist handler admission before any provider or graph I/O.
             yield stream.checkpoint()
 
+        usage = UsageAccumulator()
         try:
             config = await self.build_runnable_config(request, context)
             # Attach transient execution state after the overridable config
@@ -936,6 +938,7 @@ class ResponsesHostServer:
                 stream,
                 cancellation_signal=cancellation_signal,
                 shutdown_signal=context.shutdown,
+                usage=usage,
             ):
                 yield event
             checkpoint_ref = task_storage.checkpoint_ref
@@ -948,12 +951,13 @@ class ResponsesHostServer:
                     yield stream.emit_failed(
                         code="cancelled",
                         message="Request was cancelled.",
+                        usage=usage.response_usage,
                     )
                 else:
                     # Steering supersedes this turn without cancelling it.
                     # Preserve its checkpointed partial output and let the
                     # queued turn begin from this response as its parent.
-                    yield stream.emit_completed()
+                    yield stream.emit_completed(usage=usage.response_usage)
                 return
 
             # The updates stream carries the exact active set for this run;
@@ -966,10 +970,14 @@ class ResponsesHostServer:
                 async for event in emit_interrupts(new_pending, stream):
                     yield event
 
-            yield stream.emit_completed()
+            yield stream.emit_completed(usage=usage.response_usage)
         except Exception as exc:  # noqa: BLE001
             logger.exception("LangGraph response handler failed")
-            yield stream.emit_failed(code="internal_error", message=str(exc))
+            yield stream.emit_failed(
+                code="internal_error",
+                message=str(exc),
+                usage=usage.response_usage,
+            )
 
     # ------------------------------------------------------------------
     # Recovery helpers (resilient background responses)

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
@@ -316,7 +316,10 @@ async def test_completed_response_includes_langchain_usage_metadata(
     )
     assert completed["response"]["usage"] == {
         "input_tokens": 16,
-        "input_tokens_details": {"cached_tokens": 3},
+        "input_tokens_details": {
+            "cached_tokens": 3,
+            "cache_write_tokens": 0,
+        },
         "output_tokens": 9,
         "output_tokens_details": {"reasoning_tokens": 2},
         "total_tokens": 25,

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
@@ -27,6 +27,7 @@ from azure.ai.agentserver.responses.models import (
     ItemMessage,
     MessageContentInputTextContent,
 )
+from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableConfig
 from starlette.testclient import TestClient
 
@@ -265,6 +266,61 @@ def test_streaming_request_emits_sse_lifecycle_events() -> None:
     assert "response.completed" in types
     deltas = [p["delta"] for t, p in events if t == "response.output_text.delta"]
     assert "".join(deltas) == "Hello, world!"
+
+
+async def test_completed_response_includes_langchain_usage_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = ResponsesHostServer(make_echo_graph())
+    messages = [
+        AIMessage(
+            content="first",
+            id="msg-1",
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": 4,
+                "total_tokens": 14,
+                "input_token_details": {"cache_read": 3},
+                "output_token_details": {"reasoning": 2},
+            },
+        ),
+        AIMessage(
+            content="second",
+            id="msg-2",
+            usage_metadata={
+                "input_tokens": 6,
+                "output_tokens": 5,
+                "total_tokens": 11,
+            },
+        ),
+    ]
+
+    async def graph_stream(*_: Any, **__: Any) -> AsyncGenerator[Any, None]:
+        for message in messages:
+            yield "messages", (message, {})
+
+    monkeypatch.setattr(server.graph, "astream", graph_stream)
+    events = [
+        event
+        async for event in server.handle_create(
+            _request(),
+            _context(),
+            asyncio.Event(),
+        )
+    ]
+
+    completed = next(
+        event
+        for event in events
+        if isinstance(event, dict) and event.get("type") == "response.completed"
+    )
+    assert completed["response"]["usage"] == {
+        "input_tokens": 16,
+        "input_tokens_details": {"cached_tokens": 3},
+        "output_tokens": 9,
+        "output_tokens_details": {"reasoning_tokens": 2},
+        "total_tokens": 25,
+    }
 
 
 def test_steerable_capability_metadata_is_true_when_enabled() -> None:

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_stream.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_stream.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncIterator
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -22,6 +23,7 @@ from langchain_core.messages import (  # noqa: E402
 )
 
 from langchain_azure_ai.agents.hosting._converters._stream import (  # noqa: E402
+    UsageAccumulator,
     _extract_checkpoint_ref,
     stream_graph_to_events,
 )
@@ -82,6 +84,62 @@ async def _drive(items: list[Any]) -> list[Any]:
 
 def _types(events: list[Any]) -> list[str]:
     return [event["type"] for event in events]
+
+
+def _ai_message_with_usage(metadata: Any) -> AIMessage:
+    message = AIMessage(content="")
+    message.usage_metadata = cast(Any, metadata)
+    return message
+
+
+def test_usage_accumulator_accepts_partial_and_object_metadata() -> None:
+    usage = UsageAccumulator()
+    usage.add(
+        _ai_message_with_usage(
+            {
+                "prompt_tokens": "7",
+                "completion_tokens": 3,
+                "input_token_details": None,
+                "output_token_details": "invalid",
+            }
+        )
+    )
+    usage.add(
+        _ai_message_with_usage(
+            SimpleNamespace(
+                input_tokens=5,
+                output_tokens="2",
+                input_token_details=SimpleNamespace(cache_read="4", cache_creation="6"),
+                output_token_details=SimpleNamespace(reasoning=1),
+            )
+        )
+    )
+
+    assert usage.response_usage == {
+        "input_tokens": 12,
+        "input_tokens_details": {
+            "cached_tokens": 4,
+            "cache_write_tokens": 6,
+        },
+        "output_tokens": 5,
+        "output_tokens_details": {"reasoning_tokens": 1},
+        "total_tokens": 17,
+    }
+
+
+def test_usage_accumulator_ignores_malformed_metadata() -> None:
+    usage = UsageAccumulator()
+
+    usage.add(
+        _ai_message_with_usage(
+            {
+                "input_tokens": "invalid",
+                "input_token_details": object(),
+            }
+        )
+    )
+
+    assert usage.response_usage is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently the token usage is not exposed in responses hosting. This PR converts the LangChain usage_metadata in AIMessage which contains token usage to standard responses api usage.