### PR TITLE
fix(samples): enable LangGraph node caching

### DIFF
--- a/samples/cosmosdb-nosql/langgraph_cache.py
+++ b/samples/cosmosdb-nosql/langgraph_cache.py
@@ -23,6 +23,7 @@ from dotenv import load_dotenv
 from langchain_openai import AzureChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import add_messages
+from langgraph.types import CachePolicy
 from typing_extensions import TypedDict
 
 from langchain_azure_cosmosdb import CosmosDBCacheSync
@@ -68,7 +69,7 @@ def main() -> None:
             return {"messages": [response]}
 
         graph = StateGraph(State)
-        graph.add_node("chatbot", chatbot)
+        graph.add_node("chatbot", chatbot, cache_policy=CachePolicy(ttl=300))
         graph.add_edge(START, "chatbot")
         graph.add_edge("chatbot", END)
         app = graph.compile(cache=cache)

--- a/samples/cosmosdb-nosql/langgraph_cache_async.py
+++ b/samples/cosmosdb-nosql/langgraph_cache_async.py
@@ -24,6 +24,7 @@ from dotenv import load_dotenv
 from langchain_openai import AzureChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import add_messages
+from langgraph.types import CachePolicy
 from typing_extensions import TypedDict
 
 from langchain_azure_cosmosdb import CosmosDBCache
@@ -64,7 +65,7 @@ async def main() -> None:
                 return {"messages": [response]}
 
             graph = StateGraph(State)
-            graph.add_node("chatbot", chatbot)
+            graph.add_node("chatbot", chatbot, cache_policy=CachePolicy(ttl=300))
             graph.add_edge(START, "chatbot")
             graph.add_edge("chatbot", END)
             app = graph.compile(cache=cache)


### PR DESCRIPTION
## Summary

- configure CachePolicy with a 5-minute TTL in both LangGraph cache samples
- ensure repeated invocations can use the Cosmos DB cache instead of calling the model again

## Tests

- `python -m compileall -q samples/cosmosdb-nosql/langgraph_cache.py samples/cosmosdb-nosql/langgraph_cache_async.py`
- `ruff check --select F samples/cosmosdb-nosql/langgraph_cache.py samples/cosmosdb-nosql/langgraph_cache_async.py`
- AST check verifies both samples pass `CachePolicy(ttl=300)` to `add_node`