### PR TITLE
fix(azure-ai): preserve HITL parsing during recovery

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/hosting/_responses_host.py
@@ -859,26 +859,25 @@ class ResponsesHostServer:
             resume_command: Optional["Command"] = None
             consumed_call_ids: frozenset[str] = frozenset()
             graph_input: dict[str, Any] | Command | None
+            checkpoint_ref = task_storage.checkpoint_ref if recovering else None
 
-            if recovering:
+            if checkpoint_ref is not None:
                 # Crash-recovered re-entry. The graph's own persistent
                 # checkpointer holds the mid-turn state, so resume it (input
                 # ``None``) rather than re-injecting the original input. If the
-                # thread has no checkpoint yet (crash before the first node
-                # committed), fall back to a fresh run.
-                checkpoint_ref = task_storage.checkpoint_ref
-                if checkpoint_ref is None:
-                    logger.debug("Recovery: replaying request input")
-                    graph_input = await self.build_input(request, context)
-                else:
-                    logger.debug("Recovery: resuming graph from persisted checkpoint")
-                    config = (
-                        HostingRunnableConfig(config)
-                        .with_checkpoint_ref(checkpoint_ref)
-                        .runnable_config
-                    )
-                    graph_input = None
+                # response has no checkpoint yet, replay the request through
+                # the normal input / HITL parsing path below.
+                logger.debug("Recovery: resuming graph from persisted checkpoint")
+                config = (
+                    HostingRunnableConfig(config)
+                    .with_checkpoint_ref(checkpoint_ref)
+                    .runnable_config
+                )
+                graph_input = None
+
             else:
+                if recovering:
+                    logger.debug("Recovery: replaying request input")
                 # Detect a pause from a previous turn and try to resume it.
                 pending = await detect_pending_interrupts(self._graph, config)
                 if pending:

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_invoke_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_invoke_host.py
@@ -1099,7 +1099,29 @@ def test_resilient_foreground_invocation_honors_chain_precondition() -> None:
 
 
 @pytest.mark.asyncio
-async def test_recovered_background_invocation_resumes_checkpoint() -> None:
+@pytest.mark.parametrize(
+    "message",
+    [
+        "hi",
+        [
+            {
+                "type": "mcp_approval_response",
+                "approval_request_id": "interrupt-1",
+                "approve": True,
+            }
+        ],
+        [
+            {
+                "type": "mcp_approval_response",
+                "approval_request_id": "interrupt-1",
+                "approve": False,
+            }
+        ],
+    ],
+)
+async def test_recovered_background_invocation_resumes_checkpoint(
+    message: Any,
+) -> None:
     captured: dict[str, object] = {}
     options = ResponsesServerOptions(resilient_background=True)
     server = InvocationsHostServer(
@@ -1122,7 +1144,7 @@ async def test_recovered_background_invocation_resumes_checkpoint() -> None:
         input={
             "invocation_id": invocation_id,
             "session_id": session_id,
-            "message": "hi",
+            "message": message,
             "stream": False,
         },
         input_id=invocation_id,
@@ -1137,6 +1159,67 @@ async def test_recovered_background_invocation_resumes_checkpoint() -> None:
     assert configurable["checkpoint_id"] == "checkpoint-1"
     assert result["status"] == "completed"
     assert result["response"] == "Recovered"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("approve", [None, True, False])
+async def test_recovered_background_invocation_replays_without_checkpoint(
+    approve: bool | None,
+) -> None:
+    captured: dict[str, object] = {}
+    pending = (
+        Interrupt(value="Approve recovered action?", id="interrupt-1")
+        if approve is not None
+        else None
+    )
+    server = InvocationsHostServer(
+        make_recovery_probe_graph(captured, pending),
+        options=ResponsesServerOptions(resilient_background=True),
+    )
+    invocation_id = f"replay-{uuid.uuid4()}"
+    session_id = "replay-session"
+    message: Any = (
+        "hi"
+        if approve is None
+        else [
+            {
+                "type": "mcp_approval_response",
+                "approval_request_id": "interrupt-1",
+                "approve": approve,
+            }
+        ]
+    )
+    context = TaskContext(
+        task_id=session_id,
+        session_id=session_id,
+        input={
+            "invocation_id": invocation_id,
+            "session_id": session_id,
+            "message": message,
+            "stream": False,
+        },
+        input_id=invocation_id,
+        entry_mode="recovered",
+    )
+
+    result = await server._execute_task_invocation(context)
+
+    state_config = captured["state_config"]
+    assert isinstance(state_config, dict)
+    assert state_config["configurable"]["thread_id"] == session_id
+    if approve is None:
+        graph_input = captured["input"]
+        assert isinstance(graph_input, dict)
+        assert graph_input["messages"][0].content == "hi"
+    elif approve:
+        graph_input = captured["input"]
+        assert isinstance(graph_input, Command)
+        assert pending is not None
+        assert graph_input.resume == pending.value
+    else:
+        assert "input" not in captured
+        assert result["status"] == "failed"
+        assert result["error"]["code"] == "interrupt_rejected"
 
 
 @pytest.mark.asyncio

--- a/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
+++ b/libs/azure-ai/tests/unit_tests/agents/hosting/test_responses_host.py
@@ -29,6 +29,7 @@ from azure.ai.agentserver.responses.models import (
 )
 from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableConfig
+from langgraph.types import Command, Interrupt
 from starlette.testclient import TestClient
 
 from langchain_azure_ai.agents.hosting import (
@@ -53,6 +54,7 @@ from .conftest import (  # noqa: E402
     make_checkpointed_two_node_graph,
     make_custom_state_graph,
     make_echo_graph,
+    make_recovery_probe_graph,
     make_streaming_graph,
 )
 
@@ -626,8 +628,108 @@ async def test_recovery_replays_input_without_current_response_checkpoint(
     assert [message.content for message in graph_input["messages"]] == ["replay me"]
 
 
+async def test_recovery_replays_hitl_approval_without_current_response_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+    foundry_state_stores: dict[str, dict[str, Any]],
+) -> None:
+    _seed_conversation_checkpoint(
+        foundry_state_stores,
+        "chain-1",
+        thread_id="resp-root",
+        checkpoint_id="checkpoint-parent",
+    )
+    captured: dict[str, Any] = {}
+    pending = Interrupt(value="Approve recovered action?", id="interrupt-1")
+    server = ResponsesHostServer(make_recovery_probe_graph(captured, pending))
+    context = _context(conversation_id=None, conversation_chain_id="chain-1")
+    context.is_recovery = True
+    context.persisted_response = _response_object("resp-current")
+    context.get_input_items.return_value = [
+        {
+            "type": "mcp_approval_response",
+            "approval_request_id": pending.id,
+            "approve": True,
+        }
+    ]
+
+    graph_input, config = await _capture_graph_call(
+        server,
+        _request(),
+        context,
+        monkeypatch,
+    )
+
+    assert isinstance(graph_input, Command)
+    assert graph_input.resume == pending.value
+    assert captured["state_config"]["configurable"]["checkpoint_id"] == (
+        "checkpoint-parent"
+    )
+    assert config["configurable"]["checkpoint_id"] == "checkpoint-parent"
+
+
+async def test_recovery_replays_hitl_rejection_without_current_response_checkpoint(
+    foundry_state_stores: dict[str, dict[str, Any]],
+) -> None:
+    _seed_conversation_checkpoint(
+        foundry_state_stores,
+        "chain-1",
+        thread_id="resp-root",
+        checkpoint_id="checkpoint-parent",
+    )
+    captured: dict[str, Any] = {}
+    pending = Interrupt(value="Approve recovered action?", id="interrupt-1")
+    server = ResponsesHostServer(make_recovery_probe_graph(captured, pending))
+    context = _context(conversation_id=None, conversation_chain_id="chain-1")
+    context.is_recovery = True
+    context.persisted_response = _response_object("resp-current")
+    context.get_input_items.return_value = [
+        {
+            "type": "mcp_approval_response",
+            "approval_request_id": pending.id,
+            "approve": False,
+        }
+    ]
+
+    events = [
+        event
+        async for event in server.handle_create(
+            _request(),
+            context,
+            asyncio.Event(),
+        )
+    ]
+
+    assert "input" not in captured
+    assert captured["state_config"]["configurable"]["checkpoint_id"] == (
+        "checkpoint-parent"
+    )
+    failed = next(event for event in events if event.get("type") == "response.failed")
+    assert failed["response"]["error"]["code"] == "interrupt_rejected"
+
+
+@pytest.mark.parametrize(
+    "input_items",
+    [
+        [_message_item("do not replay")],
+        [
+            {
+                "type": "mcp_approval_response",
+                "approval_request_id": "interrupt-1",
+                "approve": True,
+            }
+        ],
+        [
+            {
+                "type": "mcp_approval_response",
+                "approval_request_id": "interrupt-1",
+                "approve": False,
+            }
+        ],
+    ],
+)
 async def test_recovery_resumes_from_current_response_checkpoint(
     monkeypatch: pytest.MonkeyPatch,
+    input_items: list[object],
 ) -> None:
     server = ResponsesHostServer(make_checkpointed_echo_graph())
     context = _context(conversation_id=None, current_text="do not replay")
@@ -639,6 +741,7 @@ async def test_recovery_resumes_from_current_response_checkpoint(
             METADATA_LANGGRAPH_THREAD_ID: "resp-root",
         },
     )
+    context.get_input_items.return_value = input_items
     request = _request()
     graph_input, config = await _capture_graph_call(
         server,
@@ -650,6 +753,7 @@ async def test_recovery_resumes_from_current_response_checkpoint(
     assert graph_input is None
     assert config["configurable"]["thread_id"] == "resp-root"
     assert config["configurable"]["checkpoint_id"] == "checkpoint-current"
+    context.get_input_items.assert_not_awaited()
 
 
 def test_readiness_endpoint_is_available() -> None:


### PR DESCRIPTION
## Summary

- Preserve normal input and HITL parsing when a recovered Responses task has no response-scoped LangGraph checkpoint.
- Continue from the exact response-scoped checkpoint with `graph_input=None` once the request input has already been consumed.
- Add symmetric recovery coverage for user messages, HITL approvals, and HITL rejections across Responses and Invocations hosts, with and without a task checkpoint.

## Testing

- `pytest tests/unit_tests/agents/hosting/test_responses_host.py tests/unit_tests/agents/hosting/test_invoke_host.py -k "recovery_replays or recovery_resumes_from_current_response_checkpoint or recovered_background_invocation_replays_without_checkpoint or recovered_background_invocation_resumes_checkpoint" -q`
- 12 passed, 95 deselected