### PR TITLE
docs: add package-aware Copilot code review skill

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: code-review
+description: >-
+  Reviews changes in the langchain-azure monorepo using package-specific
+  knowledge of langchain-azure-ai, langchain-azure-compute,
+  langchain-azure-cosmosdb, langchain-azure-postgresql, langchain-azure-storage,
+  langchain-sqlserver, and langchain-azure-dynamic-sessions, together with the
+  LangChain, LangGraph, Deep Agents, and Azure SDK contracts each package must
+  satisfy. Use this skill whenever reviewing a pull request or diff, checking
+  code for bugs or regressions, or assessing changes under libs/, samples/, or
+  .github/ in this repository, including when the request is only to "review",
+  "check", "look at", or "give feedback on" a change, and even when no package
+  is named explicitly.
+license: MIT
+---
+
+# Reviewing langchain-azure changes
+
+Every directory under `libs/` is a separately versioned, separately released
+package with its own maintainers, dependency manager, conventions, and upstream
+contracts. A finding is only useful if it is correct *for the package it lands
+in*, so the first job in any review is to work out which package changed and
+load that package's rules before judging anything.
+
+## What to report
+
+Report defects the change introduces: incorrect behavior, broken edge cases,
+regressions in released public API, violations of an upstream contract
+(LangChain, LangGraph, Deep Agents, Azure SDK), breakage on a supported Python
+version, and security, credential-leak, data-loss, resource-leak, or
+concurrency problems.
+
+Stay silent about everything else. In particular, do not comment on formatting,
+naming, or docstring wording that `ruff` and `mypy` already enforce; do not
+restate what the diff does; do not raise pre-existing issues the change merely
+touches; and do not suggest refactors that are not required for correctness.
+Returning no comments on a correct change is a good review — never manufacture
+findings to look thorough.
+
+Copilot code review never sees `**/*.lock`, `**/*.svg`, `**/*.log`, or
+`**/dist/**`, so `uv.lock` is invisible to you. Never write a finding about
+lockfile contents; instead, see the lockfile gotcha below.
+
+## Review workflow
+
+1. **Identify the packages touched.** Group changed files by `libs/<package>/`.
+   Treat each package as an independent review.
+2. **Load the package's rules** from the routing table below, plus any
+   `AGENTS.md` or `.github/copilot-instructions.md` along the changed path. The
+   repository root `AGENTS.md` is already in your context; do not re-derive it.
+3. **Read enough surrounding code** to know what the changed lines actually do:
+   the function, its callers, its sync or async twin, and the nearest tests.
+   Never review a hunk in isolation.
+4. **Check the upstream contract** for the base class being implemented, using
+   [ecosystem contracts](references/ecosystem-contracts.md) and
+   [Azure SDK contracts](references/azure-sdk-contracts.md).
+5. **Confirm each finding** before writing it. A finding must satisfy all four:
+   the changed code causes it; a realistic supported input or code path reaches
+   it; the consequence is concrete; and you can point at the specific lines. If
+   any of these is missing, drop it.
+
+## Package routing
+
+Read the file for each package that changed. Skip the rest.
+
+| Changed path | Package | Read |
+|---|---|---|
+| `libs/azure-ai/` | `langchain-azure-ai` | [azure-ai.md](references/azure-ai.md) |
+| `libs/azure-compute/` | `langchain-azure-compute` | [azure-compute.md](references/azure-compute.md) |
+| `libs/azure-cosmosdb/` | `langchain-azure-cosmosdb` | [azure-cosmosdb.md](references/azure-cosmosdb.md) |
+| `libs/azure-postgresql/` | `langchain-azure-postgresql` | [azure-postgresql.md](references/azure-postgresql.md) |
+| `libs/azure-storage/` | `langchain-azure-storage` | [azure-storage.md](references/azure-storage.md) |
+| `libs/sqlserver/` | `langchain-sqlserver` | [sqlserver.md](references/sqlserver.md) |
+| `libs/azure-dynamic-sessions/` | deprecated | [azure-dynamic-sessions.md](references/azure-dynamic-sessions.md) |
+| `.github/`, `samples/`, root docs | repo infrastructure | [repo-infrastructure.md](references/repo-infrastructure.md) |
+
+Also read [ecosystem contracts](references/ecosystem-contracts.md) when the
+change implements or overrides a LangChain, LangGraph, or Deep Agents base
+class, and [Azure SDK contracts](references/azure-sdk-contracts.md) when it
+constructs an Azure client, handles credentials, or maps service errors.
+
+## Repository gotchas
+
+These are the mistakes that pass local review and break later. They are
+specific to this repository and override any general instinct.
+
+- **A `pyproject.toml` dependency edit needs a matching `uv lock`.** CI runs
+  `uv lock --check` and fails if `uv.lock` is stale. You cannot see the
+  lockfile, so when a diff changes dependencies, check that `uv.lock` is in the
+  changed-file list and flag it when it is absent.
+- **CI only runs Python 3.10 and 3.14, but the support range is 3.10–3.14.**
+  A construct that breaks only on 3.11–3.13 passes CI. Reason about the whole
+  range rather than trusting a green build.
+- **`langchain-azure-compute` enforces 100% coverage** (`fail_under = 100`).
+  A new uncovered branch there fails CI, so a new `if` or `except` without a
+  test is a real finding in that package only.
+- **`langchain-azure-ai` lazy imports must be updated in three places** — the
+  `TYPE_CHECKING` import, `__all__`, and `_module_lookup`. Updating fewer makes
+  the symbol import-time-invisible or `__all__`-inconsistent, and unit tests
+  catch only some of these.
+- **Deprecation decorators differ per package.** `azure-ai` and
+  `azure-dynamic-sessions` use their own `_api.base` (`deprecated`,
+  `experimental`); the other packages use `langchain_core._api` (`beta`,
+  `deprecated`). Do not flag one package for using the other's convention.
+- **New Azure client construction must stamp the package user agent.** Each
+  package defines its own constant or helper (`USER_AGENT`, `_user_agent`,
+  `get_user_agent`, `with_user_agent`). A new client path that omits it
+  silently drops partner telemetry attribution.
+- **`asyncio_mode = "auto"`** in every package: async tests need no
+  `@pytest.mark.asyncio`. Do not ask for it.
+- **`--strict-markers` and `--strict-config`** are set: a new `pytest.mark.*`
+  must be registered in that package's `pyproject.toml` or collection fails.
+- **`azure-cosmosdb`'s local instructions still describe `poetry`**, but its
+  `Makefile` and CI use `uv run --frozen`. The `Makefile` is authoritative;
+  do not flag correct `uv` usage there.
+- **`azure-postgresql`'s local instructions ask for Sphinx-style docstrings**
+  while its `ruff` config sets `pydocstyle` convention to `google`. Follow the
+  style already used in the file being changed and raise no docstring-style
+  findings in that package.
+- **Unit tests must not touch the network.** `azure-ai` enforces this with
+  `pytest-socket`; the same expectation applies everywhere. A new unit test that
+  reaches a live service is a finding.
+
+## Severity
+
+Copilot code review labels comments High, Medium, or Low. Use that vocabulary.
+
+- **High** — data loss, credential or secret exposure, a regression in released
+  public API, or a failure most users of the changed path will hit.
+- **Medium** — a real correctness, compatibility, or resource-handling defect
+  on a narrower but supported path.
+- **Low** — a genuine but minor defect worth fixing.
+
+If a finding does not clear the Low bar, leave it out.
+
+## Comment format
+
+Keep each comment to the smallest useful line range and this shape:
+
+> **[Severity] Short imperative title**
+>
+> What breaks, and the specific input or code path that triggers it. Which
+> contract or package rule it violates. One concrete suggested fix, only when
+> it is short and unambiguous.
+
+Cite the contract by name (for example, "`VectorStore.get_by_ids` must not
+raise for missing IDs") rather than linking to documentation, and prefer one
+precise sentence over a paragraph of hedging.

--- a/.github/skills/code-review/references/azure-ai.md
+++ b/.github/skills/code-review/references/azure-ai.md
@@ -1,0 +1,89 @@
+# `langchain-azure-ai` (`libs/azure-ai`)
+
+The largest package: chat models, embeddings, Agent Service, LangGraph agent
+hosting, content-safety middleware, Azure AI Search vector stores, tools,
+document loaders, retrievers, evaluation, and tracing. It has its own
+`AGENTS.md` — read it, and treat its public-API and docstring rules as binding.
+
+## Public surface
+
+Submodule `__init__.py` files use a lazy-import pattern. A new public symbol
+must appear in **all three** of the `TYPE_CHECKING` import, `__all__`, and
+`_module_lookup`. Missing one produces a symbol that fails at attribute access
+or is absent from `__all__`, and the import tests catch only part of that.
+
+Every exported name is a compatibility contract: import path, signature,
+defaults, return type, raised exceptions. Optional extras (`tools`,
+`opentelemetry`, `hosting`, `v1`) must not become required — importing the base
+package with none of them installed must still work, and the guard must raise
+`ImportError` naming the extra to install.
+
+## Chat models and embeddings
+
+Apply the `BaseChatModel` contract in
+[ecosystem-contracts.md](ecosystem-contracts.md), and pay particular attention
+to two things this package gets wrong easily:
+
+- Classes keyed on `azure_deployment`, `deployment_name`, or `model_id` **must**
+  override `_get_ls_params`, because the base resolves only `model` /
+  `model_name` and will otherwise report the wrong model to tracing.
+- OpenAI-compatible classes inherit from `ChatOpenAI` / `OpenAIEmbeddings`.
+  When a change overrides a method there, check it against the parent's
+  behavior, not against `BaseChatModel` alone.
+
+## Agent Service and hosting
+
+- Agent nodes run remotely but compose into ordinary graphs. Check thread and
+  conversation identity, state propagation, streaming and event ordering,
+  interrupt / human-in-the-loop handling, and cleanup of remote resources.
+- The hosting layer implements a protocol boundary: request-to-state and
+  state-to-event conversion, durable checkpoint references, task and
+  conversation isolation, replay and resume, disconnect and cancellation, and
+  exactly-once terminal events. Credentials and private state must never reach
+  a response event.
+- Hosting maintains process-global state (user-agent prefixes, feature flags,
+  `AZURE_HTTP_USER_AGENT`). Changes there must stay idempotent under repeated
+  import and must not clobber a value the application set itself.
+- The `_foundry_checkpoint_saver` is a LangGraph checkpointer: the
+  `BaseCheckpointSaver` rules in
+  [ecosystem-contracts.md](ecosystem-contracts.md) apply in full, including
+  descending `list` order and serializer type tags.
+
+## Middleware and content safety
+
+Middleware must preserve message ordering and types and must not silently
+bypass a configured safety check. Review whether a failure fails open or
+closed, and say which the change chooses — a content-safety check that fails
+open on a transient service error is a High-severity finding unless that is the
+documented, intended behavior.
+
+## Azure AI Search
+
+Preserve index schema compatibility, vector dimensions, field mappings, filter
+syntax, scoring configuration, pagination, and metadata round-tripping. The
+`VectorStore` rules in [ecosystem-contracts.md](ecosystem-contracts.md) apply,
+especially relevance-score direction and the `add_texts` / `add_documents`
+delegation trap.
+
+## Versioned and deprecated APIs
+
+`agents/v1` and `agents/_v1` exist for compatibility with Microsoft Foundry
+classic and are gated behind the `v1` extra. New functionality belongs in the
+current API; expanding the deprecated surface is a design finding. Deprecations
+in this package use the local `langchain_azure_ai._api.base` decorators
+(`deprecated`, `experimental`), not `langchain_core._api`.
+
+## Tests
+
+- Unit tests are network-isolated with `pytest-socket`; a new unit test that
+  reaches a service will fail in CI.
+- Optional SDKs are stubbed in `sys.modules` at the **top of the test file**,
+  before importing the module under test, because the tool module raises on a
+  missing import at import time.
+- When a tool imports an SDK at module level, patching that name only during
+  construction does not keep it patched for later method calls. The call must
+  happen inside the `with patch(...)` block.
+- `FDPResourceService.validate_environment` reads `AZURE_AI_PROJECT_ENDPOINT`.
+  Tests that construct a service without an explicit `endpoint` will fail when
+  that variable is set in the environment. Passing `endpoint` explicitly or
+  deleting the variable is the fix, so do not flag those as redundant.

--- a/.github/skills/code-review/references/azure-compute.md
+++ b/.github/skills/code-review/references/azure-compute.md
@@ -1,0 +1,84 @@
+# `langchain-azure-compute` (`libs/azure-compute`)
+
+Two **different Azure products** live here, not two tiers of one:
+
+| | Dynamic sessions | Sandboxes |
+|---|---|---|
+| ARM resource | `Microsoft.App/sessionPools` | `Microsoft.App/sandboxGroups` |
+| Access | HTTP via pool management endpoint | per-sandbox data plane SDK |
+| State | ephemeral, destroyed after cooldown | stateful: suspend, resume, snapshot |
+| Storage | none | volumes |
+
+Do not apply one side's lifecycle, endpoint, or credential assumptions to the
+other.
+
+## Coverage gate
+
+This package enforces `fail_under = 100` on unit-test coverage, and integration
+tests are not measured. A new branch — including a new `except` or an early
+return — without a unit test **fails CI**. This is the one package where "add a
+test for this branch" is a mechanical finding rather than a judgment call.
+
+## Extras and imports
+
+Extras control dependencies, not module presence: every module ships in the
+wheel. Importing a subpackage without its dependencies must raise the existing
+actionable error naming the extra, and must not break unrelated imports.
+`deepagents` is installed only on Python 3.11+, so import-time code must
+tolerate its absence on 3.10.
+
+Both Deep Agents backends are marked `@beta` via `langchain_core._api` (this
+package uses `langchain_core._api`, not a local `_api.base`). The `@beta`
+marker is load-bearing and covered by tests; removing or relocating it changes
+observable warning behavior.
+
+## Data-plane realities
+
+These are documented service behaviors the code deliberately works around.
+Changes that drop the workaround are defects even though the code looks
+simpler afterwards:
+
+- The dynamic sessions data plane **intermittently drops a command's final
+  line of output** (measured at 1.6–4%). `ls`, `read`, `glob`, and `grep`
+  detect this with a completion marker and retry. `execute()` is deliberately
+  not covered, because wrapping it would change the exit status it returns.
+- The data plane **silently caps stdout and stderr at 4,096 bytes**. `read`
+  pages beneath the cap in base64 chunks; listings that exceed it must report
+  `truncated` honestly. Returning a truncated result as complete is a
+  High-severity finding.
+- Session file transfer is a **flat store rooted at `/mnt/data`**. Only
+  `/mnt/data/<name>` is storable; anything else must be rejected with
+  `invalid_path` rather than silently rewritten. `write()` goes through the
+  shell and has no such limit.
+- Shell command payloads are capped by Linux at 128 KiB per string; `write()`
+  and `edit()` refuse above roughly 90 KB, and `edit()` budgets `old_string`
+  and `new_string` together because both ride in one command.
+
+## Protocol conformance
+
+`SessionsBashBackend` and `ACASandbox` implement Deep Agents protocols, so the
+rules in [ecosystem-contracts.md](ecosystem-contracts.md) apply exactly:
+errors in the result `error` field rather than raised, input-ordered
+`upload_files` / `download_files` results, the four `FileOperationError`
+literals, `ReadResult` pagination invariants, literal-string `grep`, and
+`exit_code` for failure detection.
+
+`ACASandbox` conformance is checked against
+`langchain_tests.integration_tests.SandboxIntegrationTests`.
+
+`glob()` follows Python-glob semantics for common shapes (`*.py` stays in one
+directory level, `**/name` recurses); patterns with several `**` segments use a
+documented `find -path` approximation. As in Python, a wildcard does not match a
+leading dot.
+
+## Client ownership
+
+`ACASandbox` wraps a **caller-constructed** client and never builds endpoints or
+handles credentials itself. A change that makes it construct, replace, or close
+that client, or that moves sandbox lifecycle control inside the backend, breaks
+the ownership contract — see the lifecycle section of
+[azure-sdk-contracts.md](azure-sdk-contracts.md).
+
+For dynamic sessions, preserve token scopes, custom `access_token_provider`
+support, session ID propagation and reuse, cooldown and deletion semantics,
+request timeouts, and context-manager cleanup.

--- a/.github/skills/code-review/references/azure-cosmosdb.md
+++ b/.github/skills/code-review/references/azure-cosmosdb.md
@@ -1,0 +1,74 @@
+# `langchain-azure-cosmosdb` (`libs/azure-cosmosdb`)
+
+Vector stores, semantic cache, chat message history, and LangGraph
+checkpointer / store / cache over Cosmos DB. Source lives under `src/`.
+
+Its `.github/copilot-instructions.md` predates the migration to `uv` and still
+describes a Poetry workflow; the `Makefile` is the source of truth
+(`uv run --frozen ...`). Do not raise findings that assume Poetry.
+
+## Sync and async parity
+
+`langchain_azure_cosmosdb/` and `langchain_azure_cosmosdb/aio/` are separate
+implementations with mirrored names, matching the Azure separation rule in
+[azure-sdk-contracts.md](azure-sdk-contracts.md). A behavior change on one side
+that is not mirrored on the other is a defect in its own right — check for the
+counterpart file before assuming an omission was deliberate. Note that
+`_vectorstore_documentdb.py` and `_query_constructor.py` are intentionally
+sync-only.
+
+## Cosmos DB data-model rules
+
+These are the failure modes that show up as runtime errors in production rather
+than test failures:
+
+- **Partition keys.** A cross-partition query where a single-partition query
+  was intended is a cost and latency regression; a point read that omits the
+  partition key fails outright. Any change to key selection changes the
+  physical layout of existing containers, so it is a breaking change for
+  deployed data even when the Python signature is unchanged.
+- **Container and index configuration.** Vector index type and dimensions,
+  full-text index configuration, and throughput settings must stay compatible
+  with containers already provisioned by earlier versions. Silently
+  recreating or reconfiguring a container is worse than failing.
+- **Document schema.** Field names, `id` construction, and metadata layout are
+  a persisted contract. Changing them without a documented migration orphans
+  existing documents.
+- **Request units.** Query shape, page size, and projection drive RU cost.
+  Reviewing a query change means asking what it does to RU consumption, not
+  only whether it returns the right rows.
+
+The request-charge callback reports RU consumption to callers. Preserve when it
+fires, what it aggregates, and that it never suppresses or delays the
+underlying result; an exception raised by a user callback must not corrupt the
+operation's return value.
+
+## NoSQL and vCore / DocumentDB
+
+The NoSQL API and the Mongo-vCore / DocumentDB APIs have different query
+languages, index models, and vector-search capabilities. Keep them separate,
+and do not assume a fix in one applies to the other.
+
+## Vector and hybrid search
+
+Apply the `VectorStore` contract in
+[ecosystem-contracts.md](ecosystem-contracts.md). Cosmos-specific points:
+similarity metric and its score direction must match
+`_select_relevance_score_fn`; filter translation in `_query_constructor.py`
+must produce parameterized queries, never string-interpolated user values; and
+hybrid / full-text ranking changes alter result ordering for existing callers.
+
+## LangGraph integrations
+
+The checkpointer, store, and cache implement `BaseCheckpointSaver`,
+`BaseStore`, and the cache protocol — the LangGraph section of
+[ecosystem-contracts.md](ecosystem-contracts.md) applies in full. In addition:
+
+- Checkpoint and store key construction is persisted state. The dedicated
+  `test_langgraph_checkpoint_keys.py` and `test_langgraph_cache_keys.py` unit
+  tests exist because key-format changes are silent data-compatibility breaks;
+  a change to key layout that leaves those tests untouched is suspicious.
+- Thread, namespace, and checkpoint-id scoping must remain isolated across
+  concurrent graphs.
+- TTL and eviction behavior must be preserved, including what happens when a
+  cached entry expires mid-run.

--- a/.github/skills/code-review/references/azure-dynamic-sessions.md
+++ b/.github/skills/code-review/references/azure-dynamic-sessions.md
@@ -1,0 +1,28 @@
+# `langchain-azure-dynamic-sessions` (`libs/azure-dynamic-sessions`)
+
+**Deprecated. It will not receive further fixes.** It has been superseded by
+`langchain-azure-compute`, whose `dynamic-sessions` extra provides the same
+functionality.
+
+Review consequences:
+
+- New features do not belong here. If a PR adds capability to this package,
+  the finding is that it should go to `libs/azure-compute` instead — say so
+  once, with a link, rather than reviewing the implementation in depth.
+- Acceptable changes are security fixes, packaging fixes, and documentation
+  that points users to the replacement.
+- Deprecation warnings come from the local `langchain_azure_dynamic_sessions._api.base`
+  decorators, not `langchain_core._api`. `tests/unit_tests/test_deprecation.py`
+  asserts the warning behavior, so warning text and category are tested
+  contract, not incidental.
+- The public names (`SessionsPythonREPLTool`, `SessionsBashBackend` and the
+  `backends` / `tools` subpackages) must keep working for existing users.
+- This package's `deepagents` extra and `langchain-azure-compute`'s cannot be
+  co-installed while their version floors differ. A dependency change here can
+  therefore break installs of the *other* package; check the pins on both
+  sides before approving one.
+
+Where a change does need review, the underlying dynamic-sessions data-plane
+behavior — 4,096-byte output cap, dropped final line, the flat `/mnt/data`
+store — is documented in [azure-compute.md](azure-compute.md) and applies
+equally.

--- a/.github/skills/code-review/references/azure-postgresql.md
+++ b/.github/skills/code-review/references/azure-postgresql.md
@@ -1,0 +1,65 @@
+# `langchain-azure-postgresql` (`libs/azure-postgresql`)
+
+Azure Database for PostgreSQL integration: connection management
+(`common/`, `common/aio/`) and vector store (`langchain/`, `langchain/aio/`),
+under `src/`. Built on `psycopg` and `pgvector`.
+
+Its `.github/copilot-instructions.md` asks for Sphinx-style docstrings, but
+`pyproject.toml` configures pydocstyle with `convention = "google"`. Follow the
+tooling. This package also uses `uv` and `tox` rather than the repository-wide
+`make` targets — check its `Makefile` and `tox.ini` before claiming a command
+is wrong.
+
+## Connections, pools, and credentials
+
+- Entra ID tokens **expire**. Any caching of a token or of a connection built
+  from one must handle refresh; a pool that outlives the token it was created
+  with will start failing mid-process. Password and Entra ID paths must both
+  keep working.
+- Pool ownership follows the rule in
+  [azure-sdk-contracts.md](azure-sdk-contracts.md): a caller-supplied pool or
+  connection must never be closed by the vector store, and one the store
+  created must be released. Getting this backwards leaks connections under
+  load or closes a pool the application is still using.
+- Sync and async connection code are separate implementations; changes must be
+  mirrored unless there is a stated reason not to.
+- SSL and network configuration defaults are security-relevant: weakening a
+  default is a High-severity finding.
+
+## SQL construction
+
+Every identifier — table, schema, column, index name — must be quoted through
+`psycopg.sql.Identifier`, and every value must be a bound parameter. String
+interpolation of a user-controlled value into SQL is a High-severity injection
+finding with no exceptions. This applies to the metadata filter translator as
+much as to the main query path: filter keys arrive from user data and become
+identifiers or JSON paths.
+
+Schema and table creation must stay idempotent, must not silently drop or
+rewrite existing data, and must remain compatible with tables created by
+earlier versions of the package.
+
+## Vector search
+
+- The `VectorStore` contract in
+  [ecosystem-contracts.md](ecosystem-contracts.md) applies, including
+  relevance scores normalized to `[0, 1]` with 1 as most similar. `pgvector`
+  distance operators return *distances*, so the conversion direction is the
+  usual source of bugs here.
+- Index type (DiskANN, HNSW, IVFFlat) and its build parameters must match the
+  distance operator used at query time, or the index is silently not used.
+  A query change that stops matching the index is a performance regression
+  worth flagging even though results stay correct.
+- Extension requirements (`vector`, `pg_diskann`, `azure_ai`) must be checked
+  or documented rather than assumed.
+- Embedding dimension mismatches must fail with a clear error, not a database
+  error from three layers down.
+
+## Filters
+
+The filter-to-SQL translator is the highest-risk code in the package: it must
+reject or safely escape unknown operators rather than pass them through, must
+produce the same semantics in sync and async paths, and must handle `None`,
+empty dicts, and nested boolean combinations without silently dropping a
+condition. A dropped condition returns *more* rows than the caller asked for,
+which no test that only checks "results are non-empty" will catch.

--- a/.github/skills/code-review/references/azure-sdk-contracts.md
+++ b/.github/skills/code-review/references/azure-sdk-contracts.md
@@ -1,0 +1,171 @@
+# Azure SDK contracts
+
+Read this when a change constructs an Azure client, handles credentials, maps
+service errors, logs, paginates, or adds telemetry. These rules come from the
+Azure SDK for Python design guidelines and the `azure-sdk-tools` pylint
+checkers, and they apply to every package here because all of them wrap
+`azure-*` clients.
+
+Where a rule below is enforced by a pylint checker, the code is given so the
+finding can be stated precisely.
+
+- [Credentials](#credentials)
+- [Sync and async separation](#sync-and-async-separation)
+- [Errors](#errors)
+- [Retries, timeouts, and cancellation](#retries-timeouts-and-cancellation)
+- [Client lifecycle](#client-lifecycle)
+- [Pagination and long-running operations](#pagination-and-long-running-operations)
+- [Logging](#logging)
+- [Telemetry and user agent](#telemetry-and-user-agent)
+- [API surface hygiene](#api-surface-hygiene)
+- [Where Azure and LangChain conventions conflict](#where-azure-and-langchain-conventions-conflict)
+
+## Credentials
+
+- Accept `credential` as a single parameter and support `TokenCredential` /
+  `AsyncTokenCredential`, not just keys (`C4717`). A parameter that accepts
+  only an API key is a design regression in a package whose other integrations
+  accept Entra ID.
+- Connection strings belong in a `from_connection_string` factory, never in
+  `__init__` (`C4736`).
+- Async credentials must be used with the async protocol; passing a sync
+  credential into an `.aio` client is a real defect, not a typing nit.
+- **Never let a credential, key, SAS token, or connection string reach a log,
+  an exception message, a `__repr__`, or model-visible output.** In LangChain
+  classes this is sharper than usual: `_identifying_params` is logged *and*
+  used as a cache key, so a secret leaked there is persisted, not just printed.
+
+## Sync and async separation
+
+- Sync and async clients are separate classes with the **same name**,
+  distinguished by namespace (`azure.x` vs `azure.x.aio`).
+- Do not put `Async` in a class name or suffix methods with `_async` (`C4731`).
+- A single class that switches at runtime between a sync client and an `.aio`
+  client violates the separation rule.
+- An `@overload` set must be uniformly sync or uniformly async (`C4765`).
+- The LangChain-side consequence: `_agenerate`, `aadd_texts`,
+  `asimilarity_search`, and friends should be backed by a genuine `.aio`
+  client. `run_in_executor` around the sync client is acceptable only when no
+  async client exists, and is worth flagging when one does.
+
+## Errors
+
+The `azure-core` hierarchy is:
+
+```
+AzureError
+├── ServiceRequestError      # request never left the client
+├── ServiceResponseError     # no response received; retryable if idempotent
+└── HttpResponseError        # any non-success response; .status_code, .error
+    ├── ResourceNotFoundError, ResourceExistsError
+    ├── ResourceModifiedError, ResourceNotModifiedError
+    ├── ClientAuthenticationError
+    └── DecodeError, TooManyRedirectsError, ...
+```
+
+- Prefer these types over inventing new ones. A new exception type is justified
+  only when the caller can remediate the error programmatically; otherwise add
+  context to an existing type.
+- Always chain with `raise ... from e` so the original error survives.
+- **Do not signal failure by return value.** Returning `None`, `False`, or `[]`
+  where the service actually failed hides outages. The deliberate exceptions
+  are `exists`-style checks (return `False` on 404) and LangChain's
+  `get_by_ids` (return fewer documents rather than raising).
+- Do not raise for normal responses.
+- Validate parameters the client itself consumes, especially URL components.
+  Do not add null/empty/range checks for values the service validates — that
+  duplicates validation and drifts as the service evolves.
+- A blanket `except Exception` around a service call that returns a
+  success-shaped default is a High-severity finding: it converts an outage into
+  silently wrong data.
+
+## Retries, timeouts, and cancellation
+
+- `azure-core` supplies retry and timeout policies; per-call keyword arguments
+  must use the same names as the constructor policy options so callers can
+  override per request (`C4771` for a missing retry policy).
+- Any method performing I/O should thread `**kwargs` through to the client so
+  per-request policy options survive (`C4728`).
+- Custom retry loops layered on top of `azure-core`'s retry policy usually
+  produce accidental exponential retry multiplication; check whether the SDK is
+  already retrying before accepting a hand-rolled loop.
+
+## Client lifecycle
+
+Azure clients own network resources. In practice every `azure-*` client exposes
+`close()` and the (async) context-manager protocol, and credentials and
+pipelines require it by rule. A LangChain integration that constructs a client
+must either own and expose a way to release it, or use `with` / `async with`
+internally.
+
+The ownership question is the one to review: when the caller passes a client or
+session in, the integration **must not** close it; when the integration creates
+it, it must. Getting this backwards either leaks connections or closes a client
+the caller is still using.
+
+## Pagination and long-running operations
+
+- `list_*` methods return `ItemPaged[T]` / `AsyncItemPaged[T]` (`C4733`).
+  Iterating yields items; `.by_page()` yields pages. Continuation tokens are
+  reached only through `.by_page(continuation_token=...)`, never as a method
+  parameter.
+- Code that consumes a paged result must iterate it to completion (or page
+  deliberately). Taking the first page and treating it as the full result is a
+  common and silent correctness bug — flag it wherever a listing feeds a
+  document set, a delete set, or a search result.
+- `begin_*` methods return `LROPoller` / `AsyncLROPoller` (`C4734`, `C4735`);
+  `delete_*` returns `None` (`C4752`).
+
+## Logging
+
+- Use the stdlib `logging` module with a module-named logger.
+- **Never log sensitive information above `DEBUG`**, and redact headers.
+- Do not log an error and re-raise it — that double-reports. Do not use
+  `logging.exception()` in that position (`C4762`).
+- Do not log exceptions at levels other than `DEBUG`, because exception text
+  can carry service payloads and credentials (`C4766`).
+- Body-level network logging must stay opt-in (`logging_enable=True`).
+
+The two most reviewable versions of these rules: an f-string log line that
+interpolates an endpoint or URL that may carry a SAS token, and a
+`logger.exception(...)` sitting next to a `raise`.
+
+## Telemetry and user agent
+
+- The SDK user-agent format is
+  `[<application_id> ]azsdk-python-<package>/<version> <platform>`, supplied by
+  `UserAgentPolicy`; `application_id` is capped at 24 characters.
+- Every package in this repository stamps its own partner user agent on client
+  construction. A new client path that skips it drops attribution — see the
+  gotcha in `SKILL.md`.
+- Telemetry values must never contain PII.
+
+## API surface hygiene
+
+- Non-public API takes a single leading underscore; `__all__` lists the public
+  names. Anything under a `_private` module is internal even if the leaf name
+  looks public.
+- Optional or rarely used arguments are keyword-only; no more than five
+  positional parameters (`C4721`).
+- `**kwargs` is for pass-through to a lower layer only, and the target must be
+  documented. Arguments the method itself consumes must be explicit.
+- Prefer properties over getter/setter pairs; avoid `@staticmethod` in favor of
+  module-level functions (`C4725`).
+- An optional keyword-only `api_version` should be accepted, default to the
+  latest non-preview version, and never be silently ignored (`C4748`).
+
+## Where Azure and LangChain conventions conflict
+
+These are the places where a reviewer applying one ecosystem's rules to the
+other produces a false positive:
+
+| Topic | Azure SDK | LangChain | Which wins here |
+|---|---|---|---|
+| Missing item lookup | raise `ResourceNotFoundError` | `get_by_ids` returns fewer, never raises | LangChain, for `get_by_ids` |
+| Type hints | prefers `typing.Optional` / `Union` | uses `X \| Y` with `from __future__ import annotations` | LangChain style, as used in this repo |
+| Naming | approved verb prefixes (`get_`, `list_`, `begin_`) | LangChain method names (`add_texts`, `similarity_search`) | LangChain, for the integration surface |
+| Errors from tools | raise | `ToolException` so the agent recovers | LangChain, inside tools and backends |
+
+Outside these, the Azure rule applies: this repository ships Azure client
+libraries, and its users expect Azure error types, credential handling, and
+logging behavior.

--- a/.github/skills/code-review/references/azure-storage.md
+++ b/.github/skills/code-review/references/azure-storage.md
@@ -1,0 +1,49 @@
+# `langchain-azure-storage` (`libs/azure-storage`)
+
+Azure Blob Storage document loaders and a Deep Agents filesystem backend.
+The package is in **public preview**: its README says interfaces may change.
+Preview status is not a licence to break users silently — a breaking change
+still needs to be called out in the PR description and README.
+
+## Document loaders
+
+- `lazy_load()` is the real implementation; `load()` builds on it. Both must
+  stream: materializing every blob in a container into memory defeats the
+  loader's purpose and fails on realistic data. A change that collects results
+  into a list before yielding is a design finding.
+- Blobs are downloaded to temporary files for parsing. Every path out of that
+  code — success, parse failure, cancellation — must delete the temporary file.
+  Missing cleanup on the exception path is the common defect.
+- Prefix, name, and container filtering must not accidentally widen scope, and
+  results should stay deterministic in ordering where the service allows it.
+- Metadata attached to each `Document` (source URL, blob name, container,
+  metadata properties) is a contract that downstream retrieval code depends on.
+- Credential handling follows [azure-sdk-contracts.md](azure-sdk-contracts.md):
+  `TokenCredential` support, no SAS token or account key in logs, exception
+  messages, or `Document.metadata`.
+
+## Deep Agents blob backend
+
+`AzureBlobBackend` presents a flat blob namespace as a filesystem, so the
+mapping itself is where bugs live:
+
+- Path-to-blob-name translation must be consistent in both directions and must
+  not let a `..` segment or an absolute path escape the configured prefix.
+- Directory semantics are simulated. Listing, existence checks, and recursive
+  operations must agree on whether a prefix with no blob of its own is a
+  directory.
+- Concurrency is optimistic: ETag / `If-Match` conditions are how lost updates
+  are prevented. A write that drops the ETag condition introduces a silent
+  last-writer-wins data-loss window, which is a High-severity finding.
+- Batch operations must report **per-item** outcomes. Failing the whole batch
+  because one blob failed, or reporting success because most succeeded, both
+  lose information the agent needs.
+- The protocol rules in [ecosystem-contracts.md](ecosystem-contracts.md) apply:
+  errors in the result `error` field rather than raised, the fixed
+  `FileOperationError` literals, input-ordered results, and honest `truncated`
+  reporting.
+
+## User agent
+
+`_user_agent.py` stamps the partner user agent on constructed clients. Any new
+client construction path must go through it.

--- a/.github/skills/code-review/references/ecosystem-contracts.md
+++ b/.github/skills/code-review/references/ecosystem-contracts.md
@@ -1,0 +1,179 @@
+# Upstream contracts: LangChain, LangGraph, Deep Agents
+
+Read this when a change implements, overrides, or calls into a LangChain,
+LangGraph, or Deep Agents base class. These are the contract details that
+integrations get wrong most often; each one is a defect a reviewer can state
+concretely rather than a style preference.
+
+Contents:
+
+- [Standard test suites](#standard-test-suites)
+- [VectorStore](#vectorstore)
+- [BaseChatModel](#basechatmodel)
+- [BaseTool](#basetool)
+- [LangGraph persistence](#langgraph-persistence)
+- [Deep Agents backends](#deep-agents-backends)
+
+## Standard test suites
+
+`langchain-tests` ships the conformance suites an integration is expected to
+pass. When a change adds or materially alters an integration of one of these
+types, the absence of the matching suite is a legitimate finding.
+
+| Integration | Suite |
+|---|---|
+| Chat model | `langchain_tests.unit_tests.ChatModelUnitTests`, `langchain_tests.integration_tests.ChatModelIntegrationTests` |
+| Embeddings | `EmbeddingsUnitTests`, `EmbeddingsIntegrationTests` |
+| Tool | `ToolsUnitTests`, `ToolsIntegrationTests` |
+| Vector store | `VectorStoreIntegrationTests` |
+| Retriever | `RetrieversIntegrationTests` |
+| KV store / cache | `BaseStoreSyncTests`, `BaseStoreAsyncTests`, `SyncCacheTestSuite`, `AsyncCacheTestSuite` |
+| Deep Agents sandbox | `SandboxIntegrationTests` (exported only when `deepagents` is importable) |
+
+Rules that apply to all of them:
+
+- A standard test may not be deleted or silently overridden. Opting out
+  requires `@pytest.mark.xfail(reason=...)` with a real reason; a bare override
+  or `skip` violates the suite's own meta-test.
+- A test class may not inherit from more than one `langchain_tests` base.
+- `VectorStoreIntegrationTests` requires a `vectorstore` fixture that yields an
+  **empty** store and cleans up in a `finally` block. A fixture that leaks
+  state between tests produces false passes.
+- LangGraph checkpointers have their own package,
+  `langgraph-checkpoint-conformance` (`from langgraph.checkpoint.conformance
+  import checkpointer_test, validate`). LangGraph's `BaseCache` has no
+  conformance suite, so a cache implementation must bring its own tests.
+
+## VectorStore
+
+- Only `similarity_search` and the `from_texts` classmethod are abstract.
+- **The `add_texts` / `add_documents` mutual-delegation trap:** each base
+  implementation delegates to the other and only if the *other* is overridden.
+  Override exactly one. Overriding neither raises `NotImplementedError` at call
+  time, not at import, so it survives a green unit-test run.
+- `kwargs["ids"]` takes precedence over `Document.id`. The base collects IDs
+  when `any(ids)` is true, not `all(ids)`, so a partially populated list is
+  passed through with `None` holes.
+- These raise by default and must be overridden if advertised: `delete`,
+  `similarity_search_with_score`, `_select_relevance_score_fn`,
+  `max_marginal_relevance_search`, `max_marginal_relevance_search_by_vector`.
+- **Score direction.** `similarity_search_with_score` returns provider-native
+  scores. `similarity_search_with_relevance_scores` must return values in
+  `[0, 1]` where **1 is most similar**. The base only emits a `warnings.warn`
+  when a value escapes `[0, 1]`, so an inverted distance/similarity conversion
+  silently reverses ranking. The built-in normalizers all assume a *distance*
+  input.
+- `get_by_ids(ids, /)` is positional-only, must set `Document.id`, may return
+  fewer documents than requested, guarantees no ordering, and **must not raise**
+  for missing IDs. This is the one place where LangChain's "do not raise" rule
+  overrides Azure's "raise, never return a sentinel" rule.
+- `delete` returns `bool | None`, where `None` specifically means "not
+  implemented". `delete(ids=None)` means delete everything.
+- `upsert` is **not** part of `VectorStore`; that contract lives on
+  `langchain_core.indexing.DocumentIndex`.
+- The async methods fall back to `run_in_executor` around their sync twins.
+  Inheriting that fallback when the package already has an `azure.*.aio` client
+  is a real defect: it burns a thread per call and serializes concurrency.
+
+## BaseChatModel
+
+- Only `_generate` and the `_llm_type` property are abstract. `_agenerate`
+  falls back to `run_in_executor`, `_stream` raises, and `_astream` wraps
+  `_stream`.
+- If `_agenerate` delegates to `_generate`, it must convert the callback
+  manager with `run_manager.get_sync()`.
+- `usage_metadata` shape: required `input_tokens`, `output_tokens`,
+  `total_tokens` (which must equal input + output), plus optional
+  `input_token_details` (`audio`, `cache_creation`, `cache_read`) and
+  `output_token_details` (`audio`, `reasoning`). Detail values need not sum to
+  the totals, but `input_tokens` must be at least the sum of its details.
+- `_get_ls_params` must return `ls_model_type="chat"`, a stable snake_case
+  `ls_provider`, and `ls_model_name`. It resolves the model name as
+  `kwargs["model"]`, then `self.model`, then `self.model_name` — so any class
+  keyed on `azure_deployment`, `deployment_name`, or `model_id` **must**
+  override it or it will report the wrong model to tracing.
+- Streaming correctness, in rough order of how often it breaks:
+  - the final chunk must carry `chunk_position="last"`, or `tool_call_chunks`
+    never resolve into `tool_calls` on the aggregated message;
+  - `ToolCallChunk.index` must be a stable, non-`None` int per tool call, since
+    chunks merge only on equal non-`None` index;
+  - emit `input_tokens` on exactly one chunk and `output_tokens` per chunk,
+    otherwise aggregation multiply-counts input tokens;
+  - propagate the provider message `id` on chunks, or the aggregate falls back
+    to a synthetic `lc_*` id;
+  - `response_metadata["model_name"]` must be a non-empty string.
+- `with_structured_output(include_raw=True)` must capture parse failures into
+  `parsing_error`; with `include_raw=False` it must raise.
+
+## BaseTool
+
+- Required members: `name`, `description`, and `_run`. `_arun` is optional.
+- `args_schema` accepts a Pydantic model or a raw JSON-Schema dict. `_run` must
+  declare real named parameters matching it.
+- `run_manager` and a `RunnableConfig` parameter are injected **by parameter
+  name and annotation** only when declared.
+- Anything the model must not see — state, credentials, tool call IDs — must be
+  annotated `InjectedToolArg`, `InjectedToolCallId`, or typed as `ToolRuntime`
+  so it is stripped from `tool_call_schema`. Passing such values as ordinary
+  schema fields exposes them to the model and is a security finding.
+- `response_format="content_and_artifact"` requires `_run` to return a 2-tuple.
+- Recoverable failures should raise `ToolException` so `handle_tool_error` can
+  turn them into a `ToolMessage(status="error")` the agent can recover from. A
+  bare `raise` bypasses that path and kills the run.
+
+## LangGraph persistence
+
+**`BaseCheckpointSaver`** must implement `get_tuple`, `list`, `put`,
+`put_writes`, `delete_thread` and their async twins. `get`/`aget` are free.
+
+- `list` must yield **newest first**, descending by `checkpoint_id`. This is a
+  tested conformance requirement, not a convention.
+- `delete_thread` is in the required base capability set, not optional.
+- Conformance detects a capability by comparing the subclass method against the
+  base method, so a method overridden only to `raise NotImplementedError` is
+  detected as supported and then fails. Use `skip_capabilities=` instead.
+- `CheckpointTuple` is `(config, checkpoint, metadata, parent_config,
+  pending_writes)`. The `config["configurable"]` keys are `thread_id`,
+  `checkpoint_ns` (`""` at root, `node:uuid` for subgraphs, nested joined by
+  `|`), and `checkpoint_id`.
+- Persist the **type tag** from `serde.dumps_typed()`, not just the bytes.
+  Dropping it makes stored checkpoints unreadable.
+
+**`BaseStore`** has only two abstract methods, `batch` and `abatch`; everything
+else is sugar over them. Results **must be positionally aligned with the input
+operations** — a reordered or filtered result list silently corrupts caller
+state. `delete` is expressed as a `PutOp` with `value=None`. Without an
+`IndexConfig`, `index=` arguments to `put` are ignored.
+
+**LangGraph's `BaseCache`** is a different class from
+`langchain_core.caches.BaseCache`. All six methods are abstract, they are batch
+oriented over `(namespace, key)` tuples, and TTL is the second element of the
+`set` value tuple, in seconds.
+
+## Deep Agents backends
+
+`BackendProtocol` covers `ls`, `read`, `grep`, `glob`, `write`, `edit`,
+`delete`, `upload_files`, `download_files` plus async twins.
+`SandboxBackendProtocol` adds exactly two members: an `id` property and
+`execute`. Sync defaults raise `NotImplementedError`; async defaults delegate
+to the sync method via `asyncio.to_thread`.
+
+- **Expected failures go in the result's `error` field — do not raise.** Every
+  result dataclass carries `error: str | None`, where `None` means success.
+  Raising for a missing file or a permission error breaks the agent loop.
+- `upload_files` / `download_files` must return results **in input order** and
+  use the four `FileOperationError` literals: `file_not_found`,
+  `permission_denied`, `is_directory`, `invalid_path`.
+- `ReadResult.__post_init__` raises `ValueError` on inconsistent pagination:
+  `start_line`/`end_line` are 1-indexed and set together, `1 <= start <= end`,
+  `total_lines >= end_line`, and **`next_offset` must equal `end_line`**.
+- `grep` takes a **literal** string, not a regex.
+- `read` returns raw content; line-number gutters are added downstream, so
+  adding them in the backend double-formats the output.
+- Detect command failure with `ExecuteArtifact["exit_code"]`, not
+  `ToolMessage.status`.
+- `ExecuteResponse.output` combines stdout and stderr.
+- Deep Agents is pre-1.0 and changed breakingly at 0.7: `ls_info`, `glob_info`,
+  `grep_raw`, and `files_update` are gone; backends are concrete instances
+  rather than factories; `virtual_mode` defaults to `True`; and `write_file` is
+  create-or-replace. Treat a widened version range here with suspicion.

--- a/.github/skills/code-review/references/repo-infrastructure.md
+++ b/.github/skills/code-review/references/repo-infrastructure.md
@@ -1,0 +1,68 @@
+# Repository infrastructure
+
+Read this when a PR touches `.github/`, `pyproject.toml`, `Makefile`, `uv.lock`,
+version numbers, or `samples/`.
+
+## CI shape
+
+`check_diffs.yml` detects which packages a diff touches (via
+`.github/scripts/check_diff.py`) and fans out to reusable workflows:
+`_lint.yml`, `_test.yml`, `_codespell.yml`, `_compile_integration_test.yml`,
+and `_test_release.yml`. Releases run through `_release.yml`.
+
+Two consequences for review:
+
+- **`check_diff.py` decides what gets tested.** A change that adds a package
+  directory, moves source between packages, or adds a new dependency edge may
+  need matching changes here, or the new code will silently never be linted or
+  tested.
+- **The Python matrix is `["3.10", "3.14"]` only**, while all packages declare
+  support for 3.10 through 3.14. Syntax or behavior that breaks only on
+  3.11–3.13 passes CI. Flag constructs whose behavior differs across those
+  versions even though CI is green.
+
+`_lint.yml` runs `uv lock --check`. Because Copilot code review cannot see
+`uv.lock` (it is in the excluded-file list), a dependency change whose lockfile
+is missing from the changed-file list is a build break the reviewer must infer
+rather than observe.
+
+## Package independence
+
+Each `libs/*` package versions, releases, and pins independently. Do not
+propose sharing code across package boundaries: duplication between packages is
+a deliberate choice here, not an oversight.
+
+Cross-package coupling that *is* real and worth flagging: two packages whose
+extras pull incompatible versions of the same third-party dependency cannot be
+co-installed. `langchain-azure-compute` and `langchain-azure-dynamic-sessions`
+already have this problem with their `deepagents` floors.
+
+Version bumps belong in the package's own `pyproject.toml`, and the README
+changelog for that package is where the change is announced.
+
+## Dependency changes
+
+- A new runtime dependency needs justification; a new *required* dependency on
+  a package that previously worked without it is a breaking change for
+  installed users, and belongs behind an extra.
+- Widening a version range needs evidence that the wider range actually works;
+  narrowing one can break existing environments.
+- Dependency edits must be reflected in `uv.lock`.
+
+## PR hygiene
+
+- Titles follow Conventional Commits: `type(scope): description`, for example
+  `feat(azure-ai): add streaming support`. The scope is the package.
+- A new feature should come with a usage example under `samples/` when it is
+  user-facing. `samples/` code is read by users as a template, so review it for
+  correctness and for credential handling — a sample that hardcodes a key
+  teaches every reader to do the same.
+- Public behavior changes need README or docstring updates in the same PR.
+
+## Instruction files
+
+`AGENTS.md` at the repository root is loaded automatically; per-package
+instructions live at `libs/<pkg>/AGENTS.md` or
+`libs/<pkg>/.github/copilot-instructions.md`. When a PR adds or edits one,
+check it against the package's actual tooling — two of the existing ones have
+already drifted from the code they describe.

--- a/.github/skills/code-review/references/sqlserver.md
+++ b/.github/skills/code-review/references/sqlserver.md
@@ -1,0 +1,52 @@
+# `langchain-sqlserver` (`libs/sqlserver`)
+
+SQL Server and Azure SQL vector store (`vectorstores.py`) and chat message
+history (`chat_message_histories.py`). Built directly on SQLAlchemy with
+`pyodbc`.
+
+`SQLServer_VectorStore` is the historical public name and `SQLServer` is an
+alias; both are exported and both must keep working.
+
+## SQLAlchemy ownership
+
+The vector store owns engine and session lifecycle. Review whether a change
+leaks sessions, holds one open across an entire iteration, or closes an engine
+the caller supplied — see the lifecycle section of
+[azure-sdk-contracts.md](azure-sdk-contracts.md). Transaction boundaries matter
+in particular: a multi-statement write that is not committed as a unit can
+leave the table half-updated after a failure.
+
+Connection string and driver handling must keep supporting both SQL
+authentication and Entra ID, and must not log the connection string.
+
+## Vector type
+
+SQL Server's native `VECTOR` type has version and dimension requirements.
+
+- Dimension is fixed at column creation. A change that alters the declared
+  dimension, or that stops validating embedding length against it, breaks
+  existing tables.
+- The supported distance metrics and their score direction feed
+  `_select_relevance_score_fn`. The `VectorStore` rules in
+  [ecosystem-contracts.md](ecosystem-contracts.md) apply: relevance scores are
+  normalized to `[0, 1]` with 1 as most similar, while the underlying SQL
+  operator returns a distance. Inverting that mapping silently reverses result
+  ordering, which no smoke test catches.
+- Schema creation must be idempotent and must not drop or rewrite an existing
+  table.
+
+## Queries
+
+Identifiers must be quoted through SQLAlchemy constructs and values must be
+bound parameters. Table and schema names arriving from user configuration are
+the usual injection vector here. Metadata filter translation must not drop
+conditions on unknown operators — returning extra rows is a correctness bug,
+not a leniency feature.
+
+## Chat message history
+
+Message serialization is persisted data: round-tripping through
+`messages_from_dict` / `messages_to_dict` must preserve type, content blocks,
+tool calls, and `additional_kwargs`. Session-id scoping must isolate
+conversations, and ordering must be stable and explicit rather than relying on
+insertion order.


### PR DESCRIPTION
## Why

Every directory under `libs/` is a separately versioned, separately released package with its own maintainers, dependency tooling, and upstream contracts. Copilot code review currently sees only the root `AGENTS.md`, so it reviews a Cosmos DB change with the same assumptions as an Azure AI Search change, and it has no knowledge of the LangChain, LangGraph, Deep Agents, or Azure SDK contracts these packages are obligated to satisfy. The result is a mix of false positives (flagging correct `uv` usage in `azure-cosmosdb` because that package's local instructions still say `poetry`) and missed defects (an inverted relevance score, a dropped ETag condition, a missing `uv.lock`).

This adds a `code-review` agent skill so reviews are grounded in what each package actually is.

## Approach

`.github/skills/code-review/` uses progressive disclosure rather than one large instruction file:

- **`SKILL.md` (148 lines)** is a router. It defines what to report and what to stay silent about, a five-step workflow, a path-to-package routing table, the repository-wide gotchas, and the comment format.
- **`references/*.md`** hold the detail and are loaded only for the packages a diff actually touches. There are two contract files (`ecosystem-contracts.md` for LangChain/LangGraph/Deep Agents, `azure-sdk-contracts.md` for the Azure SDK guidelines), seven per-package files, and `repo-infrastructure.md` for `.github/` and `samples/`.

This matters for more than tidiness: instruction size drives review cost on every PR, and the routing means a one-package change never pays for the other six.

The content was built from three sources: published guidance on authoring skills for Copilot code review, the upstream base-class contracts and their conformance suites, and a pass over this repository to confirm each claim against the actual code and CI config.

## Things worth a careful look

A few decisions that are deliberate rather than accidental:

- **Severity is High/Medium/Low**, matching what Copilot code review natively emits. An earlier draft used a P0-P3 scheme, which would simply have been ignored.
- **`uv.lock` is on Copilot's excluded-file list**, so the reviewer can never see it. The skill instructs it to infer a stale lockfile from the changed-file list instead of commenting on contents, since `_lint.yml` runs `uv lock --check`.
- **CI runs Python 3.10 and 3.14 only**, while all packages declare 3.10-3.14 support. The skill tells the reviewer to reason across the full range rather than trust a green build.
- **Two local instruction files have drifted from their code.** `azure-cosmosdb/.github/copilot-instructions.md` still describes Poetry, and `azure-postgresql/.github/copilot-instructions.md` asks for Sphinx docstrings while its `pyproject.toml` sets pydocstyle to `google`. The skill records both so the reviewer does not raise findings against correct code. Fixing those files is worth doing separately; documenting the conflict here is the lower-risk step.
- **`azure-sdk-contracts.md` ends with a conflict table** for the handful of places where Azure and LangChain rules genuinely disagree, most notably that `VectorStore.get_by_ids` must not raise for missing IDs even though the Azure rule is to raise rather than return a sentinel. Without this, a reviewer applying Azure guidelines produces confidently wrong findings.
- Package-specific claims (the 100% coverage gate in `azure-compute`, the 4096-byte output cap, the three-place lazy-import rule in `azure-ai`, the `deepagents` floor conflict between `azure-compute` and `azure-dynamic-sessions`) were each checked against the source rather than carried over from prose.

Docs only, no code or dependency changes. Copilot code review reads instructions from the head branch, so this PR exercises the skill on itself.