### PR TITLE
fix(azure-ai): respect middleware output boundaries in agent hosts

### DIFF
--- a/libs/azure-ai/README.md
+++ b/libs/azure-ai/README.md
@@ -162,6 +162,34 @@ if __name__ == "__main__":
 
 `ResponsesHostServer` serves the OpenAI Responses-style `/responses` endpoint. `InvocationsHostServer` serves the generic `/invocations` endpoint for applications that want to define their own JSON request and response shape.
 
+Both hosts default to `output_mode="tokens"`, which forwards model text before
+`after_model` output checks finish. With `PIIMiddleware(apply_to_output=True)`
+or another output guardrail, explicitly use `output_mode="final"`:
+
+```python
+from langchain.agents import create_agent
+from langchain.agents.middleware import PIIMiddleware
+from langchain_azure_ai.agents.hosting import ResponsesHostServer
+
+agent = create_agent(
+    model,
+    middleware=[PIIMiddleware("email", strategy="redact", apply_to_output=True)],
+)
+server = ResponsesHostServer(agent, output_mode="final")
+# InvocationsHostServer(agent, output_mode="final") uses the same policy.
+```
+
+Final mode publishes only the final assistant text after successful graph
+completion. SSE remains available, but text arrives after output checks.
+Intermediate text, reasoning, and tool traces are omitted. Blocked or cancelled
+runs publish no assistant text; paused runs expose approval requests without
+releasing unapproved text. Configure the same mode when recovering background
+runs. This policy controls host response output; it does not sanitize tracing,
+tool side effects, or graph checkpoints.
+
+Internal `SummarizationMiddleware` model calls are excluded from token output
+in both hosts using their `lc_source="summarization"` metadata.
+
 Both hosts accept `ResponsesServerOptions`. For the Invocations host,
 `resilient_background=True` enables durable background turns and
 `steerable_conversations=True` lets a new turn supersede an active turn in the

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_stream.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_stream.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncIterator, Mapping, Sequence
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from azure.ai.agentserver.responses import ResponseEventStream
 from azure.ai.agentserver.responses.models import ResponseUsage
@@ -56,7 +56,13 @@ from langchain_core.messages import (
 from langchain_core.runnables import RunnableConfig
 
 from .._responses import CheckpointRef, HostingRunnableConfig, TaskStorageManager
-from ._utils import extract_reasoning_summary_fragments, extract_text
+from ._final import _emit_message, _messages_for_this_turn
+from ._utils import (
+    extract_reasoning_summary_fragments,
+    extract_text,
+    is_internal_message,
+    last_ai_message_text,
+)
 
 
 async def stream_graph_to_events(
@@ -66,6 +72,7 @@ async def stream_graph_to_events(
     cancellation_signal: asyncio.Event,
     shutdown_signal: asyncio.Event | None = None,
     usage: UsageAccumulator | None = None,
+    output_mode: Literal["tokens", "final"] = "tokens",
 ) -> AsyncIterator[Any]:
     """Iterate the graph stream and yield Responses API events.
 
@@ -87,12 +94,16 @@ async def stream_graph_to_events(
         shutdown_signal: Set when the host is draining. Iteration stops on set
             so the caller can defer resilient work to the next lifetime.
         usage: Optional accumulator for LangChain AI message usage metadata.
+        output_mode: Publish tokens immediately, or publish only the final
+            assistant text after successful, uninterrupted graph completion.
 
     Yields:
         Responses API event payload dicts.
     """
     converter = StreamConverter(stream, usage=usage)
     task_storage = TaskStorageManager.from_stream(stream)
+    latest_state: Any = None
+    interrupted = False
 
     # Common timeline:
     #   ...
@@ -118,15 +129,27 @@ async def stream_graph_to_events(
         if stop_requested() and mode != "checkpoints":
             break
         if mode == "messages":
+            if output_mode == "final":
+                message = _extract_ai_message(payload)
+                if message is not None and usage is not None:
+                    usage.add(message)
+                continue
             async for event in converter.handle_message_chunk(payload):
                 yield event
                 if stop_requested():
                     break
         elif mode == "updates":
+            if output_mode == "final":
+                interrupted = interrupted or bool(
+                    isinstance(payload, dict) and payload.get("__interrupt__")
+                )
+                continue
             async for event in converter.handle_update(payload):
                 yield event
                 if stop_requested():
                     break
+        elif mode == "values":
+            latest_state = payload
         elif mode == "checkpoints":
             checkpoint_ref = _extract_checkpoint_ref(payload)
             if checkpoint_ref is not None:
@@ -140,6 +163,13 @@ async def stream_graph_to_events(
 
     async for event in converter.flush():
         yield event
+    if output_mode == "final" and not stop_requested() and not interrupted:
+        if latest_state is None:
+            raise RuntimeError("LangGraph response produced no output state.")
+        text = last_ai_message_text(_messages_for_this_turn(latest_state))
+        if text:
+            async for event in _emit_message(stream, text):
+                yield event
 
 
 class UsageAccumulator:
@@ -516,6 +546,8 @@ def _extract_ai_message(payload: Any) -> AIMessage | None:
     (notably :class:`ToolMessage`, which LangGraph also publishes on this
     channel) are ignored here and handled from the ``updates`` channel.
     """
+    if is_internal_message(payload):
+        return None
     if isinstance(payload, AIMessage):
         return payload
     if isinstance(payload, tuple) and payload:

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_utils.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_converters/_utils.py
@@ -10,6 +10,14 @@ from typing import Any, Iterable, get_type_hints
 from langchain_core.messages import AIMessage, BaseMessage
 
 
+def is_internal_message(payload: Any) -> bool:
+    """Identify middleware-internal model calls in a messages stream payload."""
+    if not isinstance(payload, tuple) or len(payload) != 2:
+        return False
+    metadata = payload[1]
+    return isinstance(metadata, dict) and metadata.get("lc_source") == "summarization"
+
+
 def is_messages_state_schema(state_schema: Any) -> bool:
     """Return ``True`` when *state_schema* exposes a ``messages`` field.
 

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_invoke_host.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_invoke_host.py
@@ -41,7 +41,7 @@ import logging
 from collections.abc import AsyncIterator, Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generic, Optional, TypeVar, cast
+from typing import Any, Generic, Literal, Optional, TypeVar, cast
 
 try:
     from azure.ai.agentserver.core import (
@@ -105,6 +105,7 @@ from ._converters import (
     parse_resume_command,
     track_pending_interrupts,
 )
+from ._converters._utils import is_internal_message
 from ._invocation_store import (
     InvocationStateStore,
     create_invocation_state_store,
@@ -429,13 +430,20 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
             have configured them on ``app`` itself.
         applicationinsights_connection_string: Forwarded to
             :class:`AgentServerHost`.
+        output_mode: Output publication policy. Defaults to "tokens", which
+            forwards model text before output middleware finishes. Use "final"
+            with output guardrails such as PIIMiddleware: publish only the final
+            assistant text after successful graph completion, without intermediate
+            text, reasoning, or tool traces. Interrupts still surface approval
+            items, but no assistant text. This also applies to SSE requests;
+            it changes publication timing, not the HTTP transport.
         graceful_shutdown_timeout: Forwarded to :class:`AgentServerHost`.
 
     Raises:
         ValueError: If the graph's state schema does not declare a
             ``messages`` field, or if ``resilient_background=True`` is
             configured without a LangGraph checkpointer. Override this class
-            to host custom-state graphs.
+            to host custom-state graphs. Also raised for an invalid output_mode.
     """
 
     def __init__(
@@ -443,12 +451,16 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
         graph: Runnable[GraphInputT, GraphOutputT],
         *,
         output_parser: Optional[InvocationOutputParser[GraphOutputT]] = None,
+        output_mode: Literal["tokens", "final"] = "tokens",
         options: Optional[ResponsesServerOptions] = None,
         app: Optional[InvocationAgentServerHost] = None,
         applicationinsights_connection_string: Optional[str] = None,
         graceful_shutdown_timeout: Optional[int] = None,
     ) -> None:
         self._validate_graph_schema(graph)
+        if output_mode not in ("tokens", "final"):
+            raise ValueError("output_mode must be 'tokens' or 'final'.")
+        self._output_mode = output_mode
         self._hosting_features = HostingFeature.INVOCATIONS
         if options is not None and options.resilient_background:
             self._hosting_features |= HostingFeature.RESILIENT_BACKGROUND
@@ -910,6 +922,8 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
         body: dict[str, Any] = {"response": text}
         pending_items = interrupt_output_items(active_interrupts)
         if pending_items:
+            if self._output_mode == "final":
+                body["response"] = ""
             body["output"] = pending_items
         return JSONResponse(body)
 
@@ -1347,7 +1361,7 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
 
         if self._supports_langgraph_stream_modes:
             stream_modes = ["values", "updates"]
-            if stream_tokens:
+            if stream_tokens and self._output_mode == "tokens":
                 stream_modes.append("messages")
             graph_stream_kwargs: dict[str, Any] = {}
             if self._graph_has_checkpointer:
@@ -1407,7 +1421,7 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
                                 latest_state,
                                 payload,
                             )
-                            if stream_tokens:
+                            if stream_tokens and self._output_mode == "tokens":
                                 message_chunk = _extract_message_chunk(payload)
                                 if message_chunk is not None:
                                     token = extract_text(message_chunk.content)
@@ -1419,7 +1433,11 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
                                             status="in_progress",
                                             token=token,
                                         )
-                        elif mode == "messages" and stream_tokens:
+                        elif (
+                            mode == "messages"
+                            and stream_tokens
+                            and self._output_mode == "tokens"
+                        ):
                             message_chunk = _extract_message_chunk(payload)
                             if message_chunk is not None:
                                 token = extract_text(message_chunk.content)
@@ -1475,6 +1493,17 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
                 raise RuntimeError("LangGraph invocation produced no output state.")
             response_text = self.parse_output(cast(GraphOutputT, latest_state))
             pending_items = interrupt_output_items(active_interrupts)
+            if self._output_mode == "final":
+                if pending_items:
+                    response_text = ""
+                elif stream_tokens and response_text:
+                    await self._emit_invocation_status(
+                        event_stream,
+                        invocation_id=invocation_id,
+                        session_id=session_id,
+                        status="in_progress",
+                        token=response_text,
+                    )
             recovery_state[_METADATA_RESPONSE] = response_text
             recovery_state[_METADATA_OUTPUT] = pending_items
             await self._set_task_recovery_state(
@@ -1888,6 +1917,20 @@ class InvocationsHostServer(Generic[GraphInputT, GraphOutputT]):
         with _hosting_feature_scope(self._hosting_features):
             active_interrupts: list[Any] = []
             try:
+                if self._output_mode == "final":
+                    output, pending = await self._invoke_graph(graph_input, config)
+                    if pending:
+                        async for event in self._stream_pending_items(
+                            interrupt_output_items(pending)
+                        ):
+                            yield event
+                    else:
+                        text = self.parse_output(output)
+                        if text:
+                            payload = json.dumps({"token": text}, ensure_ascii=False)
+                            yield f"data: {payload}\n\n".encode("utf-8")
+                        yield b"event: done\ndata: {}\n\n"
+                    return
                 if (
                     self._supports_langgraph_stream_modes
                     and self._graph_has_checkpointer
@@ -1973,6 +2016,8 @@ def _messages_from_state(state: Any) -> list[Any]:
 
 
 def _extract_message_chunk(chunk: Any) -> Optional[AIMessageChunk]:
+    if is_internal_message(chunk):
+        return None
     if isinstance(chunk, AIMessageChunk):
         return chunk
     if isinstance(chunk, tuple) and chunk:

--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
@@ -295,13 +295,20 @@ class ResponsesHostServer:
         prefix: URL prefix for response routes (e.g. ``"/v1"``).
         applicationinsights_connection_string: Forwarded to
             :class:`AgentServerHost`.
+        output_mode: Output publication policy. Defaults to "tokens", which
+            forwards model text before output middleware finishes. Use "final"
+            with output guardrails such as PIIMiddleware: publish only the final
+            assistant text after successful graph completion, without intermediate
+            text, reasoning, or tool traces. Interrupts still surface approval
+            items, but no assistant text. This also applies to SSE requests;
+            it changes publication timing, not the HTTP transport.
         graceful_shutdown_timeout: Forwarded to :class:`AgentServerHost`.
 
     Raises:
         ValueError: If the graph's state schema does not declare a
             ``messages`` field, or if ``resilient_background=True`` is
             configured without a LangGraph checkpointer. Override this class
-            to host custom-state graphs.
+            to host custom-state graphs. Also raised for an invalid output_mode.
     """
 
     def __init__(
@@ -312,10 +319,14 @@ class ResponsesHostServer:
         options: Optional[ResponsesServerOptions] = None,
         store: Optional[ResponseProviderProtocol] = None,
         prefix: str = "",
+        output_mode: Literal["tokens", "final"] = "tokens",
         applicationinsights_connection_string: Optional[str] = None,
         graceful_shutdown_timeout: Optional[int] = None,
     ) -> None:
         self._validate_graph_schema(graph)
+        if output_mode not in ("tokens", "final"):
+            raise ValueError("output_mode must be 'tokens' or 'final'.")
+        self._output_mode = output_mode
         self._graph = graph
         self._graph_has_checkpointer = _uses_langgraph_checkpointer(graph)
         if (
@@ -329,6 +340,8 @@ class ResponsesHostServer:
                 "resilient_background=True."
             )
         self._stream_modes: list[StreamMode] = ["updates", "messages"]
+        if output_mode == "final":
+            self._stream_modes.append("values")
         self._durability: Literal["sync"] | None = None
         if self._graph_has_checkpointer:
             self._stream_modes.append("checkpoints")
@@ -939,6 +952,7 @@ class ResponsesHostServer:
                 cancellation_signal=cancellation_signal,
                 shutdown_signal=context.shutdown,
                 usage=usage,
+                output_mode=self._output_mode,
             ):
                 yield event
             checkpoint_ref = task_storage.checkpoint_ref

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_middleware_output.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_middleware_output.py
@@ -1,0 +1,252 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""Middleware output must be checked before being published by a host."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Literal
+
+import pytest
+from azure.ai.agentserver.responses import ResponseEventStream, ResponsesServerOptions
+from langchain.agents import create_agent
+from langchain.agents.middleware import PIIMiddleware, SummarizationMiddleware
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.types import Command, interrupt
+from starlette.testclient import TestClient
+
+from langchain_azure_ai.agents.hosting import (
+    InvocationsHostServer,
+    ResponsesHostServer,
+)
+from langchain_azure_ai.agents.hosting._converters._stream import stream_graph_to_events
+from langchain_azure_ai.agents.hosting._converters._utils import is_internal_message
+
+
+def _events(body: str) -> list[dict[str, Any]]:
+    return [
+        json.loads(line.removeprefix("data:").strip())
+        for line in body.splitlines()
+        if line.startswith("data:") and line.removeprefix("data:").strip() != "[DONE]"
+    ]
+
+
+@pytest.mark.parametrize("protocol", ["responses", "invocations"])
+@pytest.mark.parametrize("strategy", ["redact", "block"])
+@pytest.mark.parametrize("task_backed", [False, True])
+def test_final_output_checks_pii_before_publishing(
+    protocol: str, strategy: Literal["redact", "block"], task_backed: bool
+) -> None:
+    graph = create_agent(
+        FakeListChatModel(responses=["Contact alice@example.com"]),
+        middleware=[
+            PIIMiddleware(
+                "email", strategy=strategy, apply_to_input=False, apply_to_output=True
+            )
+        ],
+        checkpointer=InMemorySaver() if task_backed else None,
+    )
+    options = ResponsesServerOptions(steerable_conversations=task_backed)
+    server: Any = (
+        ResponsesHostServer(graph, output_mode="final", options=options)
+        if protocol == "responses"
+        else InvocationsHostServer(graph, output_mode="final", options=options)
+    )
+    request = (
+        {"input": "hello", "stream": True}
+        if protocol == "responses"
+        else {"message": "hello", "stream": True}
+    )
+    with TestClient(server.app) as client:
+        response = client.post(f"/{protocol}", json=request)
+    assert response.status_code == 200, response.text
+    assert "alice@example.com" not in response.text
+    events = _events(response.text)
+    text = "".join(
+        event.get("token", "")
+        + (
+            event.get("delta", "")
+            if event.get("type") == "response.output_text.delta"
+            else ""
+        )
+        for event in events
+    )
+    if strategy == "redact":
+        assert text == "Contact [REDACTED_EMAIL]"
+    else:
+        assert text == ""
+        assert (
+            "response.failed" in response.text
+            or "event: error" in response.text
+            or any(event.get("status") == "failed" for event in events)
+        )
+
+
+@pytest.mark.parametrize("protocol", ["responses", "invocations"])
+async def test_summary_tokens_are_not_published(protocol: str) -> None:
+    graph = create_agent(
+        FakeListChatModel(responses=["PUBLIC_ANSWER"]),
+        middleware=[
+            SummarizationMiddleware(
+                FakeListChatModel(responses=["INTERNAL_SUMMARY"]),
+                trigger=("messages", 3),
+                keep=("messages", 1),
+            )
+        ],
+    )
+    if protocol == "responses":
+        with TestClient(ResponsesHostServer(graph).app) as client:
+            response = client.post(
+                "/responses",
+                json={
+                    "input": [
+                        {"role": "user", "content": "old question"},
+                        {"role": "assistant", "content": "old answer"},
+                        {"role": "user", "content": "new question"},
+                    ],
+                    "stream": True,
+                },
+            )
+        assert response.status_code == 200, response.text
+        body = response.text
+    else:
+        server = InvocationsHostServer(graph)
+        body = b"".join(
+            [
+                chunk
+                async for chunk in server._stream_tokens(
+                    {
+                        "messages": [
+                            HumanMessage("old question"),
+                            AIMessage("old answer"),
+                            HumanMessage("new question"),
+                        ]
+                    },
+                    {},
+                )
+            ]
+        ).decode()
+    events = _events(body)
+    text = "".join(
+        event.get("token", "")
+        + (
+            event.get("delta", "")
+            if event.get("type") == "response.output_text.delta"
+            else ""
+        )
+        for event in events
+    )
+    assert text == "PUBLIC_ANSWER"
+    assert "INTERNAL_SUMMARY" not in body
+
+
+@pytest.mark.parametrize("termination", ["cancel", "shutdown", "interrupt", "error"])
+async def test_final_response_never_publishes_unapproved_state(
+    termination: str,
+) -> None:
+    cancel = asyncio.Event()
+    shutdown = asyncio.Event()
+
+    async def graph_stream() -> Any:
+        yield "values", {"messages": [AIMessage("UNAPPROVED")]}
+        if termination == "cancel":
+            cancel.set()
+        elif termination == "shutdown":
+            shutdown.set()
+        elif termination == "interrupt":
+            yield "updates", {"__interrupt__": [object()]}
+        else:
+            raise ValueError("Output rejected")
+
+    stream = ResponseEventStream(response_id="resp-test")
+    stream.emit_created()
+    stream.emit_in_progress()
+    events = []
+    try:
+        async for event in stream_graph_to_events(
+            graph_stream(),
+            stream,
+            cancellation_signal=cancel,
+            shutdown_signal=shutdown,
+            output_mode="final",
+        ):
+            events.append(event)
+    except ValueError:
+        assert termination == "error"
+    assert not events
+
+
+def test_summary_filter_uses_call_metadata_only() -> None:
+    message = AIMessage("visible", additional_kwargs={"lc_source": "summarization"})
+    assert not is_internal_message(message)
+    assert not is_internal_message((message, {"lc_source": "another_source"}))
+    assert not is_internal_message((message, {"lc_internal_call": "caller_supplied"}))
+    assert is_internal_message((message, {"lc_source": "summarization"}))
+
+
+@pytest.mark.parametrize("protocol", ["responses", "invocations"])
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_final_output_waits_for_approval_and_resumes(
+    protocol: str, streaming: bool
+) -> None:
+    def model(state: MessagesState) -> dict[str, Any]:
+        return {"messages": [AIMessage("UNAPPROVED", id="answer")]}
+
+    def review(state: MessagesState) -> dict[str, Any]:
+        interrupt("Approve output?")
+        return {"messages": [AIMessage("APPROVED", id="answer")]}
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("model", model)
+    builder.add_node("review", review)
+    builder.add_edge(START, "model")
+    builder.add_edge("model", "review")
+    builder.add_edge("review", END)
+    graph = builder.compile(checkpointer=InMemorySaver())
+    if protocol == "responses":
+        server: Any = ResponsesHostServer(graph, output_mode="final")
+        request = {"input": "hello", "stream": streaming}
+    else:
+        server = InvocationsHostServer(graph, output_mode="final")
+        request = {"message": "hello", "stream": streaming}
+    with TestClient(server.app) as client:
+        response = client.post(f"/{protocol}", json=request)
+    assert response.status_code == 200, response.text
+    assert "UNAPPROVED" not in response.text
+    assert "Approve output?" in response.text
+
+    # Verify the checked state replaces the earlier message after resuming.
+    config: Any = {"configurable": {"thread_id": "resume-test"}}
+    await graph.ainvoke({"messages": [HumanMessage("hello")]}, config)
+    if protocol == "invocations":
+        body = b"".join(
+            [
+                chunk
+                async for chunk in server._stream_tokens(Command(resume=True), config)
+            ]
+        ).decode()
+    else:
+        stream = ResponseEventStream(response_id="resp-resume")
+        stream.emit_created()
+        stream.emit_in_progress()
+        events = [
+            event
+            async for event in stream_graph_to_events(
+                graph.astream(
+                    Command(resume=True),
+                    config,
+                    stream_mode=["values", "updates", "messages"],
+                ),
+                stream,
+                cancellation_signal=asyncio.Event(),
+                output_mode="final",
+            )
+        ]
+        body = json.dumps(events)
+    assert "UNAPPROVED" not in body
+    assert "APPROVED" in body


### PR DESCRIPTION
Agent hosts currently forward raw model text before output middleware finishes and publish internal summarization calls as assistant answers. For example, an email can already be delivered when PIIMiddleware later redacts the final state or raises a blocking error.

Add the opt-in output_mode="final" policy to ResponsesHostServer and InvocationsHostServer. It emits only the final assistant text after successful, uninterrupted graph completion, including SSE and task-backed invocations. Failed, cancelled, and paused runs do not release intermediate assistant text; approval items remain available. The default token mode and its latency remain unchanged. Applications using output guardrails must explicitly select final mode; enabling PIIMiddleware alone does not change the host policy.

Both token paths now inspect stream metadata and suppress SummarizationMiddleware calls marked with lc_source="summarization". This uses the existing streaming API and supported metadata rather than migrating hosts to the experimental v3 protocol. The README documents configuration and the omission of intermediate text, reasoning, and tool traces in final mode. This policy does not sanitize tracing, tool side effects, or stored graph checkpoints.

Validated with 261 passing hosting tests, including 19 new regression cases covering real create_agent PII redaction/blocking, internal summaries, task-backed streaming, cancellation/shutdown, and interrupt/resume behavior. Ruff and focused mypy checks pass. The regressions were run before implementation and failed for the missing publication policy and leaked summary text. Validation used the locked LangChain 1.3.15 / LangGraph 1.2.11 dependencies and local fake models; no external model service was required.
